### PR TITLE
feat(launchpad): fee router with 70/30 split

### DIFF
--- a/contracts/evm/src/launchpad/FeeRouter.sol
+++ b/contracts/evm/src/launchpad/FeeRouter.sol
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title FeeRouter
+/// @notice Splits incoming fees (ERC-20 or native) between an agent's creator and
+///         the protocol treasury. Default split is 70% creator / 30% treasury but
+///         the creator share is configurable per agent by the owner.
+/// @dev    Callable by anyone: the caller funds the distribution by approving + pulling
+///         ERC-20 via {distribute}, or forwarding native via {distributeNative}. The
+///         router never custodies funds across transactions; every call fans out the
+///         full amount in the same transaction (after rounding-down the creator side —
+///         the dust stays with the treasury). CEI is enforced: state (routes) is
+///         validated and splits computed up front, then effects (pulling ERC-20 from
+///         the caller or accepting msg.value) settle, then outbound transfers land.
+///         `ReentrancyGuard` wraps both distribute entry points because the native
+///         path uses raw `call{value:}` and unknown tokens may have callbacks.
+///         Immutable `treasury` is the fallback recipient when an agent has no route
+///         configured (100% to treasury) and the protocol-side recipient when split.
+contract FeeRouter is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ---------------------------------------------------------------------
+    // Types
+    // ---------------------------------------------------------------------
+
+    /// @notice Route metadata for a single agent token.
+    /// @param creator     Recipient of the creator share of fees.
+    /// @param creatorBps  Creator share in basis points (0..BPS_DENOMINATOR).
+    /// @param configured  True once {setRoute} has been called for this agent.
+    struct Route {
+        address creator;
+        uint16 creatorBps;
+        bool configured;
+    }
+
+    // ---------------------------------------------------------------------
+    // Constants / immutables
+    // ---------------------------------------------------------------------
+
+    /// @notice Basis-point denominator used throughout split math.
+    uint16 public constant BPS_DENOMINATOR = 10_000;
+
+    /// @notice Default creator share in basis points. 7000 = 70%.
+    uint16 public constant DEFAULT_CREATOR_BPS = 7000;
+
+    /// @notice Treasury address — protocol-side recipient. Fixed at construction.
+    address public immutable treasury;
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent routing table. Key = agent ERC-20 address.
+    mapping(address agent => Route) public routes;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @dev Emitted when the owner configures (or reconfigures) an agent's split.
+    event RouteSet(address indexed agent, address indexed creator, uint16 creatorBps);
+
+    /// @dev Emitted when the owner clears an agent's route. Subsequent distributions
+    ///      fall back to sending 100% to the treasury.
+    event RouteCleared(address indexed agent);
+
+    /// @dev Emitted on every successful distribution. `token` is `address(0)` for
+    ///      native distributions.
+    event Distributed(address indexed agent, address indexed token, uint256 creatorAmount, uint256 treasuryAmount);
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Thrown on any zero-address argument where a non-zero is required.
+    error ZeroAddress();
+    /// @dev Thrown when `creatorBps > BPS_DENOMINATOR`. Carries the offending value.
+    error BpsTooHigh(uint16 creatorBps);
+    /// @dev Thrown when a native transfer (via `call{value:}`) fails. Carries the
+    ///      recipient that rejected.
+    error NativeTransferFailed(address recipient);
+    /// @dev Thrown by {distributeNative} when `msg.value == 0`.
+    error InsufficientValue();
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @param treasury_  Protocol treasury address. Non-zero.
+    /// @param owner_     Initial owner; gates {setRoute} and {clearRoute}.
+    constructor(address treasury_, address owner_) Ownable(_validated(owner_)) {
+        if (treasury_ == address(0)) revert ZeroAddress();
+        treasury = treasury_;
+    }
+
+    /// @dev Hoists the zero-address check above OZ Ownable so callers see our
+    ///      canonical {ZeroAddress} error instead of OZ's `OwnableInvalidOwner`.
+    function _validated(address addr) private pure returns (address) {
+        if (addr == address(0)) revert ZeroAddress();
+        return addr;
+    }
+
+    // ---------------------------------------------------------------------
+    // Admin
+    // ---------------------------------------------------------------------
+
+    /// @notice Configure (or reconfigure) the fee split for `agent`.
+    /// @param  agent        Agent ERC-20 whose fees are being routed.
+    /// @param  creator      Creator recipient of the creator share. Non-zero.
+    /// @param  creatorBps   Creator share in basis points; must be ≤ BPS_DENOMINATOR.
+    ///                      Treasury receives `BPS_DENOMINATOR - creatorBps`.
+    /// @dev    Setting `creatorBps = 0` is legal (all to treasury). Setting
+    ///         `creatorBps = BPS_DENOMINATOR` is legal (all to creator). Owner is
+    ///         expected to be a Safe multisig.
+    function setRoute(address agent, address creator, uint16 creatorBps) external onlyOwner {
+        if (agent == address(0) || creator == address(0)) revert ZeroAddress();
+        if (creatorBps > BPS_DENOMINATOR) revert BpsTooHigh(creatorBps);
+
+        routes[agent] = Route({creator: creator, creatorBps: creatorBps, configured: true});
+        emit RouteSet(agent, creator, creatorBps);
+    }
+
+    /// @notice Clear an agent's route. Subsequent distributions send 100% to treasury.
+    function clearRoute(address agent) external onlyOwner {
+        if (agent == address(0)) revert ZeroAddress();
+        delete routes[agent];
+        emit RouteCleared(agent);
+    }
+
+    // ---------------------------------------------------------------------
+    // Distribution
+    // ---------------------------------------------------------------------
+
+    /// @notice Pull `amount` of `token` from the caller and fan it out per `agent`'s route.
+    /// @dev    CEI:
+    ///           1. Compute split from route (or 100% to treasury if unconfigured).
+    ///           2. Pull `amount` from `msg.sender`.
+    ///           3. Push creator share then treasury share.
+    ///         The caller must have approved `amount` to this contract. The router
+    ///         never retains an ERC-20 balance across calls.
+    /// @param  agent  Agent key for route lookup.
+    /// @param  token  ERC-20 being distributed. Non-zero.
+    /// @param  amount Amount to distribute. If zero, the call is a no-op revert
+    ///                on SafeERC20 for most tokens; callers should size > 0.
+    function distribute(address agent, IERC20 token, uint256 amount) external nonReentrant {
+        if (address(token) == address(0)) revert ZeroAddress();
+
+        (address creator, uint256 creatorAmount, uint256 treasuryAmount) = _split(agent, amount);
+
+        // --- Interactions ---
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        if (creatorAmount != 0) token.safeTransfer(creator, creatorAmount);
+        if (treasuryAmount != 0) token.safeTransfer(treasury, treasuryAmount);
+
+        emit Distributed(agent, address(token), creatorAmount, treasuryAmount);
+    }
+
+    /// @notice Split the attached `msg.value` per `agent`'s route.
+    /// @dev    Uses `call{value:}` for both legs to remain compatible with contract
+    ///         recipients (treasury is typically a Safe). Reverts if either transfer
+    ///         fails — no dust is retained on the router. CEI is trivial here because
+    ///         state is only read.
+    /// @param  agent Agent key for route lookup.
+    function distributeNative(address agent) external payable nonReentrant {
+        if (msg.value == 0) revert InsufficientValue();
+
+        (address creator, uint256 creatorAmount, uint256 treasuryAmount) = _split(agent, msg.value);
+
+        // --- Interactions ---
+        if (creatorAmount != 0) {
+            // slither-disable-next-line arbitrary-send-eth
+            (bool ok,) = payable(creator).call{value: creatorAmount}("");
+            if (!ok) revert NativeTransferFailed(creator);
+        }
+        if (treasuryAmount != 0) {
+            // slither-disable-next-line arbitrary-send-eth
+            (bool ok,) = payable(treasury).call{value: treasuryAmount}("");
+            if (!ok) revert NativeTransferFailed(treasury);
+        }
+
+        emit Distributed(agent, address(0), creatorAmount, treasuryAmount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice Preview the split `amount` would produce for `agent`.
+    /// @dev    If `agent` has no route configured, `creatorAmount == 0` and the full
+    ///         `amount` is attributed to the treasury (matches {distribute} behaviour).
+    /// @return creatorAmount  Portion routed to the creator (0 if unconfigured).
+    /// @return treasuryAmount Portion routed to the treasury. Includes any rounding dust.
+    function getSplit(address agent, uint256 amount)
+        external
+        view
+        returns (uint256 creatorAmount, uint256 treasuryAmount)
+    {
+        (, creatorAmount, treasuryAmount) = _split(agent, amount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal
+    // ---------------------------------------------------------------------
+
+    /// @dev Compute the `(creator, creatorAmount, treasuryAmount)` tuple for a given
+    ///      `(agent, amount)`. Rounding: the creator share is floored via integer
+    ///      division; the treasury receives the remainder (`amount - creatorAmount`).
+    ///      This guarantees the two parts sum to exactly `amount`, and prevents dust
+    ///      from escaping the router on-chain. If the agent has no route, the creator
+    ///      tuple element is returned as `address(0)` and `creatorAmount == 0`; callers
+    ///      must treat `address(0)` as "no creator leg".
+    function _split(address agent, uint256 amount)
+        internal
+        view
+        returns (address creator, uint256 creatorAmount, uint256 treasuryAmount)
+    {
+        Route storage r = routes[agent];
+        if (!r.configured) {
+            // No route: entire amount to treasury.
+            return (address(0), 0, amount);
+        }
+        creator = r.creator;
+        // Creator floored; treasury gets the remainder including dust.
+        creatorAmount = (amount * r.creatorBps) / BPS_DENOMINATOR;
+        treasuryAmount = amount - creatorAmount;
+    }
+}

--- a/contracts/evm/test/unit/FeeRouter.t.sol
+++ b/contracts/evm/test/unit/FeeRouter.t.sol
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {FeeRouter} from "../../src/launchpad/FeeRouter.sol";
+
+/// @dev Minimal mintable mock used for both TITU and the agent token. No tax so
+///      split math stays exact down to the wei.
+contract TestERC20 is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
+}
+
+/// @dev Helper that happily accepts native ETH. Used as creator/treasury stand-in
+///      for native-split tests where both legs must succeed.
+contract ReceiveAccept {
+    // solhint-disable-next-line no-empty-blocks
+    receive() external payable {}
+}
+
+/// @dev Helper whose `receive()` always reverts. Used to assert that the router
+///      surfaces failures from contract recipients rather than silently dropping
+///      funds on the floor.
+contract ReceiveRevert {
+    error Rejected();
+
+    receive() external payable {
+        revert Rejected();
+    }
+}
+
+contract FeeRouterTest is Test {
+    TestERC20 internal token;
+    FeeRouter internal router;
+
+    address internal owner = address(0xA0);
+    address internal treasury = address(0x7EA5);
+    address internal creator = address(0xC0E);
+    address internal agent = address(0xA6E17);
+    address internal alice = address(0xA11CE);
+
+    function setUp() public virtual {
+        token = new TestERC20("TITU", "TITU");
+        router = new FeeRouter(treasury, owner);
+        token.mint(alice, 1_000_000e18);
+        vm.prank(alice);
+        token.approve(address(router), type(uint256).max);
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    function test_constructor_reverts_zero_treasury() public {
+        vm.expectRevert(FeeRouter.ZeroAddress.selector);
+        new FeeRouter(address(0), owner);
+    }
+
+    function test_constructor_reverts_zero_owner() public {
+        vm.expectRevert(FeeRouter.ZeroAddress.selector);
+        new FeeRouter(treasury, address(0));
+    }
+
+    function test_constructor_sets_immutables() public view {
+        assertEq(router.treasury(), treasury);
+        assertEq(router.owner(), owner);
+        assertEq(uint256(router.DEFAULT_CREATOR_BPS()), 7000);
+        assertEq(uint256(router.BPS_DENOMINATOR()), 10_000);
+    }
+
+    // ---------------------------------------------------------------------
+    // setRoute / clearRoute
+    // ---------------------------------------------------------------------
+
+    function test_setRoute_only_owner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        vm.prank(alice);
+        router.setRoute(agent, creator, 7000);
+    }
+
+    function test_setRoute_reverts_bps_too_high() public {
+        vm.expectRevert(abi.encodeWithSelector(FeeRouter.BpsTooHigh.selector, uint16(10_001)));
+        vm.prank(owner);
+        router.setRoute(agent, creator, 10_001);
+    }
+
+    function test_setRoute_reverts_zero_creator() public {
+        vm.expectRevert(FeeRouter.ZeroAddress.selector);
+        vm.prank(owner);
+        router.setRoute(agent, address(0), 7000);
+    }
+
+    function test_setRoute_reverts_zero_agent() public {
+        vm.expectRevert(FeeRouter.ZeroAddress.selector);
+        vm.prank(owner);
+        router.setRoute(address(0), creator, 7000);
+    }
+
+    function test_setRoute_stores_and_emits() public {
+        vm.expectEmit(true, true, false, true, address(router));
+        emit FeeRouter.RouteSet(agent, creator, 7000);
+        vm.prank(owner);
+        router.setRoute(agent, creator, 7000);
+
+        (address storedCreator, uint16 bps, bool configured) = router.routes(agent);
+        assertEq(storedCreator, creator);
+        assertEq(uint256(bps), 7000);
+        assertTrue(configured);
+    }
+
+    function test_clearRoute_only_owner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        vm.prank(alice);
+        router.clearRoute(agent);
+    }
+
+    function test_clearRoute_resets_state_and_emits() public {
+        vm.prank(owner);
+        router.setRoute(agent, creator, 7000);
+
+        vm.expectEmit(true, false, false, true, address(router));
+        emit FeeRouter.RouteCleared(agent);
+        vm.prank(owner);
+        router.clearRoute(agent);
+
+        (address storedCreator, uint16 bps, bool configured) = router.routes(agent);
+        assertEq(storedCreator, address(0));
+        assertEq(uint256(bps), 0);
+        assertFalse(configured);
+    }
+
+    // ---------------------------------------------------------------------
+    // distribute (ERC-20)
+    // ---------------------------------------------------------------------
+
+    function test_distribute_erc20_splits_70_30_default() public {
+        uint16 defaultBps = router.DEFAULT_CREATOR_BPS();
+        vm.prank(owner);
+        router.setRoute(agent, creator, defaultBps);
+
+        uint256 amount = 1000e18;
+        vm.expectEmit(true, true, false, true, address(router));
+        emit FeeRouter.Distributed(agent, address(token), 700e18, 300e18);
+        vm.prank(alice);
+        router.distribute(agent, IERC20(address(token)), amount);
+
+        assertEq(token.balanceOf(creator), 700e18);
+        assertEq(token.balanceOf(treasury), 300e18);
+        assertEq(token.balanceOf(address(router)), 0);
+    }
+
+    function test_distribute_erc20_splits_configured_ratio() public {
+        // 40% creator / 60% treasury.
+        vm.prank(owner);
+        router.setRoute(agent, creator, 4000);
+
+        uint256 amount = 500e18;
+        vm.prank(alice);
+        router.distribute(agent, IERC20(address(token)), amount);
+
+        assertEq(token.balanceOf(creator), 200e18);
+        assertEq(token.balanceOf(treasury), 300e18);
+        assertEq(token.balanceOf(address(router)), 0);
+    }
+
+    function test_distribute_erc20_unconfigured_all_to_treasury() public {
+        uint256 amount = 123e18;
+        vm.expectEmit(true, true, false, true, address(router));
+        emit FeeRouter.Distributed(agent, address(token), 0, amount);
+        vm.prank(alice);
+        router.distribute(agent, IERC20(address(token)), amount);
+
+        assertEq(token.balanceOf(treasury), amount);
+        assertEq(token.balanceOf(creator), 0);
+        assertEq(token.balanceOf(address(router)), 0);
+    }
+
+    function test_distribute_erc20_cleared_route_all_to_treasury() public {
+        vm.prank(owner);
+        router.setRoute(agent, creator, 7000);
+        vm.prank(owner);
+        router.clearRoute(agent);
+
+        vm.prank(alice);
+        router.distribute(agent, IERC20(address(token)), 1000e18);
+
+        assertEq(token.balanceOf(treasury), 1000e18);
+        assertEq(token.balanceOf(creator), 0);
+    }
+
+    function test_distribute_erc20_rounding_dust_to_treasury() public {
+        // 7000 bps of 7 wei = floor(7 * 7000 / 10_000) = floor(4.9) = 4 → treasury gets 3.
+        vm.prank(owner);
+        router.setRoute(agent, creator, 7000);
+
+        uint256 amount = 7;
+        vm.prank(alice);
+        router.distribute(agent, IERC20(address(token)), amount);
+
+        assertEq(token.balanceOf(creator), 4);
+        assertEq(token.balanceOf(treasury), 3);
+        assertEq(token.balanceOf(creator) + token.balanceOf(treasury), amount);
+    }
+
+    function test_distribute_reverts_zero_token() public {
+        vm.expectRevert(FeeRouter.ZeroAddress.selector);
+        vm.prank(alice);
+        router.distribute(agent, IERC20(address(0)), 1);
+    }
+
+    // ---------------------------------------------------------------------
+    // distributeNative
+    // ---------------------------------------------------------------------
+
+    function test_distributeNative_splits_correctly() public {
+        ReceiveAccept creatorSink = new ReceiveAccept();
+        ReceiveAccept treasurySink = new ReceiveAccept();
+        FeeRouter r = new FeeRouter(address(treasurySink), owner);
+        vm.prank(owner);
+        r.setRoute(agent, address(creatorSink), 7000);
+
+        vm.deal(alice, 10 ether);
+        vm.expectEmit(true, true, false, true, address(r));
+        emit FeeRouter.Distributed(agent, address(0), 0.7 ether, 0.3 ether);
+        vm.prank(alice);
+        r.distributeNative{value: 1 ether}(agent);
+
+        assertEq(address(creatorSink).balance, 0.7 ether);
+        assertEq(address(treasurySink).balance, 0.3 ether);
+        assertEq(address(r).balance, 0);
+    }
+
+    function test_distributeNative_unconfigured_all_to_treasury() public {
+        ReceiveAccept treasurySink = new ReceiveAccept();
+        FeeRouter r = new FeeRouter(address(treasurySink), owner);
+
+        vm.deal(alice, 10 ether);
+        vm.prank(alice);
+        r.distributeNative{value: 1 ether}(agent);
+
+        assertEq(address(treasurySink).balance, 1 ether);
+        assertEq(address(r).balance, 0);
+    }
+
+    function test_distributeNative_reverts_if_treasury_rejects() public {
+        ReceiveRevert treasurySink = new ReceiveRevert();
+        FeeRouter r = new FeeRouter(address(treasurySink), owner);
+        // Route with zero creator share so the entire amount tries to land at the
+        // reverting treasury.
+        vm.prank(owner);
+        r.setRoute(agent, creator, 0);
+
+        vm.deal(alice, 10 ether);
+        vm.expectRevert(abi.encodeWithSelector(FeeRouter.NativeTransferFailed.selector, address(treasurySink)));
+        vm.prank(alice);
+        r.distributeNative{value: 1 ether}(agent);
+    }
+
+    function test_distributeNative_reverts_if_creator_rejects() public {
+        ReceiveAccept treasurySink = new ReceiveAccept();
+        ReceiveRevert creatorSink = new ReceiveRevert();
+        FeeRouter r = new FeeRouter(address(treasurySink), owner);
+        vm.prank(owner);
+        r.setRoute(agent, address(creatorSink), 7000);
+
+        vm.deal(alice, 10 ether);
+        vm.expectRevert(abi.encodeWithSelector(FeeRouter.NativeTransferFailed.selector, address(creatorSink)));
+        vm.prank(alice);
+        r.distributeNative{value: 1 ether}(agent);
+    }
+
+    function test_distributeNative_reverts_zero_value() public {
+        vm.expectRevert(FeeRouter.InsufficientValue.selector);
+        vm.prank(alice);
+        router.distributeNative(agent);
+    }
+
+    // ---------------------------------------------------------------------
+    // getSplit
+    // ---------------------------------------------------------------------
+
+    function test_getSplit_matches_actual_distribute() public {
+        vm.prank(owner);
+        router.setRoute(agent, creator, 7000);
+
+        uint256 amount = 12_345e18 + 7;
+        (uint256 previewCreator, uint256 previewTreasury) = router.getSplit(agent, amount);
+
+        vm.prank(alice);
+        router.distribute(agent, IERC20(address(token)), amount);
+
+        assertEq(token.balanceOf(creator), previewCreator);
+        assertEq(token.balanceOf(treasury), previewTreasury);
+        assertEq(previewCreator + previewTreasury, amount);
+    }
+
+    function test_getSplit_unconfigured_returns_treasury_only() public view {
+        (uint256 previewCreator, uint256 previewTreasury) = router.getSplit(agent, 1000);
+        assertEq(previewCreator, 0);
+        assertEq(previewTreasury, 1000);
+    }
+
+    // ---------------------------------------------------------------------
+    // Fuzz
+    // ---------------------------------------------------------------------
+
+    /// @dev Any split must sum to the exact input amount (no dust escapes).
+    function testFuzz_split_exact_sum(uint256 amount, uint16 creatorBps) public {
+        amount = bound(amount, 0, type(uint128).max);
+        creatorBps = uint16(bound(uint256(creatorBps), 0, 10_000));
+
+        vm.prank(owner);
+        router.setRoute(agent, creator, creatorBps);
+
+        (uint256 creatorAmount, uint256 treasuryAmount) = router.getSplit(agent, amount);
+        assertEq(creatorAmount + treasuryAmount, amount);
+        // Creator share is floored; treasury owns the dust.
+        assertLe(creatorAmount, (amount * creatorBps) / 10_000);
+        assertGe(creatorAmount, (amount * creatorBps) / 10_000);
+    }
+
+    /// @dev End-to-end fuzz: configure a route and exercise the actual ERC-20 pull +
+    ///      push path. Balances must reconcile exactly and the router never retains
+    ///      a wei.
+    function testFuzz_distribute_erc20(uint128 amount, uint16 creatorBps) public {
+        vm.assume(amount > 0);
+        uint16 bps = uint16(bound(uint256(creatorBps), 0, 10_000));
+
+        vm.prank(owner);
+        router.setRoute(agent, creator, bps);
+
+        token.mint(alice, amount);
+        vm.prank(alice);
+        router.distribute(agent, IERC20(address(token)), amount);
+
+        uint256 expectedCreator = (uint256(amount) * bps) / 10_000;
+        uint256 expectedTreasury = uint256(amount) - expectedCreator;
+        assertEq(token.balanceOf(creator), expectedCreator);
+        assertEq(token.balanceOf(treasury), expectedTreasury);
+        assertEq(token.balanceOf(address(router)), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Per-agent fee splitter for ERC-20 and native fees; default 70% creator / 30% treasury.
- Owner-configurable split via `setRoute`; unconfigured agents route 100% to treasury.
- Creator share floored, dust always lands on treasury — no fund escapes on-chain.

## Why
Isolates fee routing from the curve and agent token so splits are reconfigurable per agent without redeploying either. Keeps `BondingCurve.feeRouter` stable and composable.

Implementation notes:
- SafeERC20 + CEI; `ReentrancyGuard` on both distribute paths.
- Ownable v5 with hoisted zero-address check for canonical errors.
- Native path uses `call{value:}` for contract recipient compatibility (treasury is a Safe) and reverts on failure to avoid silently stranding funds.

## Test plan
- [x] unit (25 tests, 100% line / 98% statement / 92.86% branch / 100% function coverage)
- [x] fuzz: split sum invariant + end-to-end ERC-20 distribute under random bps
- [x] slither clean (0 findings)
- [x] `forge fmt --check`
- [ ] integration — follows in launchpad factory wiring PR

Closes #32