### PR TITLE
feat(launchpad): immutable 10-year LP lock

### DIFF
--- a/contracts/evm/src/launchpad/LPLock.sol
+++ b/contracts/evm/src/launchpad/LPLock.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title LPLock
+/// @notice Immutable 10-year timelock for Uniswap V2 LP tokens minted at graduation.
+///         One instance per graduated agent: the {Graduator} mints LP to this contract
+///         (or forwards LP via {deposit}) and only the {beneficiary} — the agent
+///         creator — can withdraw the full balance once {unlockTime} has elapsed.
+/// @dev    Immutable by design: there is no extend, no early-withdraw, and no owner.
+///         Once deployed the {unlockTime} is fixed and the contract can neither be
+///         upgraded nor paused. Anyone may top up via {deposit} so liquidity streams
+///         (e.g. secondary pairs created later) can be pinned to the same schedule.
+///         CEI is enforced on {withdraw}: `withdrawn` flips before the LP transfer.
+///         `ReentrancyGuard` is layered on for defence-in-depth against an exotic LP
+///         token with transfer hooks.
+contract LPLock is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ---------------------------------------------------------------------
+    // Constants
+    // ---------------------------------------------------------------------
+
+    /// @notice Duration of the lock, measured from construction. Fixed 10 years in
+    ///         seconds (365-day years per spec; leap-day drift is negligible at the
+    ///         policy level and keeps the arithmetic auditable).
+    uint256 public constant LOCK_DURATION = 365 days * 10;
+
+    // ---------------------------------------------------------------------
+    // Immutables
+    // ---------------------------------------------------------------------
+
+    /// @notice ERC-20 LP token held by this lock. Typically a Uniswap V2 pair.
+    IERC20 public immutable lpToken;
+
+    /// @notice Sole address authorized to {withdraw}. Expected to be the agent creator.
+    address public immutable beneficiary;
+
+    /// @notice Earliest timestamp at which {withdraw} may succeed.
+    ///         Set to `block.timestamp + LOCK_DURATION` at construction.
+    uint256 public immutable unlockTime;
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice Cumulative LP tokens deposited into this lock via {deposit}.
+    ///         Monotonic: never decreases, including on {withdraw}. This is an
+    ///         accounting counter, not a live balance; the live balance is
+    ///         `lpToken.balanceOf(address(this))` and is what {withdraw} transfers.
+    uint256 public lockedAmount;
+
+    /// @notice Flips to `true` on the single successful {withdraw}. Prevents any
+    ///         follow-on withdrawals, including of LP deposited after unlock.
+    bool public withdrawn;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @dev Emitted on every successful {deposit}. `from` is the depositor; `amount`
+    ///      is the LP wei transferred in.
+    event Deposited(address indexed from, uint256 amount);
+
+    /// @dev Emitted exactly once on the successful {withdraw}. `to` is the
+    ///      beneficiary; `amount` is the full LP balance transferred out.
+    event Withdrawn(address indexed to, uint256 amount);
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Thrown when {withdraw} is called by anyone other than {beneficiary}.
+    error NotBeneficiary();
+    /// @dev Thrown when {withdraw} is called before {unlockTime}. Carries the
+    ///      remaining seconds for UX.
+    error StillLocked(uint256 secondsRemaining);
+    /// @dev Thrown when {withdraw} is called after the one-shot withdrawal has
+    ///      already fired.
+    error AlreadyWithdrawn();
+    /// @dev Thrown when the constructor receives a zero address for the LP token
+    ///      or the beneficiary.
+    error ZeroAddress();
+    /// @dev Thrown when {deposit} is called with a zero amount.
+    error ZeroAmount();
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @param lpToken_     ERC-20 LP token to lock. Must be non-zero.
+    /// @param beneficiary_ Sole withdrawal recipient. Must be non-zero.
+    constructor(IERC20 lpToken_, address beneficiary_) {
+        if (address(lpToken_) == address(0)) revert ZeroAddress();
+        if (beneficiary_ == address(0)) revert ZeroAddress();
+
+        lpToken = lpToken_;
+        beneficiary = beneficiary_;
+        unlockTime = block.timestamp + LOCK_DURATION;
+    }
+
+    // ---------------------------------------------------------------------
+    // External
+    // ---------------------------------------------------------------------
+
+    /// @notice Top up the lock with `amount` LP tokens. Anyone may call; the
+    ///         depositor must have pre-approved this contract for `amount`.
+    /// @dev    Uses {SafeERC20.safeTransferFrom} to handle non-standard ERC-20s.
+    ///         `lockedAmount` is incremented regardless of any fee-on-transfer
+    ///         behaviour: it is an ingress counter, not a live balance. Reverts if
+    ///         `amount` is zero so we never emit a no-op {Deposited}.
+    /// @param  amount LP wei to pull from `msg.sender`.
+    function deposit(uint256 amount) external {
+        if (amount == 0) revert ZeroAmount();
+
+        // --- Effects ---
+        lockedAmount += amount;
+
+        // --- Interactions ---
+        lpToken.safeTransferFrom(msg.sender, address(this), amount);
+
+        emit Deposited(msg.sender, amount);
+    }
+
+    /// @notice Release the full LP balance to the {beneficiary}. One-shot.
+    /// @dev    Permissioning: only {beneficiary} may call. Gating:
+    ///           - reverts {StillLocked} before {unlockTime};
+    ///           - reverts {AlreadyWithdrawn} on a second call.
+    ///         CEI: `withdrawn` flips before the LP transfer. `ReentrancyGuard` is
+    ///         an additional safety net in case the LP token has transfer hooks.
+    function withdraw() external nonReentrant {
+        if (msg.sender != beneficiary) revert NotBeneficiary();
+        if (withdrawn) revert AlreadyWithdrawn();
+        if (block.timestamp < unlockTime) {
+            revert StillLocked(unlockTime - block.timestamp);
+        }
+
+        uint256 balance = lpToken.balanceOf(address(this));
+
+        // --- Effects ---
+        withdrawn = true;
+
+        // --- Interactions ---
+        if (balance != 0) {
+            lpToken.safeTransfer(beneficiary, balance);
+        }
+
+        emit Withdrawn(beneficiary, balance);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice Seconds left until {withdraw} is callable. Returns 0 once unlocked.
+    function timeRemaining() external view returns (uint256) {
+        if (block.timestamp >= unlockTime) return 0;
+        return unlockTime - block.timestamp;
+    }
+}

