### PR TITLE
feat(launchpad): bonding curve with graduation trigger

### DIFF
--- a/contracts/evm/src/launchpad/BondingCurve.sol
+++ b/contracts/evm/src/launchpad/BondingCurve.sol
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title BondingCurve
+/// @notice Pre-graduation AMM for a single agent token. Prices the agent token against
+///         the quote asset (TITU) using a constant-product `x * y = k` curve with
+///         virtual reserves so the initial slope is bounded. Charges a fixed 1% swap
+///         fee on both sides, routed to a shared `feeRouter`. Trading is halted once
+///         `realQuoteReserve` reaches `graduationThreshold`; a graduator contract then
+///         drains both sides in a single atomic hand-off.
+/// @dev    Not cloneable — each agent deploys its own instance via the launchpad
+///         factory's `new BondingCurve(...)`. Owner is the factory deployer and gates
+///         `setGraduator` (one-shot) and `setFeeRouter` (rebindable). CEI is enforced
+///         on every external entry point: reserve deltas land before any outbound
+///         ERC-20 call, and `ReentrancyGuard` is in place for the `buy`, `sell`, and
+///         `pullForGraduation` paths. Custom errors are used for every revert; no
+///         string messages. All constant-product math uses multiplication-before-
+///         division and keeps `k` non-decreasing across trades modulo integer floor
+///         on the output side.
+contract BondingCurve is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ---------------------------------------------------------------------
+    // Immutables / constants
+    // ---------------------------------------------------------------------
+
+    /// @notice Agent ERC-20 traded by this curve. Fixed at construction.
+    address public immutable agentToken;
+
+    /// @notice Quote ERC-20 (TITU). Fixed at construction.
+    address public immutable quoteToken;
+
+    /// @notice Virtual quote reserve used for price discovery. Seeded to prevent a
+    ///         degenerate zero-reserve price at launch.
+    uint256 public immutable virtualQuoteReserve;
+
+    /// @notice Virtual agent reserve used for price discovery. This is the *initial*
+    ///         effective Y used in the constant-product formula — i.e. the notional
+    ///         agent inventory the curve "starts with" for pricing purposes. The
+    ///         physical balance of the curve starts at {initialAgentReserve}; the
+    ///         difference `virtualAgentReserve - initialAgentReserve` acts as a
+    ///         permanent offset on the agent side so that at graduation some agent
+    ///         inventory is always left in the curve to seed the Uniswap LP.
+    uint256 public immutable virtualAgentReserve;
+
+    /// @notice Physical agent token amount deposited into the curve at construction.
+    ///         Stored immutably so the constant-product math can reconstruct the
+    ///         agent-side offset `virtualAgentReserve - initialAgentReserve` on the
+    ///         fly without loading state. See {_effectiveAgentReserve}.
+    uint256 public immutable initialAgentReserve;
+
+    /// @notice Real TITU raised at which the curve halts trading and becomes eligible
+    ///         for graduation. Virtual reserves are excluded from this threshold.
+    uint256 public immutable graduationThreshold;
+
+    /// @notice Swap fee in basis points applied to the input side of both buy and
+    ///         sell. 100 bps = 1%.
+    uint16 public constant FEE_BPS = 100;
+
+    /// @notice Basis-point denominator used throughout fee math.
+    uint16 public constant BPS_DENOMINATOR = 10_000;
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice TITU balance owed to the curve (monotonically increases on buy,
+    ///         decreases on sell). Does NOT include virtual reserve or collected fees.
+    uint256 public realQuoteReserve;
+
+    /// @notice Agent tokens still held by this curve for trading.
+    uint256 public realAgentReserve;
+
+    /// @notice Set to true once `requestGraduation` has fired. Disables trading.
+    bool public graduated;
+
+    /// @notice Contract authorized to drain the curve at graduation. Set once by owner
+    ///         via {setGraduator} and cannot be rebound.
+    address public graduator;
+
+    /// @notice Recipient of all swap fees. Rebindable by owner via {setFeeRouter} to
+    ///         support fee-routing migrations across the agent fleet.
+    address public feeRouter;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @dev Emitted on every successful {buy}. `fee` is the quote amount diverted to
+    ///      {feeRouter}; `agentOut` is the tokens delivered to `buyer`.
+    event Bought(address indexed buyer, uint256 quoteIn, uint256 agentOut, uint256 fee);
+
+    /// @dev Emitted on every successful {sell}. `fee` is the quote amount diverted to
+    ///      {feeRouter}; `quoteOut` is the net delivered to `seller`.
+    event Sold(address indexed seller, uint256 agentIn, uint256 quoteOut, uint256 fee);
+
+    /// @dev Emitted exactly once when {requestGraduation} succeeds. `timestamp` is the
+    ///      block timestamp at which trading halted.
+    event Graduated(uint256 quoteReserve, uint256 agentReserve, uint256 timestamp);
+
+    /// @dev Emitted on {setGraduator}. `prev` is always address(0) because the setter
+    ///      is one-shot; included for a uniform ABI with {FeeRouterSet}.
+    event GraduatorSet(address indexed prev, address indexed next);
+
+    /// @dev Emitted on {setFeeRouter}. Includes the previous value for indexers.
+    event FeeRouterSet(address indexed prev, address indexed next);
+
+    /// @dev Emitted on {pullForGraduation}. `to` is the graduator.
+    event Pulled(address indexed to, uint256 quoteAmount, uint256 agentAmount);
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Thrown when a constructor argument is the zero address.
+    error ZeroAddress();
+    /// @dev Thrown when a constructor argument is a zero numeric value where a
+    ///      non-zero value is required (reserves / threshold).
+    error ZeroValue();
+    /// @dev Thrown when the virtual agent reserve is not strictly greater than the
+    ///      physical agent inventory (would leave the curve unable to graduate with
+    ///      non-zero LP seed).
+    error InvalidReserves();
+    /// @dev Thrown by trade entry points after graduation has fired.
+    error AlreadyGraduated();
+    /// @dev Thrown by {requestGraduation} when called below threshold.
+    error BelowThreshold();
+    /// @dev Thrown by {pullForGraduation} when called before graduation.
+    error NotGraduated();
+    /// @dev Thrown on zero-valued trade inputs.
+    error ZeroAmount();
+    /// @dev Thrown by trade entry points when computed output undershoots caller's
+    ///      slippage floor.
+    error InsufficientOutput();
+    /// @dev Thrown by {buy} when the trade would push `realQuoteReserve` strictly
+    ///      past {graduationThreshold}. The caller must size the trade to land at or
+    ///      below the threshold, then invoke {requestGraduation}.
+    error ExceedsGraduationThreshold();
+    /// @dev Thrown by {setGraduator} on any call after the graduator has been set.
+    error GraduatorAlreadySet();
+    /// @dev Thrown when a non-graduator address tries to call {pullForGraduation}.
+    error NotGraduator();
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @param owner_                Initial owner; gates `setGraduator` and `setFeeRouter`.
+    /// @param agentToken_           Agent ERC-20 traded by this curve.
+    /// @param quoteToken_           Quote ERC-20 (TITU).
+    /// @param feeRouter_            Initial fee recipient.
+    /// @param virtualQuoteReserve_  Virtual quote reserve (e.g. 30_000e18 TITU).
+    /// @param virtualAgentReserve_  Virtual agent reserve (e.g. 1_073_000_000e18).
+    /// @param graduationThreshold_  Real quote threshold that freezes trading
+    ///                              (e.g. 42_000e18 TITU).
+    /// @param initialAgentReserve_  Real agent tokens already deposited into this curve
+    ///                              and available for distribution. The factory is
+    ///                              expected to transfer exactly this amount before
+    ///                              any trade lands; the constructor does NOT pull.
+    constructor(
+        address owner_,
+        address agentToken_,
+        address quoteToken_,
+        address feeRouter_,
+        uint256 virtualQuoteReserve_,
+        uint256 virtualAgentReserve_,
+        uint256 graduationThreshold_,
+        uint256 initialAgentReserve_
+    ) Ownable(_validatedOwner(owner_)) {
+        if (agentToken_ == address(0) || quoteToken_ == address(0) || feeRouter_ == address(0)) revert ZeroAddress();
+        if (
+            virtualQuoteReserve_ == 0 || virtualAgentReserve_ == 0 || graduationThreshold_ == 0
+                || initialAgentReserve_ == 0
+        ) revert ZeroValue();
+        // Virtuals-style: virtual agent must be strictly greater than the physical
+        // inventory so there is always LP seed left when the curve graduates.
+        if (virtualAgentReserve_ <= initialAgentReserve_) revert InvalidReserves();
+
+        agentToken = agentToken_;
+        quoteToken = quoteToken_;
+        feeRouter = feeRouter_;
+        virtualQuoteReserve = virtualQuoteReserve_;
+        virtualAgentReserve = virtualAgentReserve_;
+        graduationThreshold = graduationThreshold_;
+        initialAgentReserve = initialAgentReserve_;
+        realAgentReserve = initialAgentReserve_;
+
+        emit FeeRouterSet(address(0), feeRouter_);
+    }
+
+    /// @dev Lift the zero-address check above the `Ownable` constructor so callers
+    ///      see our canonical {ZeroAddress} error instead of OZ's `OwnableInvalidOwner`.
+    function _validatedOwner(address owner_) private pure returns (address) {
+        if (owner_ == address(0)) revert ZeroAddress();
+        return owner_;
+    }
+
+    // ---------------------------------------------------------------------
+    // Trading
+    // ---------------------------------------------------------------------
+
+    /// @notice Buy agent tokens with `quoteIn` TITU.
+    /// @dev    CEI:
+    ///           1. Validate preconditions and compute `agentOut` / `fee` against
+    ///              pre-trade virtual+real reserves.
+    ///           2. Update storage so reserves reflect the post-trade state before
+    ///              any external call.
+    ///           3. Pull quote from caller; push fee to `feeRouter`; push agent tokens
+    ///              to caller.
+    ///         Reverts if the post-trade `realQuoteReserve` would exceed the
+    ///         graduation threshold; callers must size the terminal buy exactly.
+    /// @param  minAgentOut  Slippage floor (agent wei).
+    /// @param  quoteIn      Quote in (TITU wei, pre-fee).
+    function buy(uint256 minAgentOut, uint256 quoteIn) external nonReentrant {
+        if (graduated) revert AlreadyGraduated();
+        if (quoteIn == 0) revert ZeroAmount();
+
+        (uint256 agentOut, uint256 fee) = _quoteBuy(quoteIn);
+        if (agentOut < minAgentOut) revert InsufficientOutput();
+        if (agentOut == 0) revert InsufficientOutput();
+        if (agentOut > realAgentReserve) revert InsufficientOutput();
+
+        uint256 quoteInAfterFee = quoteIn - fee;
+        uint256 newRealQuote = realQuoteReserve + quoteInAfterFee;
+        if (newRealQuote > graduationThreshold) revert ExceedsGraduationThreshold();
+
+        // --- Effects ---
+        realQuoteReserve = newRealQuote;
+        realAgentReserve -= agentOut;
+
+        // --- Interactions ---
+        // Pull the gross quote-in from the buyer. Fee is diverted to `feeRouter`; the
+        // remainder stays on this contract as pool reserve.
+        IERC20 qt = IERC20(quoteToken);
+        qt.safeTransferFrom(msg.sender, address(this), quoteIn);
+        if (fee != 0) qt.safeTransfer(feeRouter, fee);
+        IERC20(agentToken).safeTransfer(msg.sender, agentOut);
+
+        emit Bought(msg.sender, quoteIn, agentOut, fee);
+    }
+
+    /// @notice Sell `agentIn` agent tokens for TITU.
+    /// @dev    Mirrors {buy}. Fee is taken from the quote-out side so the seller bears
+    ///         the swap tax. CEI ordering preserved.
+    /// @param  agentIn       Agent tokens to sell (agent wei).
+    /// @param  minQuoteOut   Slippage floor on the net quote delivered to the seller.
+    function sell(uint256 agentIn, uint256 minQuoteOut) external nonReentrant {
+        if (graduated) revert AlreadyGraduated();
+        if (agentIn == 0) revert ZeroAmount();
+
+        (uint256 quoteOut, uint256 fee) = _quoteSell(agentIn);
+        if (quoteOut < minQuoteOut) revert InsufficientOutput();
+        if (quoteOut == 0) revert InsufficientOutput();
+        uint256 grossQuoteOut = quoteOut + fee;
+        if (grossQuoteOut > realQuoteReserve) revert InsufficientOutput();
+
+        // --- Effects ---
+        realQuoteReserve -= grossQuoteOut;
+        realAgentReserve += agentIn;
+
+        // --- Interactions ---
+        IERC20(agentToken).safeTransferFrom(msg.sender, address(this), agentIn);
+        IERC20 qt = IERC20(quoteToken);
+        if (fee != 0) qt.safeTransfer(feeRouter, fee);
+        qt.safeTransfer(msg.sender, quoteOut);
+
+        emit Sold(msg.sender, agentIn, quoteOut, fee);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views / quoting
+    // ---------------------------------------------------------------------
+
+    /// @notice Preview a buy without mutating state.
+    /// @return agentOut Net agent tokens the caller would receive.
+    /// @return fee      Quote wei diverted to `feeRouter`.
+    function quoteBuy(uint256 quoteIn) external view returns (uint256 agentOut, uint256 fee) {
+        if (quoteIn == 0) return (0, 0);
+        return _quoteBuy(quoteIn);
+    }
+
+    /// @notice Preview a sell without mutating state.
+    /// @return quoteOut Net quote wei the caller would receive.
+    /// @return fee      Quote wei diverted to `feeRouter`.
+    function quoteSell(uint256 agentIn) external view returns (uint256 quoteOut, uint256 fee) {
+        if (agentIn == 0) return (0, 0);
+        return _quoteSell(agentIn);
+    }
+
+    /// @notice Current constant-product `k = (virtualQuote + realQuote) * Y_effective`,
+    ///         where `Y_effective = virtualAgentReserve + realAgentReserve - initialAgentReserve`.
+    ///         Equivalently `Y_effective = realAgentReserve + agentOffset` where
+    ///         `agentOffset = virtualAgentReserve - initialAgentReserve` is a
+    ///         construction-time constant.
+    function k() external view returns (uint256) {
+        return (virtualQuoteReserve + realQuoteReserve) * _effectiveAgentReserve(realAgentReserve);
+    }
+
+    // ---------------------------------------------------------------------
+    // Graduation
+    // ---------------------------------------------------------------------
+
+    /// @notice Freeze trading once the curve has raised >= `graduationThreshold` in
+    ///         real quote. Callable by anyone — this is a keeper-style trigger that
+    ///         runs after the final buy lands. Does not move funds; the graduator
+    ///         pulls them in a separate tx via {pullForGraduation}.
+    function requestGraduation() external {
+        if (graduated) revert AlreadyGraduated();
+        if (realQuoteReserve < graduationThreshold) revert BelowThreshold();
+
+        graduated = true;
+        emit Graduated(realQuoteReserve, realAgentReserve, block.timestamp);
+    }
+
+    /// @notice Drain both reserves to the graduator. Only the configured graduator
+    ///         may call, and only after {requestGraduation} has flipped the flag.
+    /// @dev    Zeroes both reserves BEFORE transferring out (CEI) so any reentrant
+    ///         callback into the curve sees a drained state.
+    /// @return quoteAmount Quote transferred to the graduator.
+    /// @return agentAmount Agent tokens transferred to the graduator.
+    function pullForGraduation() external nonReentrant returns (uint256 quoteAmount, uint256 agentAmount) {
+        if (!graduated) revert NotGraduated();
+        if (msg.sender != graduator) revert NotGraduator();
+
+        quoteAmount = realQuoteReserve;
+        agentAmount = realAgentReserve;
+
+        // --- Effects ---
+        realQuoteReserve = 0;
+        realAgentReserve = 0;
+
+        // --- Interactions ---
+        if (quoteAmount != 0) IERC20(quoteToken).safeTransfer(msg.sender, quoteAmount);
+        if (agentAmount != 0) IERC20(agentToken).safeTransfer(msg.sender, agentAmount);
+
+        emit Pulled(msg.sender, quoteAmount, agentAmount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Admin
+    // ---------------------------------------------------------------------
+
+    /// @notice Bind the graduator address. One-shot — cannot be changed once set.
+    /// @dev    Guarded by Ownable. The `graduator` is trusted with drain rights on
+    ///         both reserves post-graduation, so re-binding would be a protocol-
+    ///         level rug vector. Owner is expected to be a Safe multisig.
+    function setGraduator(address next) external onlyOwner {
+        if (next == address(0)) revert ZeroAddress();
+        if (graduator != address(0)) revert GraduatorAlreadySet();
+
+        graduator = next;
+        emit GraduatorSet(address(0), next);
+    }
+
+    /// @notice Rebind the swap-fee recipient. Rebindable because FeeRouter may be
+    ///         upgraded across the fleet and we want to retarget existing curves
+    ///         without redeploys.
+    function setFeeRouter(address next) external onlyOwner {
+        if (next == address(0)) revert ZeroAddress();
+        address prev = feeRouter;
+        feeRouter = next;
+        emit FeeRouterSet(prev, next);
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal math
+    // ---------------------------------------------------------------------
+
+    /// @dev Constant-product buy math. Fee is taken from `quoteIn` up front; the
+    ///      remainder lands on the curve. `agentOut` is floored via integer division
+    ///      so post-trade `k` is >= pre-trade `k`.
+    ///
+    ///      Let
+    ///        X = virtualQuoteReserve + realQuoteReserve
+    ///        Y = virtualAgentReserve + realAgentReserve
+    ///        k = X * Y
+    ///        dx' = quoteIn - fee           (post-fee quote going into the pool)
+    ///      Then
+    ///        agentOut = Y - ceil(k / (X + dx'))  // to ensure k' >= k with floor div
+    ///                 = Y - (k + (X + dx') - 1) / (X + dx')
+    ///      Equivalently (standard Uniswap V2 fee-less form, which also floors out):
+    ///        agentOut = (Y * dx') / (X + dx')
+    ///      We use the latter: it is the same floor behaviour and marginally cheaper.
+    ///
+    ///      Overflow: `Y * dx'` is bounded by
+    ///        Y  <= virtualAgentReserve + initialAgentReserve <= ~2.1e27 (< 2^91)
+    ///        dx' <= graduationThreshold + virtualQuote  <= ~1e23 (< 2^77)
+    ///      product < 2^168. Well below 2^256.
+    function _quoteBuy(uint256 quoteIn) internal view returns (uint256 agentOut, uint256 fee) {
+        fee = (quoteIn * FEE_BPS) / BPS_DENOMINATOR;
+        uint256 dxPrime = quoteIn - fee;
+        uint256 x = virtualQuoteReserve + realQuoteReserve;
+        uint256 y = _effectiveAgentReserve(realAgentReserve);
+        // multiplication-before-division, Uniswap V2 floor form.
+        agentOut = (y * dxPrime) / (x + dxPrime);
+    }
+
+    /// @dev Constant-product sell math. `agentIn` is the exact tokens the seller
+    ///      hands over; the gross quote-out is computed against the pool, then a
+    ///      fee is peeled off for the router.
+    ///
+    ///      grossOut = (X * agentIn) / (Y + agentIn)   // floor
+    ///      fee      = grossOut * FEE_BPS / BPS_DENOMINATOR
+    ///      netOut   = grossOut - fee
+    function _quoteSell(uint256 agentIn) internal view returns (uint256 quoteOut, uint256 fee) {
+        uint256 x = virtualQuoteReserve + realQuoteReserve;
+        uint256 y = _effectiveAgentReserve(realAgentReserve);
+        uint256 yPlus = y + agentIn;
+        // To avoid Slither's `divide-before-multiply` warning and stay precise, compute
+        // the fee directly from the un-floored rational `x*agentIn / yPlus` by folding
+        // the bps division into one step:
+        //   fee = floor( (x * agentIn * FEE_BPS) / (yPlus * BPS_DENOMINATOR) )
+        // Then gross = floor(x*agentIn / yPlus); quoteOut = gross - fee.
+        // This rounds in favour of the pool on both terms and keeps `k_after >= k_before`.
+        // Overflow: x <= virtualQuote + graduationThreshold (<2^77) and agentIn <=
+        // initialAgentReserve (<2^91), so the numerator fits comfortably in 256 bits.
+        uint256 grossOut = (x * agentIn) / yPlus;
+        fee = (x * agentIn * FEE_BPS) / (yPlus * BPS_DENOMINATOR);
+        quoteOut = grossOut - fee;
+    }
+
+    /// @dev Effective Y used in the constant-product formula. The agent side is
+    ///      tracked as a physical balance (`realAgentReserve` starts at
+    ///      `initialAgentReserve` and ticks down on buy / up on sell). The
+    ///      pricing Y starts at `virtualAgentReserve` which, by construction,
+    ///      equals `initialAgentReserve + (virtualAgentReserve - initialAgentReserve)`.
+    ///      Rearranging, Y_eff(realAgent) = realAgent + (virtualAgentReserve -
+    ///      initialAgentReserve). The subtraction cannot underflow — the
+    ///      constructor asserts `virtualAgentReserve > initialAgentReserve` — and
+    ///      Solidity 0.8 checked math would catch it regardless.
+    function _effectiveAgentReserve(uint256 realAgent) internal view returns (uint256) {
+        unchecked {
+            // virtualAgentReserve > initialAgentReserve enforced in constructor, so
+            // the offset is strictly positive. realAgent + offset fits in 2^256 for
+            // the parameter ranges we support (see overflow note on {_quoteBuy}).
+            return realAgent + (virtualAgentReserve - initialAgentReserve);
+        }
+    }
+}

--- a/contracts/evm/test/handlers/BondingCurveHandler.sol
+++ b/contracts/evm/test/handlers/BondingCurveHandler.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {BondingCurve} from "../../src/launchpad/BondingCurve.sol";
+
+/// @dev Mintable mock used by the invariant harness. Identical to the unit-test
+///      mock; redeclared here so the invariant file can instantiate it without
+///      importing unit-test scaffolding into the invariant target.
+contract MockERC20Inv is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
+}
+
+/// @notice Fuzz handler for BondingCurve. Drives randomised buy/sell sequences
+///         from a small set of actors; amounts are bounded so the curve can
+///         neither graduate nor drain to zero during the run (we are asserting
+///         pre-graduation `k` monotonicity in the invariant file).
+contract BondingCurveHandler is Test {
+    BondingCurve public immutable curve;
+    MockERC20Inv public immutable titu;
+    MockERC20Inv public immutable agent;
+    address[] public actors;
+
+    uint256 public constant MAX_BUY = 1000e18; // keeps sum well under 42k threshold
+    uint256 public constant MAX_SELL = 5_000_000e18;
+
+    constructor(BondingCurve _curve, MockERC20Inv _titu, MockERC20Inv _agent) {
+        curve = _curve;
+        titu = _titu;
+        agent = _agent;
+        actors.push(address(0xA11CE));
+        actors.push(address(0xB0B));
+        actors.push(address(0xCAFE));
+        actors.push(address(0xDEAD));
+
+        for (uint256 i = 0; i < actors.length; ++i) {
+            titu.mint(actors[i], 10_000e18);
+            vm.prank(actors[i]);
+            titu.approve(address(curve), type(uint256).max);
+            vm.prank(actors[i]);
+            agent.approve(address(curve), type(uint256).max);
+        }
+    }
+
+    function _pick(uint256 i) internal view returns (address) {
+        return actors[i % actors.length];
+    }
+
+    /// @dev Random buy. Input is bounded and the handler silently returns if the
+    ///      trade would exceed the graduation threshold — the invariant does not
+    ///      care about that path (a separate unit test already covers it).
+    function buy(uint256 actorIdx, uint96 amt) external {
+        address a = _pick(actorIdx);
+        uint256 quoteIn = bound(uint256(amt), 1e15, MAX_BUY);
+        if (titu.balanceOf(a) < quoteIn) {
+            titu.mint(a, quoteIn);
+        }
+
+        (uint256 expectedOut, uint256 fee) = curve.quoteBuy(quoteIn);
+        if (expectedOut == 0) return;
+        if (curve.realQuoteReserve() + (quoteIn - fee) > curve.graduationThreshold()) return;
+        if (expectedOut > curve.realAgentReserve()) return;
+        if (curve.graduated()) return;
+
+        vm.prank(a);
+        try curve.buy(0, quoteIn) {} catch {}
+    }
+
+    /// @dev Random sell using whatever agent inventory the actor currently holds.
+    function sell(uint256 actorIdx, uint96 amt) external {
+        address a = _pick(actorIdx);
+        uint256 bal = agent.balanceOf(a);
+        if (bal == 0) return;
+        uint256 agentIn = bound(uint256(amt), 1, bal);
+        if (agentIn == 0) return;
+
+        (uint256 net, uint256 fee) = curve.quoteSell(agentIn);
+        if (net == 0) return;
+        if (net + fee > curve.realQuoteReserve()) return;
+        if (curve.graduated()) return;
+
+        vm.prank(a);
+        try curve.sell(agentIn, 0) {} catch {}
+    }
+}

--- a/contracts/evm/test/invariant/BondingCurveInvariant.sol
+++ b/contracts/evm/test/invariant/BondingCurveInvariant.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {StdInvariant} from "forge-std/StdInvariant.sol";
+import {BondingCurve} from "../../src/launchpad/BondingCurve.sol";
+import {BondingCurveHandler, MockERC20Inv} from "../handlers/BondingCurveHandler.sol";
+
+/// @notice Invariant harness for {BondingCurve}. Under randomised buy/sell traffic
+///         the constant-product `k = (Vq + Rq) * (Va + Ra)` must be monotonic
+///         non-decreasing pre-graduation. This is the classic AMM invariant; the
+///         1% swap fee leaves the pool on the input side, which if anything grows
+///         `k`, and the output side is floored so the invariant holds exactly.
+contract BondingCurveInvariant is StdInvariant, Test {
+    BondingCurve internal curve;
+    MockERC20Inv internal titu;
+    MockERC20Inv internal agent;
+    BondingCurveHandler internal handler;
+
+    address internal owner = address(0xA0);
+    address internal feeRouter = address(0xFEE);
+
+    uint256 internal constant VIRTUAL_QUOTE = 30_000e18;
+    uint256 internal constant VIRTUAL_AGENT = 1_073_000_000e18;
+    uint256 internal constant THRESHOLD = 42_000e18;
+    uint256 internal constant INITIAL_AGENT = 1_000_000_000e18;
+
+    uint256 internal kSeed;
+
+    function setUp() public {
+        titu = new MockERC20Inv("TITU", "TITU");
+        agent = new MockERC20Inv("AGENT", "AGT");
+
+        curve = new BondingCurve(
+            owner, address(agent), address(titu), feeRouter, VIRTUAL_QUOTE, VIRTUAL_AGENT, THRESHOLD, INITIAL_AGENT
+        );
+        agent.mint(address(curve), INITIAL_AGENT);
+
+        handler = new BondingCurveHandler(curve, titu, agent);
+        targetContract(address(handler));
+
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = BondingCurveHandler.buy.selector;
+        selectors[1] = BondingCurveHandler.sell.selector;
+        targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
+
+        kSeed = curve.k();
+    }
+
+    /// @notice `k` never decreases across any sequence of handler operations.
+    function invariant_curveKNonDecreasing() public view {
+        uint256 kNow = curve.k();
+        assertGe(kNow, kSeed, "k regressed below seed");
+    }
+
+    /// @notice Real quote never pushes past the graduation threshold. The buy
+    ///         path explicitly reverts on overshoot; this is a defence-in-depth
+    ///         invariant that will catch any future change to the overshoot
+    ///         guard.
+    function invariant_realQuoteBoundedByThreshold() public view {
+        assertLe(curve.realQuoteReserve(), curve.graduationThreshold());
+    }
+
+    /// @notice The curve's physical agent balance equals `realAgentReserve`
+    ///         exactly. Because the mocks levy no transfer tax, any drift would
+    ///         indicate a bookkeeping error.
+    function invariant_agentReserveMatchesBalance() public view {
+        assertEq(agent.balanceOf(address(curve)), curve.realAgentReserve());
+    }
+}

--- a/contracts/evm/test/unit/BondingCurve.t.sol
+++ b/contracts/evm/test/unit/BondingCurve.t.sol
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {BondingCurve} from "../../src/launchpad/BondingCurve.sol";
+
+/// @dev Minimal mintable mock standing in for TITU and the agent token.
+///      No transfer tax — keeps the bonding-curve arithmetic exact so we can
+///      assert reserve deltas down to the wei without fighting tax bookkeeping.
+contract MockERC20 is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
+}
+
+contract BondingCurveTest is Test {
+    MockERC20 internal titu;
+    MockERC20 internal agent;
+    BondingCurve internal curve;
+
+    address internal owner = address(0xA0);
+    address internal feeRouter = address(0xFEE);
+    address internal grad = address(0xBEEF);
+    address internal alice = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    uint256 internal constant VIRTUAL_QUOTE = 30_000e18;
+    uint256 internal constant VIRTUAL_AGENT = 1_073_000_000e18;
+    uint256 internal constant THRESHOLD = 42_000e18;
+    uint256 internal constant INITIAL_AGENT = 1_000_000_000e18;
+
+    function setUp() public virtual {
+        titu = new MockERC20("TITU", "TITU");
+        agent = new MockERC20("AGENT", "AGT");
+
+        curve = new BondingCurve(
+            owner, address(agent), address(titu), feeRouter, VIRTUAL_QUOTE, VIRTUAL_AGENT, THRESHOLD, INITIAL_AGENT
+        );
+
+        // Seed the curve with the agent token inventory it claims to hold.
+        agent.mint(address(curve), INITIAL_AGENT);
+
+        // Fund traders with TITU; they approve the curve up front.
+        titu.mint(alice, 1_000_000e18);
+        titu.mint(bob, 1_000_000e18);
+        vm.prank(alice);
+        titu.approve(address(curve), type(uint256).max);
+        vm.prank(bob);
+        titu.approve(address(curve), type(uint256).max);
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    function test_constructor_sets_immutables() public view {
+        assertEq(curve.agentToken(), address(agent));
+        assertEq(curve.quoteToken(), address(titu));
+        assertEq(curve.virtualQuoteReserve(), VIRTUAL_QUOTE);
+        assertEq(curve.virtualAgentReserve(), VIRTUAL_AGENT);
+        assertEq(curve.graduationThreshold(), THRESHOLD);
+        assertEq(curve.realAgentReserve(), INITIAL_AGENT);
+        assertEq(curve.realQuoteReserve(), 0);
+        assertEq(curve.feeRouter(), feeRouter);
+        assertEq(curve.owner(), owner);
+        assertEq(curve.graduator(), address(0));
+        assertFalse(curve.graduated());
+        assertEq(uint256(curve.FEE_BPS()), 100);
+    }
+
+    function test_constructor_reverts_on_zero_address() public {
+        vm.expectRevert(BondingCurve.ZeroAddress.selector);
+        new BondingCurve(
+            address(0), address(agent), address(titu), feeRouter, VIRTUAL_QUOTE, VIRTUAL_AGENT, THRESHOLD, INITIAL_AGENT
+        );
+    }
+
+    function test_constructor_reverts_on_zero_value() public {
+        vm.expectRevert(BondingCurve.ZeroValue.selector);
+        new BondingCurve(owner, address(agent), address(titu), feeRouter, 0, VIRTUAL_AGENT, THRESHOLD, INITIAL_AGENT);
+    }
+
+    // ---------------------------------------------------------------------
+    // Quote math
+    // ---------------------------------------------------------------------
+
+    function test_quoteBuy_formula_matches_manual_calc() public view {
+        // First trade: X = VIRTUAL_QUOTE, Y_eff = VIRTUAL_AGENT (because real equals initial at launch).
+        uint256 quoteIn = 1000e18;
+        uint256 expectedFee = (quoteIn * 100) / 10_000; // 10e18
+        uint256 dxPrime = quoteIn - expectedFee;
+        uint256 x = VIRTUAL_QUOTE;
+        uint256 y = VIRTUAL_AGENT;
+        uint256 expectedOut = (y * dxPrime) / (x + dxPrime);
+
+        (uint256 agentOut, uint256 fee) = curve.quoteBuy(quoteIn);
+        assertEq(fee, expectedFee, "fee mismatch");
+        assertEq(agentOut, expectedOut, "agent out mismatch");
+    }
+
+    function test_quoteSell_formula_matches_manual_calc() public {
+        // Seed state with a prior buy so we can sell.
+        vm.prank(alice);
+        curve.buy(0, 500e18);
+
+        uint256 agentIn = 1_000_000e18;
+        uint256 offset = VIRTUAL_AGENT - INITIAL_AGENT;
+        uint256 x = VIRTUAL_QUOTE + curve.realQuoteReserve();
+        uint256 y = curve.realAgentReserve() + offset;
+        uint256 yPlus = y + agentIn;
+        uint256 grossOut = (x * agentIn) / yPlus;
+        // Fee folds the bps step into one division to avoid double-flooring.
+        uint256 expectedFee = (x * agentIn * 100) / (yPlus * 10_000);
+        uint256 expectedNet = grossOut - expectedFee;
+
+        (uint256 quoteOut, uint256 fee) = curve.quoteSell(agentIn);
+        assertEq(fee, expectedFee, "fee mismatch");
+        assertEq(quoteOut, expectedNet, "quote out mismatch");
+    }
+
+    // ---------------------------------------------------------------------
+    // Buy
+    // ---------------------------------------------------------------------
+
+    function test_buy_updates_reserves_and_transfers() public {
+        uint256 quoteIn = 1000e18;
+        (uint256 expectedOut, uint256 expectedFee) = curve.quoteBuy(quoteIn);
+
+        uint256 feeRouterBefore = titu.balanceOf(feeRouter);
+        uint256 aliceAgentBefore = agent.balanceOf(alice);
+
+        vm.prank(alice);
+        curve.buy(expectedOut, quoteIn);
+
+        assertEq(curve.realQuoteReserve(), quoteIn - expectedFee, "real quote reserve");
+        assertEq(curve.realAgentReserve(), INITIAL_AGENT - expectedOut, "real agent reserve");
+        assertEq(titu.balanceOf(feeRouter), feeRouterBefore + expectedFee, "fee routed");
+        assertEq(agent.balanceOf(alice), aliceAgentBefore + expectedOut, "agent delivered");
+        assertEq(titu.balanceOf(address(curve)), quoteIn - expectedFee, "pool quote balance");
+    }
+
+    function test_buy_reverts_if_min_out_not_met() public {
+        (uint256 expectedOut,) = curve.quoteBuy(1000e18);
+        vm.prank(alice);
+        vm.expectRevert(BondingCurve.InsufficientOutput.selector);
+        curve.buy(expectedOut + 1, 1000e18);
+    }
+
+    function test_buy_reverts_on_zero_amount() public {
+        vm.prank(alice);
+        vm.expectRevert(BondingCurve.ZeroAmount.selector);
+        curve.buy(0, 0);
+    }
+
+    function test_buy_reverts_after_graduation() public {
+        _graduate();
+        vm.prank(alice);
+        vm.expectRevert(BondingCurve.AlreadyGraduated.selector);
+        curve.buy(0, 1000e18);
+    }
+
+    function test_buy_cannot_cross_graduation_threshold_in_one_tx() public {
+        // With 1% fee, to land real quote on THRESHOLD the gross quoteIn must be
+        // THRESHOLD * 10000 / 9900. Pushing strictly past should revert.
+        uint256 gross = (THRESHOLD * 10_000) / 9900 + 1e18; // well past
+        vm.prank(alice);
+        vm.expectRevert(BondingCurve.ExceedsGraduationThreshold.selector);
+        curve.buy(0, gross);
+    }
+
+    function test_buy_can_exactly_hit_threshold_then_graduate() public {
+        // Gross that lands realQuoteReserve exactly on THRESHOLD: gross * 0.99 = THRESHOLD.
+        uint256 gross = (THRESHOLD * 10_000) / 9900;
+        // Round up by one wei if needed so integer floor of fee still leaves >= threshold.
+        uint256 feePreview = (gross * 100) / 10_000;
+        if (gross - feePreview < THRESHOLD) gross += 1;
+
+        titu.mint(alice, gross);
+        vm.prank(alice);
+        curve.buy(0, gross);
+        assertGe(curve.realQuoteReserve(), THRESHOLD);
+        assertLe(curve.realQuoteReserve(), THRESHOLD + 1);
+
+        // Anyone can now call requestGraduation.
+        curve.requestGraduation();
+        assertTrue(curve.graduated());
+    }
+
+    // ---------------------------------------------------------------------
+    // Sell
+    // ---------------------------------------------------------------------
+
+    function test_sell_updates_reserves() public {
+        // First, buy to produce agent inventory on alice.
+        vm.prank(alice);
+        curve.buy(0, 1000e18);
+
+        uint256 agentIn = agent.balanceOf(alice) / 2;
+        vm.prank(alice);
+        agent.approve(address(curve), agentIn);
+
+        (uint256 expectedNet, uint256 expectedFee) = curve.quoteSell(agentIn);
+
+        uint256 feeRouterBefore = titu.balanceOf(feeRouter);
+        uint256 aliceQuoteBefore = titu.balanceOf(alice);
+        uint256 quoteReserveBefore = curve.realQuoteReserve();
+        uint256 agentReserveBefore = curve.realAgentReserve();
+
+        vm.prank(alice);
+        curve.sell(agentIn, expectedNet);
+
+        assertEq(curve.realQuoteReserve(), quoteReserveBefore - (expectedNet + expectedFee), "quote reserve delta");
+        assertEq(curve.realAgentReserve(), agentReserveBefore + agentIn, "agent reserve delta");
+        assertEq(titu.balanceOf(feeRouter), feeRouterBefore + expectedFee, "fee routed");
+        assertEq(titu.balanceOf(alice), aliceQuoteBefore + expectedNet, "seller paid");
+    }
+
+    function test_sell_reverts_if_min_quote_not_met() public {
+        vm.prank(alice);
+        curve.buy(0, 1000e18);
+        uint256 agentIn = agent.balanceOf(alice) / 2;
+        vm.prank(alice);
+        agent.approve(address(curve), agentIn);
+        (uint256 net,) = curve.quoteSell(agentIn);
+        vm.prank(alice);
+        vm.expectRevert(BondingCurve.InsufficientOutput.selector);
+        curve.sell(agentIn, net + 1);
+    }
+
+    function test_sell_reverts_on_zero_amount() public {
+        vm.prank(alice);
+        vm.expectRevert(BondingCurve.ZeroAmount.selector);
+        curve.sell(0, 0);
+    }
+
+    function test_sell_reverts_after_graduation() public {
+        // Drive to graduation first, then cheat a single unit of agent inventory
+        // into Alice's wallet so we can exercise the graduated-state revert.
+        _graduate();
+        agent.mint(alice, 1);
+        vm.prank(alice);
+        agent.approve(address(curve), 1);
+        vm.prank(alice);
+        vm.expectRevert(BondingCurve.AlreadyGraduated.selector);
+        curve.sell(1, 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Graduation lifecycle
+    // ---------------------------------------------------------------------
+
+    function test_requestGraduation_reverts_below_threshold() public {
+        vm.expectRevert(BondingCurve.BelowThreshold.selector);
+        curve.requestGraduation();
+    }
+
+    function test_requestGraduation_succeeds_at_threshold() public {
+        _reachThreshold();
+
+        vm.expectEmit(false, false, false, false, address(curve));
+        emit BondingCurve.Graduated(0, 0, 0);
+        curve.requestGraduation();
+        assertTrue(curve.graduated());
+    }
+
+    function test_requestGraduation_reverts_if_already_graduated() public {
+        _graduate();
+        vm.expectRevert(BondingCurve.AlreadyGraduated.selector);
+        curve.requestGraduation();
+    }
+
+    function test_pullForGraduation_reverts_before_graduated() public {
+        vm.prank(owner);
+        curve.setGraduator(grad);
+        vm.prank(grad);
+        vm.expectRevert(BondingCurve.NotGraduated.selector);
+        curve.pullForGraduation();
+    }
+
+    function test_pullForGraduation_onlyGraduator_after_graduated() public {
+        _graduate();
+        // Graduator is set inside _graduate. Any other caller rejected.
+        vm.prank(alice);
+        vm.expectRevert(BondingCurve.NotGraduator.selector);
+        curve.pullForGraduation();
+    }
+
+    function test_pullForGraduation_drains_reserves() public {
+        _graduate();
+        uint256 expectedQuote = curve.realQuoteReserve();
+        uint256 expectedAgent = curve.realAgentReserve();
+
+        uint256 gradQuoteBefore = titu.balanceOf(grad);
+        uint256 gradAgentBefore = agent.balanceOf(grad);
+
+        vm.prank(grad);
+        (uint256 q, uint256 a) = curve.pullForGraduation();
+
+        assertEq(q, expectedQuote);
+        assertEq(a, expectedAgent);
+        assertEq(curve.realQuoteReserve(), 0);
+        assertEq(curve.realAgentReserve(), 0);
+        assertEq(titu.balanceOf(grad), gradQuoteBefore + expectedQuote);
+        assertEq(agent.balanceOf(grad), gradAgentBefore + expectedAgent);
+    }
+
+    function test_pullForGraduation_is_idempotent_on_empty_balances() public {
+        _graduate();
+        vm.prank(grad);
+        curve.pullForGraduation();
+        // Second call returns zeros; nothing reverts because reserves are already 0.
+        vm.prank(grad);
+        (uint256 q, uint256 a) = curve.pullForGraduation();
+        assertEq(q, 0);
+        assertEq(a, 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Admin
+    // ---------------------------------------------------------------------
+
+    function test_setGraduator_once_only() public {
+        vm.prank(owner);
+        vm.expectEmit(true, true, false, false, address(curve));
+        emit BondingCurve.GraduatorSet(address(0), grad);
+        curve.setGraduator(grad);
+        assertEq(curve.graduator(), grad);
+
+        vm.prank(owner);
+        vm.expectRevert(BondingCurve.GraduatorAlreadySet.selector);
+        curve.setGraduator(address(0xDEAD));
+    }
+
+    function test_setGraduator_reverts_for_non_owner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        curve.setGraduator(grad);
+    }
+
+    function test_setGraduator_reverts_on_zero() public {
+        vm.prank(owner);
+        vm.expectRevert(BondingCurve.ZeroAddress.selector);
+        curve.setGraduator(address(0));
+    }
+
+    function test_setFeeRouter_rebindable() public {
+        address newRouter = address(0xFE2);
+        vm.prank(owner);
+        vm.expectEmit(true, true, false, false, address(curve));
+        emit BondingCurve.FeeRouterSet(feeRouter, newRouter);
+        curve.setFeeRouter(newRouter);
+        assertEq(curve.feeRouter(), newRouter);
+    }
+
+    function test_setFeeRouter_reverts_for_non_owner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        curve.setFeeRouter(address(0xFE2));
+    }
+
+    function test_setFeeRouter_reverts_on_zero() public {
+        vm.prank(owner);
+        vm.expectRevert(BondingCurve.ZeroAddress.selector);
+        curve.setFeeRouter(address(0));
+    }
+
+    // ---------------------------------------------------------------------
+    // Fee routing
+    // ---------------------------------------------------------------------
+
+    function test_fee_transferred_to_feeRouter_on_buy() public {
+        uint256 quoteIn = 500e18;
+        (, uint256 expectedFee) = curve.quoteBuy(quoteIn);
+        uint256 before = titu.balanceOf(feeRouter);
+        vm.prank(alice);
+        curve.buy(0, quoteIn);
+        assertEq(titu.balanceOf(feeRouter) - before, expectedFee);
+    }
+
+    function test_fee_transferred_to_feeRouter_on_sell() public {
+        vm.prank(alice);
+        curve.buy(0, 500e18);
+        uint256 agentIn = agent.balanceOf(alice) / 3;
+        vm.prank(alice);
+        agent.approve(address(curve), agentIn);
+        (, uint256 expectedFee) = curve.quoteSell(agentIn);
+        uint256 before = titu.balanceOf(feeRouter);
+        vm.prank(alice);
+        curve.sell(agentIn, 0);
+        assertEq(titu.balanceOf(feeRouter) - before, expectedFee);
+    }
+
+    // ---------------------------------------------------------------------
+    // Fuzz: k non-decreasing across trades
+    // ---------------------------------------------------------------------
+
+    /// @dev Fuzzes a buy-then-sell sequence with bounded inputs and asserts `k`
+    ///      (over virtual + real reserves) is monotonic non-decreasing. The 1%
+    ///      fee leaves the pool, so the pool's notional `k` can grow but never
+    ///      shrink modulo integer floor on output sizing.
+    function testFuzz_k_non_decreasing_across_trades(uint96 quoteIn, uint96 agentIn) public {
+        uint256 qIn = bound(uint256(quoteIn), 1e15, 10_000e18);
+        uint256 aIn = bound(uint256(agentIn), 1e15, 1_000_000e18);
+
+        uint256 kBefore = curve.k();
+        // Fund Alice with the inputs she might need.
+        titu.mint(alice, qIn);
+
+        vm.prank(alice);
+        curve.buy(0, qIn);
+        uint256 kAfterBuy = curve.k();
+        assertGe(kAfterBuy, kBefore, "k decreased on buy");
+
+        // Constrain the sell to inventory Alice actually holds.
+        uint256 bal = agent.balanceOf(alice);
+        if (bal == 0) return;
+        aIn = bound(aIn, 1, bal);
+        vm.prank(alice);
+        agent.approve(address(curve), aIn);
+
+        (uint256 net,) = curve.quoteSell(aIn);
+        if (net == 0) return;
+        if (net + (net * 100) / 10_000 > curve.realQuoteReserve()) return;
+
+        vm.prank(alice);
+        curve.sell(aIn, 0);
+        uint256 kAfterSell = curve.k();
+        assertGe(kAfterSell, kAfterBuy, "k decreased on sell");
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    /// @dev Advance the curve to the point `realQuoteReserve == THRESHOLD`. Leaves
+    ///      the `graduated` flag as false; graduator is NOT set here either.
+    function _reachThreshold() internal {
+        // Gross quote to deposit so that (gross - fee) == THRESHOLD.
+        // fee = gross * 100 / 10_000 = gross / 100, so gross = THRESHOLD * 100 / 99.
+        uint256 gross = (THRESHOLD * 10_000) / 9900;
+        // Bump by 1 wei if integer flooring left us below.
+        uint256 fee = (gross * 100) / 10_000;
+        if (gross - fee < THRESHOLD) gross += 1;
+        titu.mint(alice, gross);
+        vm.prank(alice);
+        curve.buy(0, gross);
+        assertGe(curve.realQuoteReserve(), THRESHOLD);
+    }
+
+    /// @dev Drive the curve all the way to a graduated state with graduator set.
+    function _graduate() internal {
+        vm.prank(owner);
+        curve.setGraduator(grad);
+        _reachThreshold();
+        curve.requestGraduation();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `BondingCurve.sol`: constant-product AMM with virtual reserves (30k TITU / 1.073B agent) that halts trading at the 42k TITU graduation threshold and hands off to a graduator contract via a one-shot drain.
- 1% swap fee on both sides routed to a shared, owner-rebindable fee router. Owner-gated one-shot `setGraduator`.
- Full unit + fuzz + invariant coverage (`k` non-decreasing, real quote bounded by threshold, physical-balance vs accounting).

## Why
Needed for M2 so an agent can actually be traded post-launch and reach graduation to Uniswap V2 in the follow-up graduator wiring.

## Test plan
- [x] unit (31 tests, all green locally)
- [x] invariant (3 invariants, 2500 calls each)
- [x] slither clean (0 findings)
- [ ] integration with launchpad factory + graduator (follow-up PRs)
- [ ] fork test against Uniswap V2 on Base Sepolia (follow-up)

Closes #28