### PR TITLE
feat(contracts): agent token clone

### DIFF
--- a/contracts/evm/src/launchpad/AgentToken.sol
+++ b/contracts/evm/src/launchpad/AgentToken.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/// @title AgentToken
+/// @notice Per-agent ERC-20 deployed as an EIP-1167 minimal proxy clone by the launchpad factory.
+///         Fixed 1B supply minted to the bonding curve on initialization. Every peer-to-peer
+///         transfer is taxed 1% (100 bps) to a shared `feeRouter` that splits between the
+///         agent creator and the protocol treasury.
+/// @dev    Tax is bypassed on mint, burn, and on any transfer that touches `feeRouter` itself
+///         so the router can sweep collected fees without paying tax on itself (which would
+///         recurse and round down to zero, wasting gas). The implementation contract disables
+///         initializers in its constructor; each clone calls {initialize} exactly once.
+contract AgentToken is Initializable, ERC20Upgradeable, OwnableUpgradeable {
+    /// @notice Fixed per-agent supply: 1,000,000,000 tokens with 18 decimals.
+    uint256 public constant TOTAL_SUPPLY = 1_000_000_000e18;
+
+    /// @notice Transfer tax, expressed in basis points (1% = 100 bps).
+    uint16 public constant TRADE_TAX_BPS = 100;
+
+    /// @notice Denominator for basis-point math.
+    uint16 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @notice Agent creator address (for off-chain attribution; not used in transfer logic).
+    address public creator;
+
+    /// @notice Shared fee router that receives the 1% transfer tax.
+    address public feeRouter;
+
+    /// @notice Address holding the full initial supply (typically the paired bonding curve).
+    address public bondingCurve;
+
+    /// @dev Emitted once per clone, at the end of {initialize}.
+    event AgentTokenInitialized(
+        address indexed creator, address indexed feeRouter, address indexed bondingCurve, string name, string symbol
+    );
+
+    /// @dev Emitted on every taxed transfer. Complements the standard ERC20 `Transfer` events.
+    event TaxCollected(address indexed from, address indexed to, uint256 taxAmount);
+
+    /// @dev Thrown when a required address argument is the zero address.
+    error ZeroAddress();
+    /// @dev Thrown when the token name or symbol is empty.
+    error EmptyMetadata();
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initialize a freshly cloned `AgentToken`.
+    /// @dev Mints the full {TOTAL_SUPPLY} to `bondingCurve_`. Can only be invoked once per
+    ///      proxy. `creator_` is stored for attribution and set as the Ownable owner so that
+    ///      downstream module calls (e.g. metadata updates, if added later) can be gated.
+    /// @param name_         ERC-20 name; must be non-empty.
+    /// @param symbol_       ERC-20 symbol; must be non-empty.
+    /// @param creator_      Agent creator; becomes the contract owner. Must be non-zero.
+    /// @param feeRouter_    Shared fee router that receives the 1% transfer tax. Non-zero.
+    /// @param bondingCurve_ Initial supply recipient (the paired bonding curve). Non-zero.
+    function initialize(
+        string memory name_,
+        string memory symbol_,
+        address creator_,
+        address feeRouter_,
+        address bondingCurve_
+    ) external initializer {
+        if (bytes(name_).length == 0 || bytes(symbol_).length == 0) revert EmptyMetadata();
+        if (creator_ == address(0) || feeRouter_ == address(0) || bondingCurve_ == address(0)) revert ZeroAddress();
+
+        __ERC20_init(name_, symbol_);
+        __Ownable_init(creator_);
+
+        creator = creator_;
+        feeRouter = feeRouter_;
+        bondingCurve = bondingCurve_;
+
+        _mint(bondingCurve_, TOTAL_SUPPLY);
+
+        emit AgentTokenInitialized(creator_, feeRouter_, bondingCurve_, name_, symbol_);
+    }
+
+    /// @dev Routes 1% of every peer-to-peer transfer to {feeRouter}. Tax is skipped for:
+    ///      - mint (`from == address(0)`) so {TOTAL_SUPPLY} lands intact on the bonding curve,
+    ///      - burn (`to == address(0)`) to preserve supply semantics,
+    ///      - transfers where either counterparty is `feeRouter`, so the router can sweep
+    ///        its own balance without paying tax on tax (which would round to zero and waste
+    ///        gas on every sweep).
+    ///
+    ///      Math: `tax = value * 100 / 10_000` is safe under Solidity 0.8 checked arithmetic
+    ///      for any `value <= TOTAL_SUPPLY`. The remainder `value - tax` can never underflow
+    ///      because `tax <= value`.
+    function _update(address from, address to, uint256 value) internal override {
+        address router = feeRouter;
+
+        // Skip tax on mint, burn, and router-involved transfers.
+        if (from == address(0) || to == address(0) || from == router || to == router) {
+            super._update(from, to, value);
+            return;
+        }
+
+        uint256 tax = (value * TRADE_TAX_BPS) / BPS_DENOMINATOR;
+        if (tax == 0) {
+            // Value too small for tax to register; forward full amount (dust-safe).
+            super._update(from, to, value);
+            return;
+        }
+
+        super._update(from, router, tax);
+        super._update(from, to, value - tax);
+
+        emit TaxCollected(from, to, tax);
+    }
+}