--- a/contracts/evm/test/unit/LPLock.t.sol
+++ b/contracts/evm/test/unit/LPLock.t.sol
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {LPLock} from "../../src/launchpad/LPLock.sol";
+
+/// @dev Minimal mintable mock standing in for a Uniswap V2 LP ERC-20.
+///      No transfer hooks — LPLock correctness does not rely on any quirk beyond
+///      the standard ERC-20 surface.
+contract MockLP is ERC20 {
+    constructor() ERC20("LP", "LP") {}
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
+}
+
+contract LPLockTest is Test {
+    LPLock internal lock;
+    MockLP internal lp;
+
+    address internal beneficiary = address(0xBEEF);
+    address internal alice = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    uint256 internal constant TEN_YEARS = 365 days * 10;
+
+    event Deposited(address indexed from, uint256 amount);
+    event Withdrawn(address indexed to, uint256 amount);
+
+    function setUp() public {
+        lp = new MockLP();
+        lock = new LPLock(IERC20(address(lp)), beneficiary);
+
+        // Fund the depositors and approve the lock.
+        lp.mint(alice, 1_000_000e18);
+        lp.mint(bob, 1_000_000e18);
+        vm.prank(alice);
+        lp.approve(address(lock), type(uint256).max);
+        vm.prank(bob);
+        lp.approve(address(lock), type(uint256).max);
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    function test_constructor_sets_immutables() public view {
+        assertEq(address(lock.lpToken()), address(lp));
+        assertEq(lock.beneficiary(), beneficiary);
+        assertEq(lock.unlockTime(), block.timestamp + TEN_YEARS);
+        assertEq(lock.LOCK_DURATION(), TEN_YEARS);
+        assertEq(lock.lockedAmount(), 0);
+        assertFalse(lock.withdrawn());
+    }
+
+    function test_constructor_reverts_zero_token() public {
+        vm.expectRevert(LPLock.ZeroAddress.selector);
+        new LPLock(IERC20(address(0)), beneficiary);
+    }
+
+    function test_constructor_reverts_zero_beneficiary() public {
+        vm.expectRevert(LPLock.ZeroAddress.selector);
+        new LPLock(IERC20(address(lp)), address(0));
+    }
+
+    // ---------------------------------------------------------------------
+    // Deposit
+    // ---------------------------------------------------------------------
+
+    function test_deposit_increments_locked_amount() public {
+        vm.expectEmit(true, false, false, true, address(lock));
+        emit Deposited(alice, 1000e18);
+        vm.prank(alice);
+        lock.deposit(1000e18);
+
+        assertEq(lock.lockedAmount(), 1000e18);
+        assertEq(lp.balanceOf(address(lock)), 1000e18);
+
+        // Second deposit from the same depositor accumulates.
+        vm.prank(alice);
+        lock.deposit(500e18);
+        assertEq(lock.lockedAmount(), 1500e18);
+        assertEq(lp.balanceOf(address(lock)), 1500e18);
+    }
+
+    function test_deposit_anyone_allowed() public {
+        // Two independent depositors should both succeed; totals accumulate.
+        vm.prank(alice);
+        lock.deposit(100e18);
+        vm.prank(bob);
+        lock.deposit(250e18);
+
+        assertEq(lock.lockedAmount(), 350e18);
+        assertEq(lp.balanceOf(address(lock)), 350e18);
+    }
+
+    function test_deposit_reverts_zero_amount() public {
+        vm.prank(alice);
+        vm.expectRevert(LPLock.ZeroAmount.selector);
+        lock.deposit(0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Withdraw — gating
+    // ---------------------------------------------------------------------
+
+    function test_withdraw_reverts_before_unlock() public {
+        vm.prank(alice);
+        lock.deposit(1000e18);
+
+        uint256 expectedRemaining = lock.unlockTime() - block.timestamp;
+        vm.prank(beneficiary);
+        vm.expectRevert(abi.encodeWithSelector(LPLock.StillLocked.selector, expectedRemaining));
+        lock.withdraw();
+    }
+
+    function test_withdraw_reverts_not_beneficiary() public {
+        vm.prank(alice);
+        lock.deposit(1000e18);
+
+        // Even after the lock expires, only the beneficiary may withdraw.
+        vm.warp(block.timestamp + TEN_YEARS);
+        vm.prank(alice);
+        vm.expectRevert(LPLock.NotBeneficiary.selector);
+        lock.withdraw();
+    }
+
+    // ---------------------------------------------------------------------
+    // Withdraw — happy path
+    // ---------------------------------------------------------------------
+
+    function test_withdraw_succeeds_after_unlock() public {
+        vm.prank(alice);
+        lock.deposit(1000e18);
+
+        vm.warp(block.timestamp + TEN_YEARS);
+
+        vm.expectEmit(true, false, false, true, address(lock));
+        emit Withdrawn(beneficiary, 1000e18);
+        vm.prank(beneficiary);
+        lock.withdraw();
+
+        assertTrue(lock.withdrawn());
+        assertEq(lp.balanceOf(beneficiary), 1000e18);
+        assertEq(lp.balanceOf(address(lock)), 0);
+    }
+
+    function test_withdraw_transfers_all_balance() public {
+        // Mix of deposits from different senders + a direct transfer in. All of
+        // it should be swept to the beneficiary.
+        vm.prank(alice);
+        lock.deposit(1000e18);
+        vm.prank(bob);
+        lock.deposit(2000e18);
+        // Direct transfer (not through deposit) — still gets swept out.
+        lp.mint(address(lock), 500e18);
+
+        uint256 totalHeld = lp.balanceOf(address(lock));
+        assertEq(totalHeld, 3500e18);
+
+        vm.warp(lock.unlockTime());
+
+        vm.expectEmit(true, false, false, true, address(lock));
+        emit Withdrawn(beneficiary, totalHeld);
+        vm.prank(beneficiary);
+        lock.withdraw();
+
+        assertEq(lp.balanceOf(beneficiary), totalHeld);
+        assertEq(lp.balanceOf(address(lock)), 0);
+        // `lockedAmount` tracks ingress only; the direct mint was not counted.
+        assertEq(lock.lockedAmount(), 3000e18);
+    }
+
+    function test_withdraw_reverts_if_already_withdrawn() public {
+        vm.prank(alice);
+        lock.deposit(1000e18);
+
+        vm.warp(lock.unlockTime());
+        vm.prank(beneficiary);
+        lock.withdraw();
+
+        vm.prank(beneficiary);
+        vm.expectRevert(LPLock.AlreadyWithdrawn.selector);
+        lock.withdraw();
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    function test_timeRemaining_reports_zero_after_unlock() public {
+        uint256 unlock = lock.unlockTime();
+
+        // Pre-unlock: full duration minus elapsed time.
+        assertEq(lock.timeRemaining(), TEN_YEARS);
+
+        vm.warp(unlock - 7 days);
+        assertEq(lock.timeRemaining(), 7 days);
+
+        vm.warp(unlock);
+        assertEq(lock.timeRemaining(), 0);
+
+        vm.warp(unlock + 1 days);
+        assertEq(lock.timeRemaining(), 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Fuzz
+    // ---------------------------------------------------------------------
+
+    /// @dev Deposit a bounded sequence of amounts from alice and assert
+    ///      `lockedAmount` tracks the running sum exactly, and the LP balance on
+    ///      the lock matches. Individual amounts are trimmed to the supply cap and
+    ///      the list is capped to avoid absurd fuzz runtimes.
+    function testFuzz_deposit_multiple_times(uint128[] memory amounts) public {
+        uint256 cap = amounts.length > 16 ? 16 : amounts.length;
+
+        uint256 aliceStart = lp.balanceOf(alice);
+        uint256 running;
+
+        for (uint256 i = 0; i < cap; i++) {
+            uint256 amt = uint256(amounts[i]);
+            // Skip zero (reverts) and anything that exceeds remaining balance.
+            uint256 remaining = lp.balanceOf(alice);
+            if (amt == 0 || amt > remaining) {
+                continue;
+            }
+            vm.prank(alice);
+            lock.deposit(amt);
+            running += amt;
+
+            assertEq(lock.lockedAmount(), running);
+            assertEq(lp.balanceOf(address(lock)), running);
+            assertEq(lp.balanceOf(alice), aliceStart - running);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `LPLock` contract at `contracts/evm/src/launchpad/LPLock.sol`: immutable 10-year timelock for Uniswap V2 LP tokens, one instance per graduated agent.
- Permissionless `deposit`, beneficiary-only one-shot `withdraw`, `timeRemaining` view. No extend, no early-withdraw, no owner.
- Full unit + fuzz coverage at `contracts/evm/test/unit/LPLock.t.sol` (13 tests incl. 256-run fuzz on deposit accumulation).

## Why

Graduation hand-off needs a trust-minimised home for the LP tokens minted when the bonding curve seeds Uniswap V2. A 10-year hard lock with no escape hatch is the UX promise to traders and governance; making the contract immutable by construction closes the rug vector that configurable locks open. `lockedAmount` is a monotonic ingress counter; the actual withdrawal transfers the live balance so any tokens sent directly to the lock are still swept to the beneficiary on unlock.

## Test plan

- [x] unit tests: constructor immutables, constructor zero-address reverts (token + beneficiary), deposit increments + accumulates, deposit permissionless, deposit zero reverts, withdraw reverts pre-unlock with remaining seconds in error, withdraw reverts for non-beneficiary, withdraw succeeds at unlock, withdraw sweeps direct transfers, withdraw one-shot (second call reverts), `timeRemaining` monotone to zero
- [x] fuzz: bounded `testFuzz_deposit_multiple_times` asserts running-sum invariant across LP balance and `lockedAmount`
- [ ] integration (`Graduate.t.sol`) — follow-up, wired when the graduator lands

Closes #31