### PR TITLE
feat(launchpad): add anti-sniper tax decay module

### DIFF
--- a/contracts/evm/src/launchpad/modules/AntiSniperModule.sol
+++ b/contracts/evm/src/launchpad/modules/AntiSniperModule.sol
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title  AntiSniperModule
+/// @notice Per-agent dynamic buy-tax that decays linearly from {Config.startBps}
+///         down to {Config.endBps} over {Config.duration} seconds, beginning at
+///         {Config.startTime}. Used by the launchpad's buy path to burn the
+///         first-block / first-minute sniper advantage: the earlier a buyer
+///         lands after launch, the larger the tax they pay.
+/// @dev    Single shared instance across the agent fleet. The launchpad factory
+///         owns this module and calls {configure} exactly once per agent as the
+///         final step of launch. Per-agent config is one-shot: it can never be
+///         mutated after {configure} lands, so a malicious upgrade path cannot
+///         retroactively spike the tax on a live curve.
+///
+///         This contract is a pure view oracle — it holds no tokens, makes no
+///         external calls, and emits exactly one event ({Configured}). The
+///         consumer (bonding-curve buy path) reads {currentBps} or
+///         {computeTax} and deducts the tax itself. Because the module never
+///         touches funds, there is no reentrancy surface to guard.
+contract AntiSniperModule is Ownable {
+    // ---------------------------------------------------------------------
+    // Types
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent decay curve. All fields are immutable once
+    ///         {configured} flips to true.
+    /// @dev    Packs into a single 256-bit slot:
+    ///           startTime  64 bits
+    ///           duration   32 bits
+    ///           startBps   16 bits
+    ///           endBps     16 bits
+    ///           configured  8 bits (bool)
+    ///         = 136 bits, one SSTORE per {configure} call.
+    struct Config {
+        uint64 startTime;
+        uint32 duration;
+        uint16 startBps;
+        uint16 endBps;
+        bool configured;
+    }
+
+    // ---------------------------------------------------------------------
+    // Constants
+    // ---------------------------------------------------------------------
+
+    /// @notice Basis-point denominator. 10_000 = 100%.
+    uint16 public constant MAX_BPS = 10_000;
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent decay configuration. Empty struct until the factory
+    ///         calls {configure} for that agent.
+    mapping(address agent => Config) public configs;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @dev Emitted exactly once per agent when the factory locks in the decay
+    ///      curve at launch. All subsequent {configure} calls for the same
+    ///      agent revert with {AlreadyConfigured}.
+    event Configured(address indexed agent, uint64 startTime, uint32 duration, uint16 startBps, uint16 endBps);
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Thrown by {configure} if the agent already has a decay curve bound.
+    error AlreadyConfigured();
+    /// @dev Thrown when `agent` or `owner_` is the zero address.
+    error ZeroAddress();
+    /// @dev Thrown when a basis-point argument is out of range. `bps` is echoed
+    ///      for indexers chasing misconfigured launches.
+    error InvalidBps(uint16 bps);
+    /// @dev Thrown when `duration == 0` (would divide-by-zero in the linear
+    ///      interpolation branch of {currentBps}).
+    error InvalidDuration();
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @param owner_ Initial owner. Expected to be the launchpad factory (or a
+    ///               Safe multisig acting as it) so that only the factory can
+    ///               bind a decay curve to a freshly deployed agent.
+    constructor(address owner_) Ownable(_validatedOwner(owner_)) {}
+
+    /// @dev Wrap OZ `Ownable`'s zero-owner check so callers see our canonical
+    ///      {ZeroAddress} error instead of OZ's `OwnableInvalidOwner`.
+    function _validatedOwner(address owner_) private pure returns (address) {
+        if (owner_ == address(0)) revert ZeroAddress();
+        return owner_;
+    }
+
+    // ---------------------------------------------------------------------
+    // Admin
+    // ---------------------------------------------------------------------
+
+    /// @notice Bind a decay curve to `agent`. One-shot per agent.
+    /// @dev    onlyOwner so only the factory can register. The config is
+    ///         immutable once written — there is no setter for individual
+    ///         fields and no `reconfigure` path. This is intentional: a live
+    ///         curve's sniper-tax schedule is part of its social contract with
+    ///         buyers and must not be mutable by the operator.
+    /// @param  agent      Agent token address (key).
+    /// @param  startTime  Unix timestamp at which decay begins. May be in the
+    ///                    past; pre-start reads return {Config.startBps}.
+    /// @param  duration   Decay window in seconds. Must be non-zero.
+    /// @param  startBps   Tax rate at `startTime`. <= {MAX_BPS}.
+    /// @param  endBps     Tax rate at/after `startTime + duration`.
+    ///                    Must be <= `startBps` (decay is monotone non-increasing).
+    function configure(address agent, uint64 startTime, uint32 duration, uint16 startBps, uint16 endBps)
+        external
+        onlyOwner
+    {
+        if (agent == address(0)) revert ZeroAddress();
+        if (configs[agent].configured) revert AlreadyConfigured();
+        if (startBps > MAX_BPS) revert InvalidBps(startBps);
+        if (endBps > startBps) revert InvalidBps(endBps);
+        if (duration == 0) revert InvalidDuration();
+
+        configs[agent] =
+            Config({startTime: startTime, duration: duration, startBps: startBps, endBps: endBps, configured: true});
+
+        emit Configured(agent, startTime, duration, startBps, endBps);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice Current buy-tax rate for `agent`, in basis points.
+    /// @dev    Piecewise-linear:
+    ///           - unconfigured           -> 0
+    ///           - before `startTime`     -> `startBps`
+    ///           - after end (`startTime+duration`) -> `endBps`
+    ///           - in-window              -> `startBps - (startBps-endBps)*elapsed/duration`
+    ///         Result is monotone non-increasing in time for any fixed agent.
+    ///         Overflow is impossible: all terms are bounded by {MAX_BPS} and
+    ///         `uint32` max, well inside 256-bit arithmetic.
+    function currentBps(address agent) external view returns (uint16) {
+        return _currentBps(agent);
+    }
+
+    /// @notice Convenience view: split `amount` into `tax` and `netAmount`
+    ///         using the live rate from {currentBps}.
+    /// @dev    `tax = amount * currentBps / MAX_BPS` (floor).
+    ///         `netAmount = amount - tax`. Rounds in the pool's / protocol's
+    ///         favour on the tax side, matching the launchpad's other fee math.
+    ///         Overflow: `amount * MAX_BPS` overflows above ~1.16e73, which is
+    ///         well past any realistic token amount; callers passing absurd
+    ///         values will get a standard checked-math revert.
+    function computeTax(address agent, uint256 amount) external view returns (uint256 tax, uint256 netAmount) {
+        uint16 bps = _currentBps(agent);
+        tax = (amount * bps) / MAX_BPS;
+        netAmount = amount - tax;
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal
+    // ---------------------------------------------------------------------
+
+    /// @dev Shared implementation behind {currentBps} and {computeTax}; see
+    ///      {currentBps} for the piecewise-linear spec.
+    /// @dev Uses `block.timestamp` by design — the decay schedule is expressed
+    ///      in wall-clock seconds because the launchpad's client-visible
+    ///      "snipe window" is seconds from launch, not blocks. A miner who
+    ///      shifts `block.timestamp` by the permitted ~15s skew can at most
+    ///      advance the decay by a few percent of the typical 60s window; this
+    ///      is strictly pro-buyer (lower tax) and cannot be used to extract
+    ///      value from the pool, so the standard slither `timestamp` warning
+    ///      is not actionable here.
+    // slither-disable-next-line timestamp
+    function _currentBps(address agent) internal view returns (uint16) {
+        Config memory c = configs[agent];
+        if (!c.configured) return 0;
+        if (block.timestamp < c.startTime) return c.startBps;
+
+        // `elapsed = block.timestamp - c.startTime` fits in 256 bits trivially.
+        // When elapsed >= duration we saturate to `endBps` so the linear branch
+        // never underflows.
+        uint256 elapsed = block.timestamp - c.startTime;
+        if (elapsed >= c.duration) return c.endBps;
+
+        // Linear interpolation. `startBps >= endBps` enforced in {configure},
+        // so the subtraction is safe. `drop <= startBps <= MAX_BPS` so the
+        // final cast back to uint16 cannot truncate.
+        uint256 span = uint256(c.startBps) - uint256(c.endBps);
+        uint256 drop = (span * elapsed) / uint256(c.duration);
+        return uint16(uint256(c.startBps) - drop);
+    }
+}

--- a/contracts/evm/test/unit/AntiSniperModule.t.sol
+++ b/contracts/evm/test/unit/AntiSniperModule.t.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {AntiSniperModule} from "../../src/launchpad/modules/AntiSniperModule.sol";
+
+/// @dev Unit tests for the shared AntiSniperModule. The module is pure-view:
+///      we exercise the owner-gated {configure} path and the piecewise-linear
+///      decay read out of {currentBps} / {computeTax}.
+contract AntiSniperModuleTest is Test {
+    AntiSniperModule internal module;
+
+    address internal owner = address(0xA0);
+    address internal attacker = address(0xBAD);
+    address internal agent = address(0xA1);
+    address internal agent2 = address(0xA2);
+
+    // Representative 99% -> 1% decay over 60 seconds; matches the launch config
+    // the factory will bind to each agent.
+    uint16 internal constant START_BPS = 9900;
+    uint16 internal constant END_BPS = 100;
+    uint32 internal constant DURATION = 60;
+    uint64 internal constant START_TIME = 1_000_000;
+
+    function setUp() public {
+        module = new AntiSniperModule(owner);
+        // Put block.timestamp far below any launch window so pre-start branches
+        // can be exercised without underflowing.
+        vm.warp(START_TIME - 1000);
+    }
+
+    // ---------------------------------------------------------------------
+    // configure — access control + validation
+    // ---------------------------------------------------------------------
+
+    function test_configure_only_owner() public {
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        module.configure(agent, START_TIME, DURATION, START_BPS, END_BPS);
+    }
+
+    function test_configure_reverts_if_already_configured() public {
+        vm.startPrank(owner);
+        module.configure(agent, START_TIME, DURATION, START_BPS, END_BPS);
+        vm.expectRevert(AntiSniperModule.AlreadyConfigured.selector);
+        module.configure(agent, START_TIME, DURATION, START_BPS, END_BPS);
+        vm.stopPrank();
+    }
+
+    function test_configure_reverts_zero_agent() public {
+        vm.prank(owner);
+        vm.expectRevert(AntiSniperModule.ZeroAddress.selector);
+        module.configure(address(0), START_TIME, DURATION, START_BPS, END_BPS);
+    }
+
+    function test_configure_reverts_startBps_over_max() public {
+        uint16 bad = 10_001;
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(AntiSniperModule.InvalidBps.selector, bad));
+        module.configure(agent, START_TIME, DURATION, bad, END_BPS);
+    }
+
+    function test_configure_reverts_endBps_over_startBps() public {
+        uint16 badEnd = START_BPS + 1;
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(AntiSniperModule.InvalidBps.selector, badEnd));
+        module.configure(agent, START_TIME, DURATION, START_BPS, badEnd);
+    }
+
+    function test_configure_reverts_zero_duration() public {
+        vm.prank(owner);
+        vm.expectRevert(AntiSniperModule.InvalidDuration.selector);
+        module.configure(agent, START_TIME, 0, START_BPS, END_BPS);
+    }
+
+    function test_configure_emits_event_and_writes_storage() public {
+        vm.expectEmit(true, false, false, true, address(module));
+        emit AntiSniperModule.Configured(agent, START_TIME, DURATION, START_BPS, END_BPS);
+        vm.prank(owner);
+        module.configure(agent, START_TIME, DURATION, START_BPS, END_BPS);
+
+        (uint64 st, uint32 dur, uint16 sBps, uint16 eBps, bool configured) = module.configs(agent);
+        assertEq(st, START_TIME);
+        assertEq(uint256(dur), uint256(DURATION));
+        assertEq(uint256(sBps), uint256(START_BPS));
+        assertEq(uint256(eBps), uint256(END_BPS));
+        assertTrue(configured);
+    }
+
+    // ---------------------------------------------------------------------
+    // currentBps — piecewise-linear decay
+    // ---------------------------------------------------------------------
+
+    function test_currentBps_unconfigured_returns_zero() public view {
+        assertEq(uint256(module.currentBps(agent)), 0);
+    }
+
+    function test_currentBps_before_start_returns_startBps() public {
+        _configureDefault();
+        // setUp warped to START_TIME - 1_000; still pre-start.
+        assertEq(uint256(module.currentBps(agent)), uint256(START_BPS));
+    }
+
+    function test_currentBps_at_start_returns_startBps() public {
+        _configureDefault();
+        vm.warp(START_TIME);
+        assertEq(uint256(module.currentBps(agent)), uint256(START_BPS));
+    }
+
+    /// @dev 100% -> 0% over 1_000s. At 500s we expect ~50%.
+    ///      With floor division: drop = (10_000 * 500) / 1_000 = 5_000.
+    ///      currentBps = 10_000 - 5_000 = 5_000.
+    function test_currentBps_midway_linear_interpolation() public {
+        uint64 start = 2_000_000;
+        uint32 dur = 1000;
+        uint16 sBps = 10_000;
+        uint16 eBps = 0;
+
+        vm.prank(owner);
+        module.configure(agent2, start, dur, sBps, eBps);
+
+        vm.warp(start + 500);
+        assertEq(uint256(module.currentBps(agent2)), 5000);
+    }
+
+    function test_currentBps_after_end_returns_endBps() public {
+        _configureDefault();
+        vm.warp(uint256(START_TIME) + uint256(DURATION));
+        assertEq(uint256(module.currentBps(agent)), uint256(END_BPS));
+        vm.warp(uint256(START_TIME) + uint256(DURATION) + 10_000);
+        assertEq(uint256(module.currentBps(agent)), uint256(END_BPS));
+    }
+
+    // ---------------------------------------------------------------------
+    // computeTax
+    // ---------------------------------------------------------------------
+
+    function test_computeTax_matches_currentBps_scale() public {
+        _configureDefault();
+        vm.warp(uint256(START_TIME) + 30); // halfway — 30/60 of (9900-100) = 4900 drop
+        uint16 bps = module.currentBps(agent);
+        assertEq(uint256(bps), 9900 - 4900); // = 5_000
+
+        uint256 amount = 1_000_000 ether;
+        (uint256 tax, uint256 net) = module.computeTax(agent, amount);
+        assertEq(tax, (amount * uint256(bps)) / uint256(module.MAX_BPS()));
+        assertEq(net, amount - tax);
+    }
+
+    function test_computeTax_unconfigured_is_zero_tax() public view {
+        (uint256 tax, uint256 net) = module.computeTax(agent, 1000);
+        assertEq(tax, 0);
+        assertEq(net, 1000);
+    }
+
+    // ---------------------------------------------------------------------
+    // Fuzz
+    // ---------------------------------------------------------------------
+
+    /// @dev currentBps is monotone non-increasing in time for any configured
+    ///      agent. Bound fuzz inputs to the decay window and a small tail.
+    function testFuzz_currentBps_monotonic_nonincreasing(uint32 elapsed1, uint32 elapsed2) public {
+        _configureDefault();
+        // Bound to [0, duration + 10k] so we also cover the post-end saturation.
+        elapsed1 = uint32(bound(uint256(elapsed1), 0, uint256(DURATION) + 10_000));
+        elapsed2 = uint32(bound(uint256(elapsed2), 0, uint256(DURATION) + 10_000));
+        if (elapsed1 > elapsed2) {
+            (elapsed1, elapsed2) = (elapsed2, elapsed1);
+        }
+
+        vm.warp(uint256(START_TIME) + uint256(elapsed1));
+        uint16 b1 = module.currentBps(agent);
+        vm.warp(uint256(START_TIME) + uint256(elapsed2));
+        uint16 b2 = module.currentBps(agent);
+
+        assertLe(uint256(b2), uint256(b1));
+        assertLe(uint256(b1), uint256(START_BPS));
+        assertGe(uint256(b2), uint256(END_BPS));
+    }
+
+    /// @dev For any amount bounded away from 2^256/MAX_BPS, tax + net == amount.
+    function testFuzz_computeTax_sum_equals_amount(uint256 amount) public {
+        _configureDefault();
+        // Stay below 2^240 so amount * MAX_BPS (~14 bits) cannot overflow.
+        amount = bound(amount, 0, type(uint256).max / uint256(module.MAX_BPS()));
+        // Pick an arbitrary mid-window timestamp so the rate is non-trivial.
+        vm.warp(uint256(START_TIME) + uint256(DURATION) / 3);
+
+        (uint256 tax, uint256 net) = module.computeTax(agent, amount);
+        assertEq(tax + net, amount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    function _configureDefault() internal {
+        vm.prank(owner);
+        module.configure(agent, START_TIME, DURATION, START_BPS, END_BPS);
+    }
+}


### PR DESCRIPTION
## Summary
- New `AntiSniperModule` at `contracts/evm/src/launchpad/modules/AntiSniperModule.sol` — shared per-agent buy-tax oracle.
- Piecewise-linear decay from `startBps` down to `endBps` over a configurable window, beginning at `startTime`.
- One-shot `configure` per agent (onlyOwner), `currentBps` + `computeTax` view helpers.

## Why
The launchpad's buy path needs a dynamic tax to neutralise the first-block sniper advantage: a 99% tax at launch decaying to 1% over ~60s makes it uneconomic to front-run the curve while still allowing honest buyers to land once the rate decays. Keeping the schedule immutable once bound closes the rug-via-reconfigure vector.

## Design notes
- Shared module, not per-agent clone — no token custody, so there is no reason to deploy one per launch. Factory owns the single instance and binds a config per agent at launch.
- `configure` is one-shot: once written, the schedule is part of the agent's social contract with buyers and must not be mutable.
- Pure-view: no `transfer`/`call`, no reentrancy surface. Consumers read `currentBps` / `computeTax` and deduct the tax themselves.
- Config packs into one storage slot (136 bits used).

## Test plan
- [x] unit — 16 tests, all green (`forge test --match-path test/unit/AntiSniperModule.t.sol`)
  - access control, one-shot `configure`, input validation (zero agent, bps range, zero duration)
  - piecewise-linear read: unconfigured, before-start, at-start, midway, at-end, after-end
  - `computeTax` scale matches `currentBps`
  - fuzz: `currentBps` monotone non-increasing in time
  - fuzz: `tax + netAmount == amount` for any bounded amount
- [x] `forge fmt --check` clean
- [x] `slither` clean — 0 findings with the project's `slither.config.json`
- [ ] integration with bonding-curve buy path — follow-up PR wires the module into the factory

Closes #33