--- a/contracts/evm/test/launchpad/AgentToken.t.sol
+++ b/contracts/evm/test/launchpad/AgentToken.t.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {AgentToken} from "../../src/launchpad/AgentToken.sol";
+
+contract AgentTokenTest is Test {
+    AgentToken internal impl;
+    AgentToken internal token;
+
+    address internal creator = address(0xC0FFEE);
+    address internal feeRouter = address(0xFEE);
+    address internal bondingCurve = address(0xB0A2D);
+    address internal alice = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    string internal constant NAME = "Agent Smith";
+    string internal constant SYMBOL = "SMITH";
+
+    event AgentTokenInitialized(
+        address indexed creator, address indexed feeRouter, address indexed bondingCurve, string name, string symbol
+    );
+    event TaxCollected(address indexed from, address indexed to, uint256 taxAmount);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function setUp() public {
+        impl = new AgentToken();
+        token = _deployClone(NAME, SYMBOL, creator, feeRouter, bondingCurve);
+    }
+
+    function _deployClone(
+        string memory name_,
+        string memory symbol_,
+        address creator_,
+        address feeRouter_,
+        address bondingCurve_
+    ) internal returns (AgentToken cloned) {
+        cloned = AgentToken(Clones.clone(address(impl)));
+        cloned.initialize(name_, symbol_, creator_, feeRouter_, bondingCurve_);
+    }
+
+    // ---------------------------------------------------------------------
+    // initialize
+    // ---------------------------------------------------------------------
+
+    function test_initialize_sets_state_and_mints_total_supply() public view {
+        assertEq(token.name(), NAME);
+        assertEq(token.symbol(), SYMBOL);
+        assertEq(token.decimals(), 18);
+        assertEq(token.creator(), creator);
+        assertEq(token.feeRouter(), feeRouter);
+        assertEq(token.bondingCurve(), bondingCurve);
+        assertEq(token.owner(), creator);
+        assertEq(token.totalSupply(), token.TOTAL_SUPPLY());
+        assertEq(token.balanceOf(bondingCurve), token.TOTAL_SUPPLY());
+        assertEq(token.TRADE_TAX_BPS(), 100);
+        assertEq(token.BPS_DENOMINATOR(), 10_000);
+    }
+
+    function test_initialize_emits_event_and_mint_transfer() public {
+        AgentToken fresh = AgentToken(Clones.clone(address(impl)));
+
+        vm.expectEmit(true, true, false, true, address(fresh));
+        emit Transfer(address(0), bondingCurve, fresh.TOTAL_SUPPLY());
+        vm.expectEmit(true, true, true, true, address(fresh));
+        emit AgentTokenInitialized(creator, feeRouter, bondingCurve, NAME, SYMBOL);
+
+        fresh.initialize(NAME, SYMBOL, creator, feeRouter, bondingCurve);
+    }
+
+    function test_initialize_revert_when_called_twice() public {
+        vm.expectRevert();
+        token.initialize(NAME, SYMBOL, creator, feeRouter, bondingCurve);
+    }
+
+    function test_initialize_revert_on_implementation_directly() public {
+        vm.expectRevert();
+        impl.initialize(NAME, SYMBOL, creator, feeRouter, bondingCurve);
+    }
+
+    function test_initialize_revert_zero_creator() public {
+        AgentToken fresh = AgentToken(Clones.clone(address(impl)));
+        vm.expectRevert(AgentToken.ZeroAddress.selector);
+        fresh.initialize(NAME, SYMBOL, address(0), feeRouter, bondingCurve);
+    }
+
+    function test_initialize_revert_zero_feeRouter() public {
+        AgentToken fresh = AgentToken(Clones.clone(address(impl)));
+        vm.expectRevert(AgentToken.ZeroAddress.selector);
+        fresh.initialize(NAME, SYMBOL, creator, address(0), bondingCurve);
+    }
+
+    function test_initialize_revert_zero_bondingCurve() public {
+        AgentToken fresh = AgentToken(Clones.clone(address(impl)));
+        vm.expectRevert(AgentToken.ZeroAddress.selector);
+        fresh.initialize(NAME, SYMBOL, creator, feeRouter, address(0));
+    }
+
+    function test_initialize_revert_empty_name() public {
+        AgentToken fresh = AgentToken(Clones.clone(address(impl)));
+        vm.expectRevert(AgentToken.EmptyMetadata.selector);
+        fresh.initialize("", SYMBOL, creator, feeRouter, bondingCurve);
+    }
+
+    function test_initialize_revert_empty_symbol() public {
+        AgentToken fresh = AgentToken(Clones.clone(address(impl)));
+        vm.expectRevert(AgentToken.EmptyMetadata.selector);
+        fresh.initialize(NAME, "", creator, feeRouter, bondingCurve);
+    }
+
+    // ---------------------------------------------------------------------
+    // transfer tax
+    // ---------------------------------------------------------------------
+
+    function test_transfer_routes_one_percent_to_feeRouter() public {
+        // Seed alice from the curve (curve → user is always taxed; so tax applies here too).
+        uint256 seed = 10_000e18;
+        vm.prank(bondingCurve);
+        token.transfer(alice, seed);
+
+        uint256 expectedTax = (seed * 100) / 10_000; // 1%
+        assertEq(token.balanceOf(alice), seed - expectedTax);
+        assertEq(token.balanceOf(feeRouter), expectedTax);
+
+        // Now alice -> bob should also be taxed.
+        uint256 amount = 1000e18;
+        uint256 tax = (amount * 100) / 10_000;
+        uint256 routerBefore = token.balanceOf(feeRouter);
+
+        vm.expectEmit(true, true, false, true, address(token));
+        emit TaxCollected(alice, bob, tax);
+        vm.prank(alice);
+        token.transfer(bob, amount);
+
+        assertEq(token.balanceOf(bob), amount - tax);
+        assertEq(token.balanceOf(feeRouter), routerBefore + tax);
+    }
+
+    function test_transfer_preserves_supply() public {
+        uint256 supplyBefore = token.totalSupply();
+        vm.prank(bondingCurve);
+        token.transfer(alice, 500e18);
+
+        vm.prank(alice);
+        token.transfer(bob, 100e18);
+
+        assertEq(token.totalSupply(), supplyBefore);
+        assertEq(
+            token.balanceOf(bondingCurve) + token.balanceOf(alice) + token.balanceOf(bob) + token.balanceOf(feeRouter),
+            supplyBefore
+        );
+    }
+
+    function test_transferFrom_is_taxed() public {
+        uint256 seed = 5000e18;
+        vm.prank(bondingCurve);
+        token.transfer(alice, seed);
+
+        uint256 amount = 1000e18;
+        uint256 tax = (amount * 100) / 10_000;
+
+        vm.prank(alice);
+        token.approve(bob, amount);
+
+        uint256 routerBefore = token.balanceOf(feeRouter);
+        vm.prank(bob);
+        token.transferFrom(alice, bob, amount);
+
+        assertEq(token.balanceOf(bob), amount - tax);
+        assertEq(token.balanceOf(feeRouter), routerBefore + tax);
+        assertEq(token.allowance(alice, bob), 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // tax-skip paths
+    // ---------------------------------------------------------------------
+
+    function test_mint_is_not_taxed() public view {
+        // The constructor-time mint in initialize must not have been taxed.
+        assertEq(token.balanceOf(feeRouter), 0);
+        assertEq(token.balanceOf(bondingCurve), token.TOTAL_SUPPLY());
+    }
+
+    function test_transfer_from_feeRouter_is_not_taxed() public {
+        // Seed the router first via a taxed transfer.
+        uint256 seed = 1000e18;
+        vm.prank(bondingCurve);
+        token.transfer(alice, seed);
+        uint256 routerBalance = token.balanceOf(feeRouter);
+        assertGt(routerBalance, 0);
+
+        // Router -> alice must deliver full amount, no tax loop.
+        uint256 aliceBefore = token.balanceOf(alice);
+        vm.prank(feeRouter);
+        token.transfer(alice, routerBalance);
+
+        assertEq(token.balanceOf(alice), aliceBefore + routerBalance);
+        assertEq(token.balanceOf(feeRouter), 0);
+    }
+
+    function test_transfer_to_feeRouter_is_not_taxed() public {
+        uint256 seed = 2000e18;
+        vm.prank(bondingCurve);
+        token.transfer(alice, seed);
+
+        uint256 aliceBalance = token.balanceOf(alice);
+        uint256 routerBefore = token.balanceOf(feeRouter);
+
+        // Direct transfer to router — full amount lands, no double-tax.
+        vm.prank(alice);
+        token.transfer(feeRouter, aliceBalance);
+
+        assertEq(token.balanceOf(alice), 0);
+        assertEq(token.balanceOf(feeRouter), routerBefore + aliceBalance);
+    }
+
+    function test_zero_value_transfer_emits_no_tax() public {
+        vm.prank(bondingCurve);
+        token.transfer(alice, 1000e18);
+
+        uint256 routerBefore = token.balanceOf(feeRouter);
+        vm.prank(alice);
+        token.transfer(bob, 0);
+        assertEq(token.balanceOf(feeRouter), routerBefore);
+    }
+
+    function test_dust_value_rounds_tax_to_zero() public {
+        // Seed alice.
+        vm.prank(bondingCurve);
+        token.transfer(alice, 1000e18);
+
+        // `value = 99` → tax = 99 * 100 / 10_000 = 0. No tax collected, no dust loss.
+        uint256 routerBefore = token.balanceOf(feeRouter);
+        uint256 bobBefore = token.balanceOf(bob);
+
+        vm.prank(alice);
+        token.transfer(bob, 99);
+
+        assertEq(token.balanceOf(feeRouter), routerBefore);
+        assertEq(token.balanceOf(bob), bobBefore + 99);
+    }
+
+    // ---------------------------------------------------------------------
+    // supply conservation
+    // ---------------------------------------------------------------------
+
+    function test_totalSupply_immutable_across_transfers() public {
+        uint256 expected = token.TOTAL_SUPPLY();
+        assertEq(token.totalSupply(), expected);
+
+        vm.prank(bondingCurve);
+        token.transfer(alice, 10_000e18);
+        assertEq(token.totalSupply(), expected);
+
+        vm.prank(alice);
+        token.transfer(bob, 500e18);
+        assertEq(token.totalSupply(), expected);
+
+        uint256 routerBalance = token.balanceOf(feeRouter);
+        vm.prank(feeRouter);
+        token.transfer(alice, routerBalance);
+        assertEq(token.totalSupply(), expected);
+    }
+
+    function testFuzz_tax_math_never_exceeds_value(uint256 value) public {
+        value = bound(value, 0, token.TOTAL_SUPPLY());
+        vm.prank(bondingCurve);
+        token.transfer(alice, value);
+
+        // Balances + router sum to the seeded amount exactly.
+        uint256 tax = (value * 100) / 10_000;
+        assertEq(token.balanceOf(alice), value - tax);
+        assertEq(token.balanceOf(feeRouter), tax);
+    }
+
+    function testFuzz_router_sweeps_without_tax(uint256 seed) public {
+        seed = bound(seed, 1e18, token.TOTAL_SUPPLY());
+        vm.prank(bondingCurve);
+        token.transfer(alice, seed);
+
+        uint256 routerBalance = token.balanceOf(feeRouter);
+        vm.prank(feeRouter);
+        token.transfer(bob, routerBalance);
+
+        assertEq(token.balanceOf(feeRouter), 0);
+        assertEq(token.balanceOf(bob), routerBalance); // no tax skimmed
+    }
+}


### PR DESCRIPTION
## Summary

- New `AgentToken.sol` under `contracts/evm/src/launchpad/`: ERC-20 upgradeable clone deployed per agent via EIP-1167. Fixed 1B supply minted to the paired bonding curve on `initialize`.
- 1% transfer tax (100 bps) routed to a shared `feeRouter`. Tax bypassed on mint, burn, and router-involved transfers so the router can sweep collected fees without a tax-on-tax loop.
- Unit + fuzz tests (`test/launchpad/AgentToken.t.sol`) cover init guards, tax routing, tax-skip paths, supply conservation, and dust rounding. 100% lines, statements, branches, and functions on `AgentToken.sol`.

## Why

First contract in the launchpad suite. Every agent launch clones one of these; the shared fee router funnels trading tax to the creator (70%) and treasury (30%) downstream. Defining the tax skip-list here keeps the router-side accounting trivial.

## Test plan

- [x] unit (20 cases, all green)
- [x] fuzz (256 runs on tax math + router sweep)
- [x] `forge coverage` 100% on `AgentToken.sol`
- [x] slither clean on the new file
- [ ] integration (bonding curve wiring, follow-up PR)

Closes #27