### PR TITLE
feat(launchpad): add launch radar module

### DIFF
--- a/contracts/evm/src/launchpad/modules/LaunchRadarModule.sol
+++ b/contracts/evm/src/launchpad/modules/LaunchRadarModule.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title LaunchRadarModule
+/// @notice Shared, per-agent trade-gating module. Each agent token configured on this
+///         module gets its own (startTime, whitelistOn, whitelist set, agentAdmin)
+///         record. Callers such as {BondingCurve} invoke {canTrade} before letting a
+///         user swap: trading is blocked until `block.timestamp >= startTime` and,
+///         optionally, to a per-agent allowlist of addresses.
+/// @dev    One deployment per protocol, many agents. The factory calls
+///         {configure} once at launch (owner-gated); after that, mutations run
+///         through the agent-specific `agentAdmin` so the protocol owner does not
+///         hold fine-grained per-agent keys. Unconfigured agents are permissive so
+///         that this module is safe to wire into the trade path before an agent
+///         has been registered (makes migrations / backfills trivial). Custom errors
+///         only; no reverting string messages.
+contract LaunchRadarModule is Ownable {
+    // ---------------------------------------------------------------------
+    // Types
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent gating configuration.
+    /// @param startTime    Unix timestamp at which trading may begin. `block.timestamp`
+    ///                     strictly less than this blocks trading via {canTrade}.
+    /// @param whitelistOn  When true, only addresses in {whitelist}[agent] can trade.
+    /// @param configured   Set to true on first {configure}; used both to enforce
+    ///                     one-shot configuration and to distinguish "unknown agent"
+    ///                     (permissive) from "known agent" (gated).
+    struct Config {
+        uint64 startTime;
+        bool whitelistOn;
+        bool configured;
+    }
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent trade-gating record. Unset agents read as the zero struct,
+    ///         which {canTrade} treats as permissive.
+    mapping(address agent => Config) public configs;
+
+    /// @notice Per-agent, per-user allowlist flag. Only consulted when the agent's
+    ///         {Config.whitelistOn} is true.
+    mapping(address agent => mapping(address user => bool)) public whitelist;
+
+    /// @notice Per-agent admin authorized to mutate the agent's config and whitelist
+    ///         after the protocol owner has bootstrapped the record via {configure}.
+    ///         The factory is expected to wire this to a creator-controlled address
+    ///         (Safe / EOA / child contract) at launch time.
+    mapping(address agent => address) public agentAdmin;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @dev Emitted once per agent on {configure}. Downstream indexers key off this
+    ///      to surface a new agent's gating state.
+    event Configured(address indexed agent, uint64 startTime, bool whitelistOn, address agentAdmin);
+
+    /// @dev Emitted on every {setWhitelist} call. `count` is the number of
+    ///      `(user, allowed)` pairs the call applied — indexers should re-read the
+    ///      mapping rather than reconstruct state from this event alone.
+    event WhitelistUpdated(address indexed agent, uint256 count);
+
+    /// @dev Emitted on {setStartTime}. `startTime` is the post-mutation value.
+    event StartTimeSet(address indexed agent, uint64 startTime);
+
+    /// @dev Emitted on {setWhitelistOn}. `on` is the post-mutation value.
+    event WhitelistToggled(address indexed agent, bool on);
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Thrown when {configure} is called more than once for the same agent.
+    error AlreadyConfigured();
+    /// @dev Thrown when an agent-scoped mutation is attempted by someone other than
+    ///      the agent's configured {agentAdmin}.
+    error NotAgentAdmin();
+    /// @dev Thrown when {setWhitelist} receives `users` and `allowed` arrays of
+    ///      mismatching lengths.
+    error LengthMismatch();
+    /// @dev Thrown by {setStartTime} when the agent is already live — i.e. the
+    ///      existing `startTime` has already elapsed. Prevents a surprise lockout.
+    error AlreadyLive();
+    /// @dev Thrown when an address argument is the zero address.
+    error ZeroAddress();
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @param owner_ Protocol owner authorized to call {configure}. Expected to be
+    ///               the launchpad factory or a Safe multisig acting on its behalf.
+    constructor(address owner_) Ownable(_validatedOwner(owner_)) {}
+
+    /// @dev Promote OZ's `OwnableInvalidOwner` error into our canonical
+    ///      {ZeroAddress} so the ABI surfaces exactly one error for missing
+    ///      addresses at construction.
+    function _validatedOwner(address owner_) private pure returns (address) {
+        if (owner_ == address(0)) revert ZeroAddress();
+        return owner_;
+    }
+
+    // ---------------------------------------------------------------------
+    // Configuration
+    // ---------------------------------------------------------------------
+
+    /// @notice Register a brand-new agent on the radar. One-shot per agent: later
+    ///         mutations route through {setWhitelist} / {setStartTime} /
+    ///         {setWhitelistOn} and are gated on {agentAdmin}.
+    /// @param  agent        Agent token address being registered. Must be non-zero.
+    /// @param  startTime    Unix timestamp trading unlocks at. Passing a past time is
+    ///                      allowed (e.g. backfill of an agent that is already live).
+    /// @param  whitelistOn  Initial state of the whitelist gate.
+    /// @param  agentAdmin_  Address authorized to mutate this agent's gating post
+    ///                      bootstrap. Must be non-zero.
+    function configure(address agent, uint64 startTime, bool whitelistOn, address agentAdmin_) external onlyOwner {
+        if (agent == address(0) || agentAdmin_ == address(0)) revert ZeroAddress();
+        Config storage cfg = configs[agent];
+        if (cfg.configured) revert AlreadyConfigured();
+
+        cfg.startTime = startTime;
+        cfg.whitelistOn = whitelistOn;
+        cfg.configured = true;
+        agentAdmin[agent] = agentAdmin_;
+
+        emit Configured(agent, startTime, whitelistOn, agentAdmin_);
+    }
+
+    /// @notice Batch-update the per-agent whitelist. Pairs `(users[i], allowed[i])`
+    ///         are applied in order; passing `allowed=false` removes.
+    /// @dev    Unbounded in array length on purpose — an agent admin is the only
+    ///         party that can call this and pays the full gas. Callers are expected
+    ///         to chunk updates to fit within a block's gas limit.
+    function setWhitelist(address agent, address[] calldata users, bool[] calldata allowed) external {
+        _onlyAgentAdmin(agent);
+        uint256 n = users.length;
+        if (n != allowed.length) revert LengthMismatch();
+        mapping(address => bool) storage wl = whitelist[agent];
+        for (uint256 i; i < n;) {
+            wl[users[i]] = allowed[i];
+            unchecked {
+                // i is bounded by `users.length` (<= 2^256-1 in theory but <<2^64
+                // by gas reality). Checked math is redundant here.
+                ++i;
+            }
+        }
+        emit WhitelistUpdated(agent, n);
+    }
+
+    /// @notice Update the agent's trading start time. Blocked once the existing
+    ///         start time has already passed — at that point trading is live, and
+    ///         rewriting the gate would let the admin freeze an active market.
+    /// @param  newStart Post-mutation start timestamp. No lower bound: admins are
+    ///                  free to bring trading forward.
+    function setStartTime(address agent, uint64 newStart) external {
+        _onlyAgentAdmin(agent);
+        Config storage cfg = configs[agent];
+        // block.timestamp is the gate being guarded; tolerance is measured in
+        // hours/days so a few seconds of miner drift is immaterial.
+        // slither-disable-next-line timestamp
+        if (block.timestamp >= cfg.startTime) revert AlreadyLive();
+        cfg.startTime = newStart;
+        emit StartTimeSet(agent, newStart);
+    }
+
+    /// @notice Toggle the whitelist gate for an agent.
+    function setWhitelistOn(address agent, bool on) external {
+        _onlyAgentAdmin(agent);
+        configs[agent].whitelistOn = on;
+        emit WhitelistToggled(agent, on);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice Trade-eligibility query used by the bonding curve / router.
+    /// @dev    Permissive for unconfigured agents: we deliberately do not revert
+    ///         and do not block, so this module can be wired into the trade path
+    ///         before every agent has been registered. This is the documented
+    ///         contract — integrators relying on positive authorization must
+    ///         additionally check {configs}[agent].configured.
+    /// @param  agent Agent token being traded.
+    /// @param  user  Account attempting the trade.
+    /// @return ok     True iff the trade is allowed right now.
+    /// @return reason Short human-readable tag when `ok == false`; empty otherwise.
+    function canTrade(address agent, address user) external view returns (bool ok, string memory reason) {
+        Config storage cfg = configs[agent];
+        if (!cfg.configured) return (true, "");
+        // Time-based launch gate by design; see contract-level docs.
+        // slither-disable-next-line timestamp
+        if (block.timestamp < cfg.startTime) return (false, "before start");
+        if (cfg.whitelistOn && !whitelist[agent][user]) return (false, "not whitelisted");
+        return (true, "");
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal
+    // ---------------------------------------------------------------------
+
+    /// @dev Guard for per-agent mutations. Reverts {NotAgentAdmin} if the caller
+    ///      is not the address registered for this agent. An unregistered agent
+    ///      has `agentAdmin[agent] == address(0)`, which also fails this check.
+    function _onlyAgentAdmin(address agent) private view {
+        if (msg.sender != agentAdmin[agent]) revert NotAgentAdmin();
+    }
+}

--- a/contracts/evm/test/unit/LaunchRadarModule.t.sol
+++ b/contracts/evm/test/unit/LaunchRadarModule.t.sol
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {LaunchRadarModule} from "../../src/launchpad/modules/LaunchRadarModule.sol";
+
+/// @dev Unit coverage for the shared, per-agent launch-radar module.
+///      Event expectations use {vm.expectEmit}; revert expectations use the
+///      module's custom error selectors exclusively.
+contract LaunchRadarModuleTest is Test {
+    LaunchRadarModule internal radar;
+
+    address internal protocolOwner = address(0xA0);
+    address internal agentAdmin = address(0xAD);
+    address internal otherAdmin = address(0xBAD);
+    address internal agent = address(0xA6E17);
+    address internal user1 = address(0xAAA1);
+    address internal user2 = address(0xAAA2);
+
+    // Events re-declared so {vm.expectEmit} can match by signature.
+    event Configured(address indexed agent, uint64 startTime, bool whitelistOn, address agentAdmin);
+    event WhitelistUpdated(address indexed agent, uint256 count);
+    event StartTimeSet(address indexed agent, uint64 startTime);
+    event WhitelistToggled(address indexed agent, bool on);
+
+    function setUp() public {
+        radar = new LaunchRadarModule(protocolOwner);
+    }
+
+    // ---------------------------------------------------------------------
+    // configure
+    // ---------------------------------------------------------------------
+
+    function test_configure_only_owner() public {
+        uint64 startAt = uint64(block.timestamp + 1 hours);
+
+        // Non-owner is rejected.
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(this)));
+        radar.configure(agent, startAt, false, agentAdmin);
+
+        // Owner succeeds.
+        vm.prank(protocolOwner);
+        radar.configure(agent, startAt, false, agentAdmin);
+
+        (uint64 gotStart, bool gotWl, bool gotConfigured) = radar.configs(agent);
+        assertEq(gotStart, startAt);
+        assertFalse(gotWl);
+        assertTrue(gotConfigured);
+        assertEq(radar.agentAdmin(agent), agentAdmin);
+    }
+
+    function test_configure_reverts_if_already_configured() public {
+        uint64 startAt = uint64(block.timestamp + 1 hours);
+
+        vm.prank(protocolOwner);
+        radar.configure(agent, startAt, false, agentAdmin);
+
+        vm.prank(protocolOwner);
+        vm.expectRevert(LaunchRadarModule.AlreadyConfigured.selector);
+        radar.configure(agent, startAt, true, otherAdmin);
+    }
+
+    function test_configure_emits_event() public {
+        uint64 startAt = uint64(block.timestamp + 30 minutes);
+
+        vm.expectEmit(true, false, false, true, address(radar));
+        emit Configured(agent, startAt, true, agentAdmin);
+
+        vm.prank(protocolOwner);
+        radar.configure(agent, startAt, true, agentAdmin);
+    }
+
+    function test_configure_reverts_on_zero_agent() public {
+        vm.prank(protocolOwner);
+        vm.expectRevert(LaunchRadarModule.ZeroAddress.selector);
+        radar.configure(address(0), uint64(block.timestamp + 1), false, agentAdmin);
+    }
+
+    function test_configure_reverts_on_zero_agent_admin() public {
+        vm.prank(protocolOwner);
+        vm.expectRevert(LaunchRadarModule.ZeroAddress.selector);
+        radar.configure(agent, uint64(block.timestamp + 1), false, address(0));
+    }
+
+    // ---------------------------------------------------------------------
+    // setWhitelist
+    // ---------------------------------------------------------------------
+
+    function test_setWhitelist_only_agent_admin() public {
+        _configureAgent({startAt: uint64(block.timestamp + 1 hours), whitelistOn: true});
+
+        address[] memory users = new address[](1);
+        bool[] memory allowed = new bool[](1);
+        users[0] = user1;
+        allowed[0] = true;
+
+        // Caller that isn't the agent admin is rejected, even the protocol owner.
+        vm.prank(protocolOwner);
+        vm.expectRevert(LaunchRadarModule.NotAgentAdmin.selector);
+        radar.setWhitelist(agent, users, allowed);
+
+        vm.prank(otherAdmin);
+        vm.expectRevert(LaunchRadarModule.NotAgentAdmin.selector);
+        radar.setWhitelist(agent, users, allowed);
+
+        // Agent admin succeeds.
+        vm.prank(agentAdmin);
+        radar.setWhitelist(agent, users, allowed);
+        assertTrue(radar.whitelist(agent, user1));
+    }
+
+    function test_setWhitelist_batch_updates() public {
+        _configureAgent({startAt: uint64(block.timestamp + 1 hours), whitelistOn: true});
+
+        address[] memory users = new address[](3);
+        bool[] memory allowed = new bool[](3);
+        users[0] = user1;
+        allowed[0] = true;
+        users[1] = user2;
+        allowed[1] = true;
+        users[2] = address(0xCAFE);
+        allowed[2] = false;
+
+        vm.expectEmit(true, false, false, true, address(radar));
+        emit WhitelistUpdated(agent, 3);
+
+        vm.prank(agentAdmin);
+        radar.setWhitelist(agent, users, allowed);
+
+        assertTrue(radar.whitelist(agent, user1));
+        assertTrue(radar.whitelist(agent, user2));
+        assertFalse(radar.whitelist(agent, address(0xCAFE)));
+
+        // Second call can flip a previously-allowed user back off.
+        address[] memory users2 = new address[](1);
+        bool[] memory allowed2 = new bool[](1);
+        users2[0] = user1;
+        allowed2[0] = false;
+        vm.prank(agentAdmin);
+        radar.setWhitelist(agent, users2, allowed2);
+        assertFalse(radar.whitelist(agent, user1));
+    }
+
+    function test_setWhitelist_reverts_length_mismatch() public {
+        _configureAgent({startAt: uint64(block.timestamp + 1 hours), whitelistOn: true});
+
+        address[] memory users = new address[](2);
+        bool[] memory allowed = new bool[](1);
+        users[0] = user1;
+        users[1] = user2;
+        allowed[0] = true;
+
+        vm.prank(agentAdmin);
+        vm.expectRevert(LaunchRadarModule.LengthMismatch.selector);
+        radar.setWhitelist(agent, users, allowed);
+    }
+
+    // ---------------------------------------------------------------------
+    // setStartTime
+    // ---------------------------------------------------------------------
+
+    function test_setStartTime_only_agent_admin() public {
+        uint64 startAt = uint64(block.timestamp + 1 hours);
+        _configureAgent({startAt: startAt, whitelistOn: false});
+
+        uint64 newStart = uint64(block.timestamp + 2 hours);
+
+        vm.prank(otherAdmin);
+        vm.expectRevert(LaunchRadarModule.NotAgentAdmin.selector);
+        radar.setStartTime(agent, newStart);
+
+        vm.expectEmit(true, false, false, true, address(radar));
+        emit StartTimeSet(agent, newStart);
+
+        vm.prank(agentAdmin);
+        radar.setStartTime(agent, newStart);
+
+        (uint64 gotStart,,) = radar.configs(agent);
+        assertEq(gotStart, newStart);
+    }
+
+    function test_setStartTime_reverts_if_already_live() public {
+        uint64 startAt = uint64(block.timestamp + 1 hours);
+        _configureAgent({startAt: startAt, whitelistOn: false});
+
+        // Advance past the start time: trading is now live and the gate is frozen.
+        vm.warp(startAt);
+
+        vm.prank(agentAdmin);
+        vm.expectRevert(LaunchRadarModule.AlreadyLive.selector);
+        radar.setStartTime(agent, uint64(block.timestamp + 1 days));
+
+        // One second later — still considered live.
+        vm.warp(startAt + 1);
+        vm.prank(agentAdmin);
+        vm.expectRevert(LaunchRadarModule.AlreadyLive.selector);
+        radar.setStartTime(agent, uint64(block.timestamp + 1 days));
+    }
+
+    // ---------------------------------------------------------------------
+    // setWhitelistOn
+    // ---------------------------------------------------------------------
+
+    function test_setWhitelistOn_toggle() public {
+        _configureAgent({startAt: uint64(block.timestamp + 1 hours), whitelistOn: false});
+
+        vm.prank(otherAdmin);
+        vm.expectRevert(LaunchRadarModule.NotAgentAdmin.selector);
+        radar.setWhitelistOn(agent, true);
+
+        vm.expectEmit(true, false, false, true, address(radar));
+        emit WhitelistToggled(agent, true);
+        vm.prank(agentAdmin);
+        radar.setWhitelistOn(agent, true);
+        (, bool wlOn,) = radar.configs(agent);
+        assertTrue(wlOn);
+
+        vm.expectEmit(true, false, false, true, address(radar));
+        emit WhitelistToggled(agent, false);
+        vm.prank(agentAdmin);
+        radar.setWhitelistOn(agent, false);
+        (, wlOn,) = radar.configs(agent);
+        assertFalse(wlOn);
+    }
+
+    // ---------------------------------------------------------------------
+    // canTrade
+    // ---------------------------------------------------------------------
+
+    function test_canTrade_allowed_before_configure() public view {
+        // An agent the radar has never seen is permissive. This is the documented
+        // contract: integrators requiring positive auth must additionally check
+        // `configs(agent).configured`.
+        (bool ok, string memory reason) = radar.canTrade(agent, user1);
+        assertTrue(ok);
+        assertEq(bytes(reason).length, 0);
+    }
+
+    function test_canTrade_blocked_before_start() public {
+        uint64 startAt = uint64(block.timestamp + 1 hours);
+        _configureAgent({startAt: startAt, whitelistOn: false});
+
+        (bool ok, string memory reason) = radar.canTrade(agent, user1);
+        assertFalse(ok);
+        assertEq(reason, "before start");
+    }
+
+    function test_canTrade_allowed_after_start() public {
+        uint64 startAt = uint64(block.timestamp + 1 hours);
+        _configureAgent({startAt: startAt, whitelistOn: false});
+
+        vm.warp(startAt);
+        (bool ok, string memory reason) = radar.canTrade(agent, user1);
+        assertTrue(ok);
+        assertEq(bytes(reason).length, 0);
+    }
+
+    function test_canTrade_blocked_not_whitelisted_when_on() public {
+        uint64 startAt = uint64(block.timestamp + 1 hours);
+        _configureAgent({startAt: startAt, whitelistOn: true});
+        vm.warp(startAt);
+
+        // user1 not on the list.
+        (bool ok1, string memory reason1) = radar.canTrade(agent, user1);
+        assertFalse(ok1);
+        assertEq(reason1, "not whitelisted");
+
+        // Add user2 to the allowlist; user1 still blocked, user2 now allowed.
+        address[] memory users = new address[](1);
+        bool[] memory allowed = new bool[](1);
+        users[0] = user2;
+        allowed[0] = true;
+        vm.prank(agentAdmin);
+        radar.setWhitelist(agent, users, allowed);
+
+        (bool ok2,) = radar.canTrade(agent, user1);
+        assertFalse(ok2);
+        (bool ok3, string memory reason3) = radar.canTrade(agent, user2);
+        assertTrue(ok3);
+        assertEq(bytes(reason3).length, 0);
+    }
+
+    function test_canTrade_allowed_when_whitelist_off_regardless() public {
+        uint64 startAt = uint64(block.timestamp + 1 hours);
+        _configureAgent({startAt: startAt, whitelistOn: false});
+        vm.warp(startAt);
+
+        // Not on the (non-existent) whitelist — but whitelistOn is false, so any
+        // user can trade.
+        (bool ok, string memory reason) = radar.canTrade(agent, user1);
+        assertTrue(ok);
+        assertEq(bytes(reason).length, 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    function _configureAgent(uint64 startAt, bool whitelistOn) internal {
+        vm.prank(protocolOwner);
+        radar.configure(agent, startAt, whitelistOn, agentAdmin);
+    }
+}


### PR DESCRIPTION
## Summary
- New `LaunchRadarModule` under `contracts/evm/src/launchpad/modules/` — shared, per-agent, pre-launch whitelist + start-time gate.
- Owner-gated one-shot `configure` at launch; later mutations (`setWhitelist`, `setStartTime`, `setWhitelistOn`) routed through an agent-specific admin.
- `canTrade(agent, user)` view for the bonding curve to call before a swap. Unconfigured agents are permissive by design.

## Why
Ships milestone item #37. Gives creators a way to pre-announce an agent (configure before `startTime`), cap early access to an allowlist, and let the FE render pre-launch state. The gate is read-only from the curve's perspective, so integration is a one-line check at the top of `buy`/`sell`.

## Test plan
- [x] unit — 16 tests in `test/unit/LaunchRadarModule.t.sol` covering access control, one-shot configure, batch whitelist update (plus length mismatch), start-time mutation (plus already-live revert), whitelist toggle, and the four `canTrade` branches (unconfigured, before start, after start, whitelist off vs on)
- [x] `forge fmt --check`
- [x] `forge test` (full suite: 151 passing)
- [x] `slither` clean (0 findings, config-filtered)

Closes #37