### PR TITLE
feat(web): agent page with chart + widget

### DIFF
--- a/apps/web/__tests__/agent/page.test.tsx
+++ b/apps/web/__tests__/agent/page.test.tsx
@@ -1,0 +1,233 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ─── Mock next/navigation ─────────────────────────────────────────────────────
+// vi.mock is hoisted to the top of the file, so mockNotFound must be declared
+// via vi.hoisted to be available inside the factory.
+const { mockNotFound } = vi.hoisted(() => {
+  const mockNotFound = vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  });
+  return { mockNotFound };
+});
+vi.mock("next/navigation", () => ({ notFound: mockNotFound }));
+
+import graduatedFixture from "../../fixtures/agents/graduated.json";
+// ─── Mock fs so the server component works in jsdom ──────────────────────────
+import sampleFixture from "../../fixtures/agents/sample.json";
+
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: vi.fn((p: string) => {
+      if (p.includes("sample.json")) return true;
+      if (p.includes("graduated.json")) return true;
+      return false;
+    }),
+    readFileSync: vi.fn((p: string) => {
+      if (p.includes("sample.json")) return JSON.stringify(sampleFixture);
+      if (p.includes("graduated.json")) return JSON.stringify(graduatedFixture);
+      throw new Error("File not found");
+    }),
+  },
+}));
+
+// ─── Mock server action ───────────────────────────────────────────────────────
+vi.mock("../../app/agent/[slug]/actions", () => ({
+  submitTrade: vi.fn().mockResolvedValue({
+    txHash: "0xmocktxhash000000000000000000000000000000000000000000000000001",
+    amountIn: "100",
+    amountOut: "2186521",
+    isBuy: true,
+    gasUsed: 142000,
+    blockNumber: 18234567,
+  }),
+}));
+
+import TradeWidget from "../../app/agent/[slug]/TradeWidget";
+import AgentPage from "../../app/agent/[slug]/page";
+
+afterEach(() => cleanup());
+
+// ─── AgentPage: renders from fixture ─────────────────────────────────────────
+
+describe("AgentPage — sample fixture", () => {
+  async function renderSample() {
+    const jsx = await AgentPage({ params: Promise.resolve({ slug: "sample" }) });
+    render(jsx as React.ReactElement);
+  }
+
+  it("renders agent name and symbol", async () => {
+    await renderSample();
+    expect(screen.getByRole("heading", { name: /alphabot/i })).toBeInTheDocument();
+    expect(screen.getByText("ALPHA")).toBeInTheDocument();
+  });
+
+  it("renders description", async () => {
+    await renderSample();
+    expect(screen.getByText(/defi research agent/i)).toBeInTheDocument();
+  });
+
+  it("renders creator address (truncated)", async () => {
+    await renderSample();
+    expect(screen.getByText(/0x1234/i)).toBeInTheDocument();
+  });
+
+  it("renders module badges", async () => {
+    await renderSample();
+    expect(screen.getByText("Anti-Sniper")).toBeInTheDocument();
+    expect(screen.getByText("60-Day Escrow")).toBeInTheDocument();
+  });
+
+  it("renders current price dd element", async () => {
+    await renderSample();
+    // The <dd> element has aria-label="Current price: … TITU"
+    const priceDds = screen.getAllByLabelText(/current price/i);
+    expect(priceDds.length).toBeGreaterThan(0);
+  });
+
+  it("renders graduation progress bar", async () => {
+    await renderSample();
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toBeInTheDocument();
+    // 5000/42000 = 11.904…% → Math.round = 12
+    expect(bar).toHaveAttribute("aria-valuenow", "12");
+  });
+
+  it("renders the bonding curve chart figure", async () => {
+    await renderSample();
+    expect(screen.getByRole("img", { name: /bonding curve/i })).toBeInTheDocument();
+  });
+
+  it("renders the trade widget", async () => {
+    await renderSample();
+    expect(screen.getByRole("region", { name: /trade widget/i })).toBeInTheDocument();
+  });
+});
+
+// ─── AgentPage: graduated fixture ────────────────────────────────────────────
+
+describe("AgentPage — graduated fixture", () => {
+  async function renderGraduated() {
+    const jsx = await AgentPage({ params: Promise.resolve({ slug: "graduated" }) });
+    render(jsx as React.ReactElement);
+  }
+
+  it("shows graduated badge", async () => {
+    await renderGraduated();
+    expect(screen.getByRole("status", { name: /graduated/i })).toBeInTheDocument();
+  });
+
+  it("does not render graduation progress bar", async () => {
+    await renderGraduated();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+});
+
+// ─── AgentPage: 404 on unknown slug ──────────────────────────────────────────
+
+describe("AgentPage — unknown slug", () => {
+  it("calls notFound() for an unknown slug", async () => {
+    await expect(
+      AgentPage({ params: Promise.resolve({ slug: "does-not-exist" }) })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+});
+
+// ─── TradeWidget: calculation + submit flow ───────────────────────────────────
+
+describe("TradeWidget", () => {
+  const baseProps = { agent: sampleFixture as Parameters<typeof TradeWidget>[0]["agent"] };
+
+  it("renders buy tab selected by default", () => {
+    render(<TradeWidget {...baseProps} />);
+    const buyTab = screen.getByRole("tab", { name: /buy/i });
+    expect(buyTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("renders sell tab", () => {
+    render(<TradeWidget {...baseProps} />);
+    expect(screen.getByRole("tab", { name: /sell/i })).toBeInTheDocument();
+  });
+
+  it("switches to sell tab on click", async () => {
+    const user = userEvent.setup();
+    render(<TradeWidget {...baseProps} />);
+    await user.click(screen.getByRole("tab", { name: /sell/i }));
+    const sellTab = screen.getByRole("tab", { name: /sell/i });
+    expect(sellTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("shows estimated output after typing amount", async () => {
+    const user = userEvent.setup();
+    render(<TradeWidget {...baseProps} />);
+    await user.type(screen.getByLabelText(/titu to spend/i), "100");
+    // estimated output should appear (non-zero)
+    const output = screen.getByRole("status", { name: /estimated.*received/i });
+    expect(output).toBeInTheDocument();
+    expect(output.textContent).not.toContain("—");
+  });
+
+  it("shows validation error when submitting with no amount", async () => {
+    const user = userEvent.setup();
+    render(<TradeWidget {...baseProps} />);
+    await user.click(screen.getByRole("button", { name: /^buy$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(/greater than 0/i);
+  });
+
+  it("calls submitTrade and shows tx hash on success", async () => {
+    const user = userEvent.setup();
+    render(<TradeWidget {...baseProps} />);
+    await user.type(screen.getByLabelText(/titu to spend/i), "100");
+    await user.click(screen.getByRole("button", { name: /^buy$/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("status", { name: /trade result/i })).toBeInTheDocument();
+    });
+    expect(screen.getByRole("status", { name: /trade result/i })).toHaveTextContent(
+      /0xmocktxhash/i
+    );
+  });
+
+  it("sell tab shows agent symbol as input label", async () => {
+    const user = userEvent.setup();
+    render(<TradeWidget {...baseProps} />);
+    await user.click(screen.getByRole("tab", { name: /sell/i }));
+    expect(screen.getByLabelText(/alpha to sell/i)).toBeInTheDocument();
+  });
+
+  it("graduated agent disables the submit button", () => {
+    const graduatedAgent = {
+      ...sampleFixture,
+      graduated: true,
+    } as Parameters<typeof TradeWidget>[0]["agent"];
+    render(<TradeWidget agent={graduatedAgent} />);
+    const btn = screen.getByRole("button", { name: /graduated/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("estimated output uses constant-product math", async () => {
+    const user = userEvent.setup();
+    render(<TradeWidget {...baseProps} />);
+    await user.type(screen.getByLabelText(/titu to spend/i), "100");
+
+    // Manually compute expected output
+    const { virtualTituReserve, virtualAgentReserve, realTituReserve, realAgentReserve } =
+      sampleFixture;
+    const effectiveIn = 100 * 0.99;
+    const xReserve = virtualTituReserve + realTituReserve;
+    const yReserve = virtualAgentReserve + realAgentReserve;
+    const k = xReserve * yReserve;
+    const newX = xReserve + effectiveIn;
+    const expected = yReserve - k / newX;
+
+    const output = screen.getByRole("status", { name: /estimated.*received/i });
+    // Strip locale formatting (commas) then compare first 4 digits of integer part.
+    const rawText = (output.textContent ?? "").replace(/,/g, "");
+    const firstFour = expected.toFixed(0).slice(0, 4);
+    expect(rawText).toContain(firstFour);
+  });
+});

--- a/apps/web/__tests__/lib/bondingCurve.test.ts
+++ b/apps/web/__tests__/lib/bondingCurve.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  GRADUATION_THRESHOLD,
+  VIRTUAL_AGENT,
+  VIRTUAL_TITU,
+  buildCurvePoints,
+  getAmountOut,
+  getPrice,
+  graduationProgress,
+} from "../../lib/bondingCurve";
+
+// ─── getAmountOut: buy direction ──────────────────────────────────────────────
+
+describe("getAmountOut — buy (TITU → agent)", () => {
+  it("returns 0 for zero input", () => {
+    expect(getAmountOut(true, 0, VIRTUAL_TITU, VIRTUAL_AGENT, 0, 0)).toBe(0);
+  });
+
+  it("returns 0 for negative input", () => {
+    expect(getAmountOut(true, -10, VIRTUAL_TITU, VIRTUAL_AGENT, 0, 0)).toBe(0);
+  });
+
+  it("returns a positive amount for positive input", () => {
+    const out = getAmountOut(true, 100, VIRTUAL_TITU, VIRTUAL_AGENT, 0, 0);
+    expect(out).toBeGreaterThan(0);
+  });
+
+  it("applies the 1% fee (effective input = 99% of raw)", () => {
+    const xReserve = VIRTUAL_TITU; // realTitu = 0
+    const yReserve = VIRTUAL_AGENT;
+    const k = xReserve * yReserve;
+
+    const amountIn = 100;
+    const effectiveIn = amountIn * 0.99;
+    const newX = xReserve + effectiveIn;
+    const newY = k / newX;
+    const expected = yReserve - newY;
+
+    const result = getAmountOut(true, amountIn, VIRTUAL_TITU, VIRTUAL_AGENT, 0, 0);
+    expect(result).toBeCloseTo(expected, 6);
+  });
+
+  it("larger input yields more output (monotonic)", () => {
+    const out100 = getAmountOut(true, 100, VIRTUAL_TITU, VIRTUAL_AGENT, 5000, 145_800_000);
+    const out200 = getAmountOut(true, 200, VIRTUAL_TITU, VIRTUAL_AGENT, 5000, 145_800_000);
+    expect(out200).toBeGreaterThan(out100);
+  });
+
+  it("output is strictly less without fee than with fee applied", () => {
+    // With fee, effectiveIn < amountIn, so output < no-fee output.
+    const withFee = getAmountOut(true, 1000, VIRTUAL_TITU, VIRTUAL_AGENT, 0, 0);
+    // Manual no-fee version
+    const x = VIRTUAL_TITU;
+    const y = VIRTUAL_AGENT;
+    const k = x * y;
+    const noFeeOut = y - k / (x + 1000);
+    expect(withFee).toBeLessThan(noFeeOut);
+  });
+});
+
+// ─── getAmountOut: sell direction ─────────────────────────────────────────────
+
+describe("getAmountOut — sell (agent → TITU)", () => {
+  it("returns 0 for zero input", () => {
+    expect(getAmountOut(false, 0, VIRTUAL_TITU, VIRTUAL_AGENT, 5000, 145_800_000)).toBe(0);
+  });
+
+  it("returns positive TITU for agent tokens in", () => {
+    const out = getAmountOut(false, 1_000_000, VIRTUAL_TITU, VIRTUAL_AGENT, 5000, 145_800_000);
+    expect(out).toBeGreaterThan(0);
+  });
+
+  it("larger sell yields more TITU (monotonic)", () => {
+    const out1M = getAmountOut(false, 1_000_000, VIRTUAL_TITU, VIRTUAL_AGENT, 5000, 145_800_000);
+    const out2M = getAmountOut(false, 2_000_000, VIRTUAL_TITU, VIRTUAL_AGENT, 5000, 145_800_000);
+    expect(out2M).toBeGreaterThan(out1M);
+  });
+});
+
+// ─── Price function ───────────────────────────────────────────────────────────
+
+describe("getPrice", () => {
+  it("returns initial price at zero real reserves", () => {
+    const price = getPrice(VIRTUAL_TITU, VIRTUAL_AGENT, 0, 0);
+    expect(price).toBeCloseTo(VIRTUAL_TITU / VIRTUAL_AGENT, 10);
+  });
+
+  it("returns 0 when total agent reserve (virtual + real) is 0", () => {
+    // Both virtual and real agent are 0 → division by zero guard triggers.
+    expect(getPrice(0, 0, 100, 0)).toBe(0);
+  });
+
+  it("price increases as real TITU increases (monotonic)", () => {
+    // Simulate curve: as realTitu increases, realAgent decreases
+    const k = VIRTUAL_TITU * VIRTUAL_AGENT;
+    const steps = [0, 5000, 15000, 30000, 41000];
+    const prices = steps.map((realTitu) => {
+      const totalX = VIRTUAL_TITU + realTitu;
+      const totalY = k / totalX;
+      const realAgent = Math.max(0, totalY - VIRTUAL_AGENT);
+      return getPrice(VIRTUAL_TITU, VIRTUAL_AGENT, realTitu, realAgent);
+    });
+    for (let i = 1; i < prices.length; i++) {
+      expect(prices[i]).toBeGreaterThan(prices[i - 1]);
+    }
+  });
+});
+
+// ─── buildCurvePoints ────────────────────────────────────────────────────────
+
+describe("buildCurvePoints", () => {
+  it("starts at realTitu=0", () => {
+    const pts = buildCurvePoints(VIRTUAL_TITU, VIRTUAL_AGENT, GRADUATION_THRESHOLD, 10);
+    expect(pts[0].realTitu).toBe(0);
+  });
+
+  it("ends at the graduation threshold", () => {
+    const pts = buildCurvePoints(VIRTUAL_TITU, VIRTUAL_AGENT, GRADUATION_THRESHOLD, 10);
+    expect(pts[pts.length - 1].realTitu).toBe(GRADUATION_THRESHOLD);
+  });
+
+  it("returns steps+1 points", () => {
+    const pts = buildCurvePoints(VIRTUAL_TITU, VIRTUAL_AGENT, GRADUATION_THRESHOLD, 50);
+    expect(pts).toHaveLength(51);
+  });
+
+  it("prices are strictly increasing (monotonic curve)", () => {
+    const pts = buildCurvePoints(VIRTUAL_TITU, VIRTUAL_AGENT, GRADUATION_THRESHOLD, 100);
+    for (let i = 1; i < pts.length; i++) {
+      expect(pts[i].price).toBeGreaterThan(pts[i - 1].price);
+    }
+  });
+
+  it("all prices are positive", () => {
+    const pts = buildCurvePoints(VIRTUAL_TITU, VIRTUAL_AGENT, GRADUATION_THRESHOLD, 50);
+    for (const pt of pts) {
+      expect(pt.price).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── graduationProgress ──────────────────────────────────────────────────────
+
+describe("graduationProgress", () => {
+  it("returns 0 at zero realTitu", () => {
+    expect(graduationProgress(0)).toBe(0);
+  });
+
+  it("returns 0.5 at half threshold", () => {
+    expect(graduationProgress(GRADUATION_THRESHOLD / 2)).toBeCloseTo(0.5);
+  });
+
+  it("returns 1.0 at threshold", () => {
+    expect(graduationProgress(GRADUATION_THRESHOLD)).toBe(1);
+  });
+
+  it("clamps to 1.0 above threshold", () => {
+    expect(graduationProgress(GRADUATION_THRESHOLD * 2)).toBe(1);
+  });
+
+  it("uses custom threshold", () => {
+    expect(graduationProgress(10, 100)).toBeCloseTo(0.1);
+  });
+});
+
+// ─── Graduation threshold math ────────────────────────────────────────────────
+
+describe("graduation threshold math", () => {
+  it("at exactly 42,000 TITU raised, progress === 1", () => {
+    expect(graduationProgress(42_000, 42_000)).toBe(1);
+  });
+
+  it("buy output is never negative even near graduation", () => {
+    // Very large buy pushing close to (but not past) the reserve
+    const out = getAmountOut(
+      true,
+      41_999, // just under graduation
+      VIRTUAL_TITU,
+      VIRTUAL_AGENT,
+      0,
+      0
+    );
+    expect(out).toBeGreaterThan(0);
+  });
+
+  it("sell output is never negative with maximum agent tokens", () => {
+    const out = getAmountOut(
+      false,
+      VIRTUAL_AGENT, // sell all virtual agent tokens
+      VIRTUAL_TITU,
+      VIRTUAL_AGENT,
+      5000,
+      145_800_000
+    );
+    expect(out).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/web/app/agent/[slug]/BondingCurveChart.tsx
+++ b/apps/web/app/agent/[slug]/BondingCurveChart.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { buildCurvePoints } from "../../../lib/bondingCurve";
+import type { AgentFixture, PricePoint } from "./types";
+
+interface Props {
+  agent: AgentFixture;
+}
+
+const WIDTH = 560;
+const HEIGHT = 200;
+const PAD_LEFT = 56;
+const PAD_RIGHT = 16;
+const PAD_TOP = 12;
+const PAD_BOTTOM = 32;
+
+const CHART_W = WIDTH - PAD_LEFT - PAD_RIGHT;
+const CHART_H = HEIGHT - PAD_TOP - PAD_BOTTOM;
+
+function toSvgCoords(
+  points: Array<{ x: number; y: number }>,
+  xMin: number,
+  xMax: number,
+  yMin: number,
+  yMax: number
+): string {
+  if (points.length === 0) return "";
+  const xRange = xMax - xMin || 1;
+  const yRange = yMax - yMin || 1;
+  return points
+    .map(({ x, y }, i) => {
+      const cx = PAD_LEFT + ((x - xMin) / xRange) * CHART_W;
+      const cy = PAD_TOP + CHART_H - ((y - yMin) / yRange) * CHART_H;
+      return `${i === 0 ? "M" : "L"}${cx.toFixed(2)},${cy.toFixed(2)}`;
+    })
+    .join(" ");
+}
+
+function formatPrice(p: number): string {
+  if (p === 0) return "0";
+  if (p < 0.0001) return p.toExponential(2);
+  return p.toFixed(6);
+}
+
+export default function BondingCurveChart({ agent }: Props) {
+  const { virtualTituReserve, virtualAgentReserve, realTituReserve, graduationThreshold } = agent;
+
+  // Static bonding curve shape (theoretical full curve)
+  const curvePoints = buildCurvePoints(
+    virtualTituReserve,
+    virtualAgentReserve,
+    graduationThreshold,
+    120
+  );
+
+  // Price history scatter/line
+  const history: PricePoint[] = agent.priceHistory;
+
+  // Compute domains
+  const allPrices = curvePoints.map((p) => p.price).concat(history.map((h) => h.price));
+  const priceMin = 0;
+  const priceMax = Math.max(...allPrices) * 1.05;
+
+  // Curve path (price vs realTitu)
+  const curveSvgPoints = curvePoints.map((p) => ({ x: p.realTitu, y: p.price }));
+  const curvePath = toSvgCoords(curveSvgPoints, 0, graduationThreshold, priceMin, priceMax);
+
+  // History path (price vs time, normalised to same x domain)
+  const tMin = history.length ? history[0].t : 0;
+  const tMax = history.length ? history[history.length - 1].t : 1;
+  const histSvgPoints = history.map((h) => ({ x: h.t, y: h.price }));
+  const histPath = toSvgCoords(histSvgPoints, tMin, tMax, priceMin, priceMax);
+
+  // Current position marker on the curve
+  const currentCurveX = PAD_LEFT + (realTituReserve / graduationThreshold) * CHART_W;
+  const currentCurveYFrac = (agent.currentPrice - priceMin) / (priceMax - priceMin || 1);
+  const currentCurveY = PAD_TOP + CHART_H - currentCurveYFrac * CHART_H;
+
+  // Y-axis labels (3 ticks)
+  const yTicks = [0, 0.5, 1].map((frac) => ({
+    y: PAD_TOP + CHART_H - frac * CHART_H,
+    label: formatPrice(priceMin + frac * (priceMax - priceMin)),
+  }));
+
+  // X-axis labels (graduation threshold)
+  const xTicks = [0, 0.5, 1].map((frac) => ({
+    x: PAD_LEFT + frac * CHART_W,
+    label: `${Math.round(frac * graduationThreshold).toLocaleString()}`,
+  }));
+
+  return (
+    <figure aria-label='Bonding curve price chart' style={{ margin: 0 }}>
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        width='100%'
+        style={{ display: "block", maxWidth: WIDTH }}
+        role='img'
+        aria-label={`${agent.name} bonding curve. Current real reserve: ${realTituReserve} TITU. Graduation at ${graduationThreshold} TITU.`}
+      >
+        {/* Grid lines */}
+        {yTicks.map((tick) => (
+          <line
+            key={tick.label}
+            x1={PAD_LEFT}
+            x2={WIDTH - PAD_RIGHT}
+            y1={tick.y}
+            y2={tick.y}
+            stroke='#e2e8f0'
+            strokeWidth={1}
+          />
+        ))}
+
+        {/* Theoretical curve (grey) */}
+        <path d={curvePath} fill='none' stroke='#94a3b8' strokeWidth={1.5} />
+
+        {/* Price history (blue) */}
+        {histPath && <path d={histPath} fill='none' stroke='#2563eb' strokeWidth={2} />}
+
+        {/* Current position dot */}
+        <circle
+          cx={currentCurveX}
+          cy={currentCurveY}
+          r={5}
+          fill='#2563eb'
+          stroke='#fff'
+          strokeWidth={2}
+          aria-label={`Current price: ${formatPrice(agent.currentPrice)} TITU`}
+        />
+
+        {/* Y-axis labels */}
+        {yTicks.map((tick) => (
+          <text
+            key={tick.label}
+            x={PAD_LEFT - 4}
+            y={tick.y + 4}
+            textAnchor='end'
+            fontSize={10}
+            fill='#64748b'
+          >
+            {tick.label}
+          </text>
+        ))}
+
+        {/* X-axis labels */}
+        {xTicks.map((tick) => (
+          <text
+            key={tick.label}
+            x={tick.x}
+            y={HEIGHT - 4}
+            textAnchor='middle'
+            fontSize={10}
+            fill='#64748b'
+          >
+            {tick.label}
+          </text>
+        ))}
+
+        {/* Axis labels */}
+        <text x={PAD_LEFT - 4} y={PAD_TOP - 2} textAnchor='end' fontSize={9} fill='#94a3b8'>
+          TITU
+        </text>
+        <text x={WIDTH - PAD_RIGHT} y={HEIGHT - 4} textAnchor='end' fontSize={9} fill='#94a3b8'>
+          raised TITU
+        </text>
+      </svg>
+
+      <figcaption style={{ fontSize: 12, color: "#64748b", marginTop: 4, textAlign: "center" }}>
+        Price (TITU) vs. TITU raised — <span style={{ color: "#94a3b8" }}>grey = curve shape</span>,{" "}
+        <span style={{ color: "#2563eb" }}>blue = history</span>
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/web/app/agent/[slug]/TradeWidget.tsx
+++ b/apps/web/app/agent/[slug]/TradeWidget.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useState } from "react";
+import { getAmountOut } from "../../../lib/bondingCurve";
+import type { TradeResult } from "./actions";
+import { submitTrade } from "./actions";
+import type { AgentFixture } from "./types";
+
+interface Props {
+  agent: AgentFixture;
+}
+
+type Tab = "buy" | "sell";
+
+function formatAmount(n: number, decimals = 4): string {
+  if (n === 0) return "0";
+  if (n < 0.0001) return n.toExponential(3);
+  return n.toLocaleString("en-US", { maximumFractionDigits: decimals });
+}
+
+export default function TradeWidget({ agent }: Props) {
+  const [tab, setTab] = useState<Tab>("buy");
+  const [amountIn, setAmountIn] = useState("");
+  const [slippage, setSlippage] = useState("1");
+  const [pending, setPending] = useState(false);
+  const [result, setResult] = useState<TradeResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const isBuy = tab === "buy";
+  const numIn = Number(amountIn) || 0;
+  const slippageBps = Math.round((Number(slippage) || 1) * 100);
+
+  const estimatedOut = getAmountOut(
+    isBuy,
+    numIn,
+    agent.virtualTituReserve,
+    agent.virtualAgentReserve,
+    agent.realTituReserve,
+    agent.realAgentReserve
+  );
+
+  const minAmountOut = estimatedOut * (1 - slippageBps / 10_000);
+
+  const inputLabel = isBuy ? "TITU to spend" : `${agent.symbol} to sell`;
+  const outputLabel = isBuy ? agent.symbol : "TITU";
+
+  function handleTabChange(next: Tab) {
+    setTab(next);
+    setAmountIn("");
+    setResult(null);
+    setError(null);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (numIn <= 0) {
+      setError("Enter an amount greater than 0.");
+      return;
+    }
+    setPending(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await submitTrade({
+        slug: agent.slug,
+        isBuy,
+        amountIn: numIn,
+        minAmountOut,
+        slippageBps,
+      });
+      setResult(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section aria-label='Trade widget' style={{ maxWidth: 420 }}>
+      {/* Tabs */}
+      <div
+        role='tablist'
+        aria-label='Buy or sell'
+        style={{
+          display: "flex",
+          gap: 0,
+          marginBottom: 16,
+          borderRadius: 8,
+          overflow: "hidden",
+          border: "1px solid #e2e8f0",
+        }}
+      >
+        {(["buy", "sell"] as const).map((t) => (
+          <button
+            key={t}
+            role='tab'
+            id={`tab-${t}`}
+            aria-selected={tab === t}
+            aria-controls='tabpanel-trade'
+            type='button'
+            onClick={() => handleTabChange(t)}
+            style={{
+              flex: 1,
+              padding: "10px 0",
+              fontWeight: tab === t ? 700 : 400,
+              background: tab === t ? (t === "buy" ? "#16a34a" : "#dc2626") : "#f8fafc",
+              color: tab === t ? "#fff" : "#374151",
+              border: "none",
+              cursor: "pointer",
+              fontSize: 14,
+              letterSpacing: 0.3,
+            }}
+          >
+            {t === "buy" ? "Buy" : "Sell"}
+          </button>
+        ))}
+      </div>
+
+      <div id='tabpanel-trade' role='tabpanel' aria-labelledby={`tab-${tab}`}>
+        {agent.graduated ? (
+          <p
+            style={{
+              padding: "10px 14px",
+              background: "#fef3c7",
+              borderRadius: 6,
+              fontSize: 13,
+              color: "#92400e",
+              marginBottom: 16,
+            }}
+            role='note'
+          >
+            This agent has graduated. Trades now route through Uniswap V2 (wiring in next
+            iteration).
+          </p>
+        ) : null}
+
+        <form onSubmit={handleSubmit} aria-label={`${isBuy ? "Buy" : "Sell"} form`} noValidate>
+          {/* Input amount */}
+          <div style={{ marginBottom: 16 }}>
+            <label
+              htmlFor='amount-in'
+              style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 14 }}
+            >
+              {inputLabel} <span aria-hidden='true'>*</span>
+            </label>
+            <input
+              id='amount-in'
+              type='number'
+              min='0'
+              step='any'
+              aria-required='true'
+              aria-describedby='amount-out-preview'
+              value={amountIn}
+              onChange={(e) => {
+                setAmountIn(e.target.value);
+                setResult(null);
+                setError(null);
+              }}
+              placeholder='0'
+              disabled={pending}
+              style={{ width: "100%", padding: "8px 12px", boxSizing: "border-box", fontSize: 15 }}
+            />
+          </div>
+
+          {/* Estimated output */}
+          <output
+            id='amount-out-preview'
+            aria-live='polite'
+            aria-label={`Estimated ${outputLabel} received`}
+            style={{
+              display: "block",
+              padding: "10px 14px",
+              background: "#f1f5f9",
+              borderRadius: 6,
+              marginBottom: 16,
+              fontSize: 13,
+            }}
+          >
+            Estimated {outputLabel}:{" "}
+            <strong>
+              {numIn > 0 ? formatAmount(estimatedOut) : "—"} {outputLabel}
+            </strong>
+          </output>
+
+          {/* Slippage */}
+          <div style={{ marginBottom: 20 }}>
+            <label
+              htmlFor='slippage'
+              style={{ display: "block", fontWeight: 600, marginBottom: 4, fontSize: 13 }}
+            >
+              Slippage tolerance (%)
+            </label>
+            <input
+              id='slippage'
+              type='number'
+              min='0.1'
+              max='50'
+              step='0.1'
+              value={slippage}
+              onChange={(e) => setSlippage(e.target.value)}
+              disabled={pending}
+              style={{ width: 100, padding: "6px 10px" }}
+            />
+            {numIn > 0 && (
+              <p style={{ fontSize: 11, color: "#6b7280", marginTop: 4 }}>
+                Min received: {formatAmount(minAmountOut)} {outputLabel}
+              </p>
+            )}
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p role='alert' style={{ color: "#dc2626", fontSize: 13, marginBottom: 12 }}>
+              {error}
+            </p>
+          )}
+
+          {/* Submit */}
+          <button
+            type='submit'
+            disabled={pending || agent.graduated}
+            aria-busy={pending}
+            aria-disabled={agent.graduated}
+            style={{
+              width: "100%",
+              padding: "12px 0",
+              fontWeight: 700,
+              fontSize: 15,
+              background: agent.graduated ? "#94a3b8" : isBuy ? "#16a34a" : "#dc2626",
+              color: "#fff",
+              border: "none",
+              borderRadius: 8,
+              cursor: agent.graduated || pending ? "not-allowed" : "pointer",
+              opacity: pending ? 0.7 : 1,
+            }}
+          >
+            {pending ? "Submitting…" : agent.graduated ? "Graduated" : isBuy ? "Buy" : "Sell"}
+          </button>
+        </form>
+
+        {/* Result */}
+        {result && (
+          <output
+            aria-live='polite'
+            aria-label='Trade result'
+            style={{
+              display: "block",
+              marginTop: 16,
+              padding: "12px 14px",
+              background: "#f0fdf4",
+              borderRadius: 8,
+              fontSize: 13,
+            }}
+          >
+            <p style={{ fontWeight: 700, color: "#16a34a", marginBottom: 8 }}>Trade submitted!</p>
+            <dl style={{ margin: 0, lineHeight: 2 }}>
+              <dt style={{ fontWeight: 600, display: "inline" }}>Tx hash: </dt>
+              <dd style={{ display: "inline", wordBreak: "break-all" }}>
+                <code>{result.txHash}</code>
+              </dd>
+            </dl>
+          </output>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/agent/[slug]/actions.ts
+++ b/apps/web/app/agent/[slug]/actions.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import tradeResponse from "../../../fixtures/trade-response.json";
+
+export interface TradeResult {
+  txHash: string;
+  amountIn: string;
+  amountOut: string;
+  isBuy: boolean;
+  gasUsed: number;
+  blockNumber: number;
+}
+
+export interface TradeParams {
+  slug: string;
+  isBuy: boolean;
+  amountIn: number;
+  minAmountOut: number;
+  slippageBps: number;
+}
+
+export async function submitTrade(_params: TradeParams): Promise<TradeResult> {
+  // Fixture stub — no real wallet or chain call.
+  // Real Wagmi tx wiring follows in a later iteration.
+  await new Promise((resolve) => setTimeout(resolve, 600));
+  return tradeResponse as TradeResult;
+}

--- a/apps/web/app/agent/[slug]/error.tsx
+++ b/apps/web/app/agent/[slug]/error.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+export default function AgentError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main
+      style={{ maxWidth: 800, margin: "0 auto", padding: "40px 24px", textAlign: "center" }}
+      role='alert'
+    >
+      <h1 style={{ color: "#dc2626" }}>Something went wrong</h1>
+      <p style={{ color: "#6b7280", marginBottom: 24 }}>
+        {error.message || "Failed to load agent page."}
+      </p>
+      <button
+        type='button'
+        onClick={reset}
+        style={{
+          padding: "10px 24px",
+          background: "#2563eb",
+          color: "#fff",
+          border: "none",
+          borderRadius: 6,
+          cursor: "pointer",
+        }}
+      >
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/apps/web/app/agent/[slug]/loading.tsx
+++ b/apps/web/app/agent/[slug]/loading.tsx
@@ -1,0 +1,35 @@
+export default function AgentLoading() {
+  return (
+    <main
+      style={{ maxWidth: 800, margin: "0 auto", padding: "40px 24px" }}
+      aria-busy='true'
+      aria-label='Loading agent page'
+    >
+      <div
+        style={{
+          height: 32,
+          width: 240,
+          background: "#e2e8f0",
+          borderRadius: 6,
+          marginBottom: 24,
+          animation: "pulse 1.5s ease-in-out infinite",
+        }}
+      />
+      <div
+        style={{
+          height: 200,
+          background: "#e2e8f0",
+          borderRadius: 8,
+          marginBottom: 24,
+        }}
+      />
+      <div
+        style={{
+          height: 300,
+          background: "#e2e8f0",
+          borderRadius: 8,
+        }}
+      />
+    </main>
+  );
+}

--- a/apps/web/app/agent/[slug]/page.tsx
+++ b/apps/web/app/agent/[slug]/page.tsx
@@ -1,0 +1,252 @@
+import fs from "node:fs";
+import path from "node:path";
+import { notFound } from "next/navigation";
+import { graduationProgress } from "../../../lib/bondingCurve";
+import BondingCurveChart from "./BondingCurveChart";
+import TradeWidget from "./TradeWidget";
+import { MODULE_LABELS, agentFixtureSchema } from "./types";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+function loadAgent(slug: string) {
+  const fixtureDir = path.join(process.cwd(), "fixtures", "agents");
+  const filePath = path.join(fixtureDir, `${slug}.json`);
+
+  // Validate the slug resolves to a file inside the fixture directory
+  // (prevents path traversal — canonical path must stay inside fixtureDir).
+  const resolved = path.resolve(filePath);
+  if (!resolved.startsWith(path.resolve(fixtureDir) + path.sep)) {
+    return null;
+  }
+
+  if (!fs.existsSync(resolved)) return null;
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(resolved, "utf-8"));
+  } catch {
+    return null;
+  }
+
+  const parsed = agentFixtureSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+function formatPrice(p: number): string {
+  if (p === 0) return "0";
+  if (p < 0.0001) return p.toExponential(3);
+  return p.toFixed(6);
+}
+
+function truncateAddress(addr: string): string {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params;
+  const agent = loadAgent(slug);
+  if (!agent) return { title: "Agent not found — Titular" };
+  return {
+    title: `${agent.name} (${agent.symbol}) — Titular`,
+    description: agent.description,
+  };
+}
+
+export default async function AgentPage({ params }: PageProps) {
+  const { slug } = await params;
+  const agent = loadAgent(slug);
+
+  if (!agent) {
+    notFound();
+  }
+
+  const progress = graduationProgress(agent.realTituReserve, agent.graduationThreshold);
+  const progressPct = Math.round(progress * 100);
+
+  return (
+    <main style={{ maxWidth: 820, margin: "0 auto", padding: "40px 24px" }}>
+      {/* ── Agent header ─────────────────────────────────────────── */}
+      <header style={{ marginBottom: 32 }}>
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 20 }}>
+          {/* Agent image — rendered via next/image-compatible <img> with explicit dimensions */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={agent.imageURI}
+            alt={`${agent.name} logo`}
+            width={80}
+            height={80}
+            style={{ borderRadius: 12, objectFit: "cover", flexShrink: 0 }}
+          />
+
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+              <h1 style={{ margin: 0, fontSize: 28, fontWeight: 800 }}>{agent.name}</h1>
+              <span
+                style={{
+                  padding: "2px 10px",
+                  background: "#f1f5f9",
+                  borderRadius: 20,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: "#475569",
+                }}
+              >
+                {agent.symbol}
+              </span>
+              {agent.graduated && (
+                <output
+                  aria-label='Graduated agent'
+                  style={{
+                    padding: "2px 10px",
+                    background: "#d1fae5",
+                    borderRadius: 20,
+                    fontSize: 12,
+                    fontWeight: 700,
+                    color: "#065f46",
+                  }}
+                >
+                  Graduated
+                </output>
+              )}
+            </div>
+
+            <p style={{ margin: "8px 0 12px", color: "#475569", fontSize: 14 }}>
+              {agent.description}
+            </p>
+
+            <p style={{ margin: 0, fontSize: 13, color: "#6b7280" }}>
+              Creator: <code style={{ fontSize: 12 }}>{truncateAddress(agent.creator)}</code>
+            </p>
+          </div>
+        </div>
+
+        {/* Module badges */}
+        {agent.modules.length > 0 && (
+          <ul
+            aria-label='Enabled modules'
+            style={{
+              display: "flex",
+              gap: 8,
+              flexWrap: "wrap",
+              marginTop: 16,
+              listStyle: "none",
+              padding: 0,
+              margin: "16px 0 0",
+            }}
+          >
+            {agent.modules.map((mod) => (
+              <li
+                key={mod}
+                style={{
+                  padding: "3px 10px",
+                  background: "#eff6ff",
+                  border: "1px solid #bfdbfe",
+                  borderRadius: 20,
+                  fontSize: 12,
+                  color: "#1d4ed8",
+                  fontWeight: 500,
+                }}
+              >
+                {MODULE_LABELS[mod] ?? mod}
+              </li>
+            ))}
+          </ul>
+        )}
+      </header>
+
+      {/* ── Price & market cap ───────────────────────────────────── */}
+      <section aria-labelledby='price-heading' style={{ marginBottom: 32 }}>
+        <h2 id='price-heading' style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>
+          Price &amp; Market Cap
+        </h2>
+        <dl
+          style={{ display: "flex", gap: 32, flexWrap: "wrap", margin: 0 }}
+          aria-label='Price and market cap stats'
+        >
+          <div>
+            <dt style={{ fontSize: 12, color: "#6b7280", marginBottom: 2 }}>Current price</dt>
+            <dd
+              style={{ fontSize: 22, fontWeight: 700, margin: 0 }}
+              aria-live='polite'
+              aria-label={`Current price: ${formatPrice(agent.currentPrice)} TITU`}
+            >
+              {formatPrice(agent.currentPrice)}{" "}
+              <span style={{ fontSize: 14, fontWeight: 400, color: "#6b7280" }}>TITU</span>
+            </dd>
+          </div>
+          <div>
+            <dt style={{ fontSize: 12, color: "#6b7280", marginBottom: 2 }}>Market cap</dt>
+            <dd style={{ fontSize: 22, fontWeight: 700, margin: 0 }}>
+              {agent.marketCap.toLocaleString()}{" "}
+              <span style={{ fontSize: 14, fontWeight: 400, color: "#6b7280" }}>TITU</span>
+            </dd>
+          </div>
+          <div>
+            <dt style={{ fontSize: 12, color: "#6b7280", marginBottom: 2 }}>TITU raised</dt>
+            <dd style={{ fontSize: 22, fontWeight: 700, margin: 0 }}>
+              {agent.realTituReserve.toLocaleString()}{" "}
+              <span style={{ fontSize: 14, fontWeight: 400, color: "#6b7280" }}>
+                / {agent.graduationThreshold.toLocaleString()}
+              </span>
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      {/* ── Graduation progress ──────────────────────────────────── */}
+      {!agent.graduated && (
+        <section aria-labelledby='grad-heading' style={{ marginBottom: 32 }}>
+          <h2 id='grad-heading' style={{ fontSize: 16, fontWeight: 700, marginBottom: 8 }}>
+            Progress to graduation
+          </h2>
+          <div
+            role='progressbar'
+            aria-valuenow={progressPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${progressPct}% of graduation threshold reached`}
+            tabIndex={0}
+            style={{
+              height: 12,
+              background: "#e2e8f0",
+              borderRadius: 6,
+              overflow: "hidden",
+            }}
+          >
+            <div
+              style={{
+                height: "100%",
+                width: `${progressPct}%`,
+                background: progressPct >= 80 ? "#16a34a" : "#2563eb",
+                borderRadius: 6,
+                transition: "width 0.3s ease",
+              }}
+            />
+          </div>
+          <p style={{ margin: "6px 0 0", fontSize: 13, color: "#475569" }}>
+            {agent.realTituReserve.toLocaleString()} / {agent.graduationThreshold.toLocaleString()}{" "}
+            TITU ({progressPct}%)
+          </p>
+        </section>
+      )}
+
+      {/* ── Bonding curve chart ──────────────────────────────────── */}
+      <section aria-labelledby='chart-heading' style={{ marginBottom: 40 }}>
+        <h2 id='chart-heading' style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>
+          Bonding curve
+        </h2>
+        <BondingCurveChart agent={agent} />
+      </section>
+
+      {/* ── Trade widget ─────────────────────────────────────────── */}
+      <section aria-labelledby='trade-heading' style={{ marginBottom: 40 }}>
+        <h2 id='trade-heading' style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>
+          Trade
+        </h2>
+        <TradeWidget agent={agent} />
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/agent/[slug]/types.ts
+++ b/apps/web/app/agent/[slug]/types.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+export const pricePointSchema = z.object({
+  t: z.number(),
+  price: z.number(),
+});
+
+export const agentFixtureSchema = z.object({
+  slug: z.string(),
+  name: z.string(),
+  symbol: z.string(),
+  description: z.string(),
+  imageURI: z.string().url(),
+  creator: z.string(),
+  tokenAddress: z.string(),
+  curveAddress: z.string(),
+  uniswapPair: z.string().optional(),
+  moduleBitmap: z.number().int().min(0).max(127),
+  modules: z.array(z.string()),
+  graduated: z.boolean(),
+  virtualTituReserve: z.number(),
+  virtualAgentReserve: z.number(),
+  realTituReserve: z.number(),
+  realAgentReserve: z.number(),
+  graduationThreshold: z.number(),
+  currentPrice: z.number(),
+  marketCap: z.number(),
+  priceHistory: z.array(pricePointSchema),
+});
+
+export type AgentFixture = z.infer<typeof agentFixtureSchema>;
+export type PricePoint = z.infer<typeof pricePointSchema>;
+
+export const MODULE_LABELS: Record<string, string> = {
+  AntiSniper: "Anti-Sniper",
+  SixtyDays: "60-Day Escrow",
+  CapitalFormation: "Capital Formation",
+  Airdrop: "Airdrop",
+  LaunchRadar: "Launch Radar",
+  PreBuy: "Pre-Buy",
+  ExistingToken: "Existing Token",
+};

--- a/apps/web/fixtures/agents/graduated.json
+++ b/apps/web/fixtures/agents/graduated.json
@@ -1,0 +1,30 @@
+{
+  "slug": "graduated",
+  "name": "GradBot",
+  "symbol": "GRAD",
+  "description": "An execution agent that reached graduation and now trades on Uniswap V2.",
+  "imageURI": "https://fixtures.titular.xyz/images/gradbot.png",
+  "creator": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  "tokenAddress": "0xCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCc",
+  "curveAddress": "0xDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdDdDd",
+  "uniswapPair": "0xEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEeEe",
+  "moduleBitmap": 7,
+  "modules": ["AntiSniper", "SixtyDays", "CapitalFormation"],
+  "graduated": true,
+  "virtualTituReserve": 30000,
+  "virtualAgentReserve": 1073000000,
+  "realTituReserve": 42000,
+  "realAgentReserve": 0,
+  "graduationThreshold": 42000,
+  "currentPrice": 0.000392,
+  "marketCap": 392000,
+  "priceHistory": [
+    { "t": 1714000000, "price": 0.000028 },
+    { "t": 1714007200, "price": 0.000062 },
+    { "t": 1714014400, "price": 0.000145 },
+    { "t": 1714021600, "price": 0.00022 },
+    { "t": 1714028800, "price": 0.000301 },
+    { "t": 1714036000, "price": 0.000358 },
+    { "t": 1714043200, "price": 0.000392 }
+  ]
+}

--- a/apps/web/fixtures/agents/sample.json
+++ b/apps/web/fixtures/agents/sample.json
@@ -1,0 +1,29 @@
+{
+  "slug": "sample",
+  "name": "AlphaBot",
+  "symbol": "ALPHA",
+  "description": "A DeFi research agent specialising in on-chain analytics and yield optimisation.",
+  "imageURI": "https://fixtures.titular.xyz/images/alphabot.png",
+  "creator": "0x1234567890abcdef1234567890abcdef12345678",
+  "tokenAddress": "0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa",
+  "curveAddress": "0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb",
+  "moduleBitmap": 3,
+  "modules": ["AntiSniper", "SixtyDays"],
+  "graduated": false,
+  "virtualTituReserve": 30000,
+  "virtualAgentReserve": 1073000000,
+  "realTituReserve": 5000,
+  "realAgentReserve": 145800000,
+  "graduationThreshold": 42000,
+  "currentPrice": 0.0000458,
+  "marketCap": 45800,
+  "priceHistory": [
+    { "t": 1714000000, "price": 0.000028 },
+    { "t": 1714003600, "price": 0.000031 },
+    { "t": 1714007200, "price": 0.000035 },
+    { "t": 1714010800, "price": 0.000039 },
+    { "t": 1714014400, "price": 0.000042 },
+    { "t": 1714018000, "price": 0.000045 },
+    { "t": 1714021600, "price": 0.0000458 }
+  ]
+}

--- a/apps/web/fixtures/trade-response.json
+++ b/apps/web/fixtures/trade-response.json
@@ -1,0 +1,8 @@
+{
+  "txHash": "0xfixture00000000000000000000000000000000000000000000000000000001",
+  "amountIn": "100",
+  "amountOut": "2186521",
+  "isBuy": true,
+  "gasUsed": 142000,
+  "blockNumber": 18234567
+}

--- a/apps/web/lib/bondingCurve.ts
+++ b/apps/web/lib/bondingCurve.ts
@@ -1,0 +1,119 @@
+/**
+ * Bonding curve math matching BondingCurve.sol constant-product formula.
+ *
+ * Invariant: (virtualTitu + realTitu) * (virtualAgent + realAgent) = k
+ *
+ * Virtual reserves (Virtuals-style):
+ *   virtualTitu  = 30,000  TITU  (18-decimal amounts are passed as plain numbers here)
+ *   virtualAgent = 1,073,000,000 agent tokens
+ *
+ * Graduation threshold: 42,000 real TITU raised.
+ *
+ * All amounts here are in display units (no wei scaling) to keep the FE math
+ * simple. Contract-level calls will apply 1e18 scaling.
+ */
+
+export const VIRTUAL_TITU = 30_000;
+export const VIRTUAL_AGENT = 1_073_000_000;
+export const GRADUATION_THRESHOLD = 42_000;
+
+export interface CurveState {
+  virtualTitu: number;
+  virtualAgent: number;
+  realTitu: number;
+  realAgent: number;
+}
+
+/**
+ * Compute the amount of tokens received for a given input, applying the
+ * constant-product formula with a 1% fee taken from the input.
+ *
+ * Formula (no fee):
+ *   k  = (vX + rX) * (vY + rY)
+ *   dy = (vY + rY) - k / (vX + rX + dx)
+ *
+ * 1% fee: effective_dx = dx * 0.99
+ *
+ * @param isBuy   true  → spend TITU, receive agent tokens
+ *                false → spend agent tokens, receive TITU
+ */
+export function getAmountOut(
+  isBuy: boolean,
+  amountIn: number,
+  virtualTitu: number,
+  virtualAgent: number,
+  realTitu: number,
+  realAgent: number
+): number {
+  if (amountIn <= 0) return 0;
+
+  const effectiveIn = amountIn * 0.99; // 1% fee
+
+  if (isBuy) {
+    // dx = TITU in, dy = agent out
+    const xReserve = virtualTitu + realTitu;
+    const yReserve = virtualAgent + realAgent;
+    const k = xReserve * yReserve;
+    const newX = xReserve + effectiveIn;
+    const newY = k / newX;
+    const amountOut = yReserve - newY;
+    return Math.max(0, amountOut);
+  }
+  // dx = agent in, dy = TITU out
+  const xReserve = virtualAgent + realAgent;
+  const yReserve = virtualTitu + realTitu;
+  const k = xReserve * yReserve;
+  const newX = xReserve + effectiveIn;
+  const newY = k / newX;
+  const amountOut = yReserve - newY;
+  return Math.max(0, amountOut);
+}
+
+/**
+ * Marginal price of agent token denominated in TITU.
+ * price = (virtualTitu + realTitu) / (virtualAgent + realAgent)
+ */
+export function getPrice(
+  virtualTitu: number,
+  virtualAgent: number,
+  realTitu: number,
+  realAgent: number
+): number {
+  const xReserve = virtualTitu + realTitu;
+  const yReserve = virtualAgent + realAgent;
+  if (yReserve === 0) return 0;
+  return xReserve / yReserve;
+}
+
+/**
+ * Build an array of (realTitu, price) points for a given number of steps,
+ * ranging from realTitu=0 to realTitu=graduationThreshold.
+ * Used to render the static curve shape.
+ */
+export function buildCurvePoints(
+  virtualTitu: number,
+  virtualAgent: number,
+  graduationThreshold: number,
+  steps = 100
+): Array<{ realTitu: number; price: number }> {
+  const points: Array<{ realTitu: number; price: number }> = [];
+  for (let i = 0; i <= steps; i++) {
+    const realTitu = (graduationThreshold * i) / steps;
+    // When realTitu increases, realAgent decreases to maintain k.
+    // realAgent = k / (virtualTitu + realTitu) - virtualAgent
+    const k = virtualTitu * virtualAgent; // k at real=0, real_agent=0
+    const newX = virtualTitu + realTitu;
+    const totalY = k / newX;
+    const realAgent = Math.max(0, totalY - virtualAgent);
+    const price = getPrice(virtualTitu, virtualAgent, realTitu, realAgent);
+    points.push({ realTitu, price });
+  }
+  return points;
+}
+
+/**
+ * Returns progress toward graduation as a fraction [0, 1].
+ */
+export function graduationProgress(realTitu: number, threshold = GRADUATION_THRESHOLD): number {
+  return Math.min(1, realTitu / threshold);
+}


### PR DESCRIPTION
## Summary

- Add `/agent/[slug]` Next.js 14 App Router page (server component) that reads agent fixtures, renders a bonding-curve SVG chart, graduation progress bar, and a buy/sell trade widget
- Add `lib/bondingCurve.ts` implementing constant-product AMM math (`getAmountOut`, `getPrice`, `buildCurvePoints`, `graduationProgress`) matching `BondingCurve.sol`
- Add fixtures for an in-progress agent (`sample`) and a graduated agent, plus a mock trade response

## Why

Closes #50. Delivers the agent profile UI needed for the M2 launchpad milestone so users can view curve state and simulate trades before real chain wiring lands.

## Test plan

- [x] `apps/web/lib/bondingCurve.ts` — 25 unit tests: zero/negative inputs, fee application, monotonic price, `buildCurvePoints` shape, graduation progress clamping, near-graduation edge cases
- [x] `apps/web/__tests__/agent/page.test.tsx` — 20 tests: renders from fixture (name, symbol, description, creator, module badges, price, progress bar, chart, widget), graduated badge, `notFound()` on unknown slug, TradeWidget tab switch, estimated output math, validation error, submit → tx hash display
- [x] `pnpm --filter @titular/web lint` — biome clean
- [x] `pnpm --filter @titular/web typecheck` — tsc clean
- [x] `pnpm --filter @titular/web test` — 65/65 pass (45 new + 20 from prior wizard tests)