### PR TITLE
ci: route pr checks through aggregator

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,10 +2,6 @@
 name: lint
 
 on:
-  push:
-    branches: ["main", "feat/**", "fix/**", "chore/**", "ci/**"]
-  pull_request:
-    branches: ["main"]
   workflow_call:
 
 concurrency:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,7 +3,7 @@ name: pr-check
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "milestone/**"]
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,8 +4,6 @@ name: security
 on:
   schedule:
     - cron: "0 2 * * *"
-  pull_request:
-    branches: ["main"]
   workflow_call:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,6 @@
 name: test
 
 on:
-  push:
-    branches: ["main", "feat/**", "fix/**", "chore/**", "ci/**"]
-  pull_request:
-    branches: ["main"]
   workflow_call:
 
 concurrency:


### PR DESCRIPTION
## Summary
- drop `pull_request` + `push` triggers from `lint.yml`, `test.yml`, `security.yml`
- keep `workflow_call` (+ schedule on security) only
- `pr-check.yml` now fires on PRs targeting `main` OR `milestone/**`

## Why
On the milestone PR (#233) the `all checks` aggregator went red because `pr-check`'s inner reusable calls to `security`/`lint` were cancelled by a concurrency-group race against the standalone dispatches of the same workflows (both triggered on the same `pull_request` event, both using `lint-<ref>` / `security-<ref>` groups with `cancel-in-progress: true`). Routing everything through `pr-check` eliminates the race.

## Test plan
- [ ] pr-check fires on this PR (PR base is milestone/**)
- [ ] all inner reusables pass
- [ ] `all checks` aggregator green