### PR TITLE
feat(launchpad): add sixty-day reversible escrow module

### DIFF
--- a/contracts/evm/src/launchpad/modules/SixtyDaysModule.sol
+++ b/contracts/evm/src/launchpad/modules/SixtyDaysModule.sol
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/// @title  SixtyDaysModule
+/// @notice Reversible-launch escrow shared across every agent launch. The 70% creator
+///         leg of the swap fee (routed by the launchpad's `FeeRouter`) is held in
+///         this module for the first 60 days of an agent's life. During that window
+///         the agent's `creator` (registered at configure-time) has exactly one
+///         binary decision to make:
+///             * `commit()` — sealed only after `startTime + WINDOW`. Unlocks the
+///               full escrow balance to the creator. One-shot, irreversible.
+///             * `refund()` — sealed before `commit()` and never after. Opens a
+///               pull-pattern claim phase: each contributor (per the per-buyer
+///               ledger pushed in by the bonding curve) can claim a pro-rata share
+///               of the escrow plus any pre-graduation reserves the curve drains
+///               into the module via `accrueRefundPool`. One-shot, irreversible.
+/// @dev    Single deployment per protocol; per-agent state lives in `configs`.
+///         The protocol owner (typically the launchpad factory or a Safe) calls
+///         `configure` once per agent to bootstrap. After that the only privileged
+///         actors per agent are:
+///             * the registered `bondingCurve` — pushes contribution ledger entries
+///               via {accrueEscrow}+{recordContribution} during the trade path, and
+///               drains residual reserves via {accrueRefundPool} on `refund()`.
+///             * the registered `creator` — calls {commit} or {refund}.
+///         CEI is enforced on every state-mutating external entry that moves
+///         tokens. `claimed[agent][user]` flips before the outbound transfer so a
+///         re-entrant ERC-20 cannot double-pay; `ReentrancyGuard` layers on top.
+///         Only custom errors; no string reverts. Funds are never permanently
+///         locked: the module exposes either an unlock-to-creator path or an
+///         unlock-to-buyers path, and both phases are reachable from any state
+///         the module is ever placed in by an honest caller.
+contract SixtyDaysModule is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ---------------------------------------------------------------------
+    // Constants
+    // ---------------------------------------------------------------------
+
+    /// @notice Reversibility window measured from `startTime`. Hard-coded to 60
+    ///         days so it cannot be lengthened per-agent post-bootstrap.
+    uint64 public constant WINDOW = 60 days;
+
+    /// @notice Phase enum encoded as `uint8` to keep `Config` packed.
+    uint8 internal constant PHASE_OPEN = 0;
+    uint8 internal constant PHASE_COMMITTED = 1;
+    uint8 internal constant PHASE_REFUNDING = 2;
+
+    // ---------------------------------------------------------------------
+    // Types
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent escrow + lifecycle state.
+    /// @param startTime                Unix seconds the 60-day clock starts at.
+    /// @param windowEnd                `startTime + WINDOW`. `commit` is gated on
+    ///                                 `block.timestamp >= windowEnd`.
+    /// @param escrowToken              Token escrowed (typically the curve's quote
+    ///                                 asset, TITU). Same asset is used to pay out
+    ///                                 commit + refund.
+    /// @param bondingCurve             Sole address allowed to push escrow accruals,
+    ///                                 contribution-ledger entries, and refund-pool
+    ///                                 top-ups for this agent.
+    /// @param creator                  Sole address allowed to call {commit} or
+    ///                                 {refund}.
+    /// @param phase                    {PHASE_OPEN | PHASE_COMMITTED | PHASE_REFUNDING}.
+    /// @param configured               One-shot guard; flipped on first `configure`.
+    /// @param escrowAmountAccumulated  Running sum of escrowed token wei pushed in by
+    ///                                 the curve (creator-leg fees). On commit this
+    ///                                 is paid out gross to the creator. On refund
+    ///                                 it is added to the pull-pattern pool.
+    /// @param refundPool               Total claimable wei after `refund()` has
+    ///                                 fired: equals `escrowAmountAccumulated` plus
+    ///                                 any extra reserves the curve drains via
+    ///                                 {accrueRefundPool}. Pro-rata denominator on
+    ///                                 the contributor-ledger side stays
+    ///                                 `totalContributed`.
+    /// @param totalContributed         Sum of buyer-side quote contributions during
+    ///                                 the open phase. Used as the pro-rata
+    ///                                 denominator on {claimRefund}.
+    struct Config {
+        uint64 startTime;
+        uint64 windowEnd;
+        address escrowToken;
+        address bondingCurve;
+        address creator;
+        uint8 phase;
+        bool configured;
+        uint256 escrowAmountAccumulated;
+        uint256 refundPool;
+        uint256 totalContributed;
+    }
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent configuration + accumulated state.
+    mapping(address agent => Config) public configs;
+
+    /// @notice Per-agent, per-user cumulative buy-side quote contribution during
+    ///         the open phase. Pro-rata numerator on {claimRefund}.
+    mapping(address agent => mapping(address user => uint256)) public contributed;
+
+    /// @notice Per-agent, per-user one-shot claim flag. Set BEFORE the outbound
+    ///         token transfer in {claimRefund} (CEI). Once true, the user cannot
+    ///         claim again for this agent.
+    mapping(address agent => mapping(address user => bool)) public claimed;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @notice Emitted exactly once when the protocol owner registers an agent.
+    event Configured(
+        address indexed agent,
+        address indexed escrowToken,
+        address indexed bondingCurve,
+        address creator,
+        uint64 startTime,
+        uint64 windowEnd
+    );
+
+    /// @notice Emitted on every {accrueEscrow} push from the bonding curve.
+    event EscrowAccrued(address indexed agent, uint256 amount, uint256 totalEscrow);
+
+    /// @notice Emitted on every {recordContribution} push from the bonding curve.
+    event Contributed(address indexed agent, address indexed user, uint256 amount, uint256 totalContributed);
+
+    /// @notice Emitted on every {accrueRefundPool} top-up after refund has fired.
+    event RefundPoolToppedUp(address indexed agent, uint256 amount, uint256 totalPool);
+
+    /// @notice Emitted exactly once per agent when {commit} succeeds.
+    event Committed(address indexed agent, address indexed creator, uint256 amount);
+
+    /// @notice Emitted exactly once per agent when {refund} succeeds.
+    event Refunded(address indexed agent, address indexed creator, uint256 escrowAmount);
+
+    /// @notice Emitted on every successful {claimRefund}.
+    event RefundClaimed(address indexed agent, address indexed user, uint256 amount);
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Thrown when `configure` is called more than once for the same agent.
+    error AlreadyConfigured();
+    /// @dev Thrown by accrual / contribution paths when the caller is not the
+    ///      bonding curve registered for the agent in {configure}.
+    error NotBondingCurve();
+    /// @dev Thrown by {commit} / {refund} when the caller is not the registered
+    ///      creator.
+    error NotCreator();
+    /// @dev Thrown by {commit} when invoked before `startTime + WINDOW`.
+    error WindowNotElapsed();
+    /// @dev Thrown by {commit} / {refund} / accrual paths when the agent is not
+    ///      in {PHASE_OPEN} (the only state from which commit or refund can fire,
+    ///      and from which the curve can keep accruing).
+    error NotOpen();
+    /// @dev Thrown by {accrueRefundPool} when the agent is not in
+    ///      {PHASE_REFUNDING}.
+    error NotRefunding();
+    /// @dev Thrown by {claimRefund} when the agent has not yet entered
+    ///      {PHASE_REFUNDING}.
+    error NotInRefundPhase();
+    /// @dev Thrown by {claimRefund} when the caller has already claimed.
+    error AlreadyClaimed();
+    /// @dev Thrown by {claimRefund} when the caller never contributed (or their
+    ///      pro-rata share floors to zero).
+    error NoContribution();
+    /// @dev Thrown when an `address` argument required to be non-zero is zero.
+    error ZeroAddress();
+    /// @dev Thrown when a `uint256` amount required to be non-zero is zero.
+    error ZeroAmount();
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @param owner_ Protocol owner authorized to call {configure}. Expected to
+    ///               be the launchpad factory or a Safe multisig acting on its
+    ///               behalf. Reverts via OZ Ownable's `OwnableInvalidOwner` if
+    ///               zero — surfaced as our canonical {ZeroAddress} below.
+    constructor(address owner_) Ownable(_validatedOwner(owner_)) {}
+
+    /// @dev Promote OZ's `OwnableInvalidOwner` into our canonical {ZeroAddress}
+    ///      so the ABI exposes a single error type for missing addresses at
+    ///      construction.
+    function _validatedOwner(address owner_) private pure returns (address) {
+        if (owner_ == address(0)) revert ZeroAddress();
+        return owner_;
+    }
+
+    // ---------------------------------------------------------------------
+    // Configuration
+    // ---------------------------------------------------------------------
+
+    /// @notice Bootstrap an agent on this module. One-shot per agent.
+    /// @dev    Owner-gated. The factory wires the agent's bonding curve as the
+    ///         sole accrual / contribution source and the creator as the sole
+    ///         party authorized to call {commit} or {refund}.
+    /// @param  agent          Agent ERC-20 address (storage key).
+    /// @param  escrowToken_   Token escrowed (creator-leg fee currency).
+    /// @param  bondingCurve_  Curve allowed to push accruals + contributions.
+    /// @param  creator_       Creator allowed to commit or refund.
+    /// @param  startTime_     Unix seconds the 60-day clock starts at.
+    function configure(address agent, address escrowToken_, address bondingCurve_, address creator_, uint64 startTime_)
+        external
+        onlyOwner
+    {
+        if (agent == address(0) || escrowToken_ == address(0) || bondingCurve_ == address(0) || creator_ == address(0))
+        {
+            revert ZeroAddress();
+        }
+        Config storage cfg = configs[agent];
+        if (cfg.configured) revert AlreadyConfigured();
+
+        uint64 windowEnd_ = startTime_ + WINDOW;
+        cfg.startTime = startTime_;
+        cfg.windowEnd = windowEnd_;
+        cfg.escrowToken = escrowToken_;
+        cfg.bondingCurve = bondingCurve_;
+        cfg.creator = creator_;
+        cfg.configured = true;
+        cfg.phase = PHASE_OPEN;
+
+        emit Configured(agent, escrowToken_, bondingCurve_, creator_, startTime_, windowEnd_);
+    }
+
+    // ---------------------------------------------------------------------
+    // Curve hooks (open phase)
+    // ---------------------------------------------------------------------
+
+    /// @notice Push the creator-leg fee for `agent` into escrow. Pulled from the
+    ///         curve via {SafeERC20-safeTransferFrom}; the curve must have
+    ///         approved the module for `amount` of `escrowToken`.
+    /// @dev    Curve-gated. Allowed only while the agent is in {PHASE_OPEN};
+    ///         after commit / refund the escrow accounting is frozen and any
+    ///         further fees should be routed elsewhere by the integrator.
+    ///         CEI: the running counter updates before the inbound pull so a
+    ///         malicious token cannot reenter and double-count itself; the
+    ///         outbound transfer is the inbound pull (no further hops).
+    /// @param  agent   Agent the escrow is for.
+    /// @param  amount  Amount of `escrowToken` to pull. Non-zero.
+    function accrueEscrow(address agent, uint256 amount) external nonReentrant {
+        if (amount == 0) revert ZeroAmount();
+        Config storage cfg = configs[agent];
+        if (msg.sender != cfg.bondingCurve) revert NotBondingCurve();
+        if (cfg.phase != PHASE_OPEN) revert NotOpen();
+
+        uint256 newTotal = cfg.escrowAmountAccumulated + amount;
+        cfg.escrowAmountAccumulated = newTotal;
+
+        IERC20(cfg.escrowToken).safeTransferFrom(msg.sender, address(this), amount);
+        emit EscrowAccrued(agent, amount, newTotal);
+    }
+
+    /// @notice Record `user`'s buy-side contribution to `agent`'s curve.
+    /// @dev    Curve-gated. Used as the pro-rata numerator on {claimRefund}.
+    ///         No tokens move here — the curve already holds the buyer's quote
+    ///         in its reserves; this is pure accounting.
+    /// @param  agent   Agent the contribution is for.
+    /// @param  user    Buyer credited.
+    /// @param  amount  Net quote (post-fee) contributed by `user`.
+    function recordContribution(address agent, address user, uint256 amount) external {
+        if (amount == 0) revert ZeroAmount();
+        if (user == address(0)) revert ZeroAddress();
+        Config storage cfg = configs[agent];
+        if (msg.sender != cfg.bondingCurve) revert NotBondingCurve();
+        if (cfg.phase != PHASE_OPEN) revert NotOpen();
+
+        contributed[agent][user] += amount;
+        cfg.totalContributed += amount;
+        emit Contributed(agent, user, amount, cfg.totalContributed);
+    }
+
+    // ---------------------------------------------------------------------
+    // Creator decisions
+    // ---------------------------------------------------------------------
+
+    /// @notice Unlock the full escrow balance for `agent` to the registered
+    ///         creator. Callable only after `startTime + WINDOW` and only when
+    ///         the agent is still in {PHASE_OPEN} (i.e. the creator has not
+    ///         already chosen `refund`).
+    /// @dev    One-shot: the phase is flipped to {PHASE_COMMITTED} BEFORE the
+    ///         outbound transfer (CEI). `nonReentrant` belt-and-braces.
+    ///         Idempotency: a second call reverts {NotOpen}.
+    /// @param  agent  Agent committing.
+    function commit(address agent) external nonReentrant {
+        Config storage cfg = configs[agent];
+        if (msg.sender != cfg.creator) revert NotCreator();
+        if (cfg.phase != PHASE_OPEN) revert NotOpen();
+        // Time gate: 60 days from `startTime` must have elapsed. The granularity
+        // here is days — miner timestamp drift of seconds is irrelevant.
+        // slither-disable-next-line timestamp
+        if (block.timestamp < cfg.windowEnd) revert WindowNotElapsed();
+
+        uint256 amount = cfg.escrowAmountAccumulated;
+        cfg.phase = PHASE_COMMITTED;
+
+        if (amount != 0) {
+            IERC20(cfg.escrowToken).safeTransfer(cfg.creator, amount);
+        }
+        emit Committed(agent, cfg.creator, amount);
+    }
+
+    /// @notice Open the pull-pattern refund phase for `agent`. Callable by the
+    ///         registered creator any time before {commit} fires — including
+    ///         strictly before `startTime + WINDOW`. The full escrow balance is
+    ///         seeded into the refund pool; the bonding curve may also drain
+    ///         residual pre-graduation reserves into the pool via
+    ///         {accrueRefundPool}.
+    /// @dev    One-shot: the phase flips to {PHASE_REFUNDING} and any later
+    ///         {commit} or {refund} call reverts {NotOpen}. No tokens leave the
+    ///         module on this call — the escrow already lives here. Buyers pull
+    ///         their share via {claimRefund}.
+    /// @param  agent  Agent opening refund.
+    function refund(address agent) external {
+        Config storage cfg = configs[agent];
+        if (msg.sender != cfg.creator) revert NotCreator();
+        if (cfg.phase != PHASE_OPEN) revert NotOpen();
+
+        uint256 escrowAmount = cfg.escrowAmountAccumulated;
+        cfg.phase = PHASE_REFUNDING;
+        cfg.refundPool = escrowAmount;
+
+        emit Refunded(agent, cfg.creator, escrowAmount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Curve hooks (refund phase)
+    // ---------------------------------------------------------------------
+
+    /// @notice Top up the refund pool for `agent` from the bonding curve.
+    /// @dev    Curve-gated. Used by the curve to drain residual quote reserves
+    ///         into the module after {refund} has fired so that buyers receive
+    ///         not just the escrowed creator-leg fees but also their share of
+    ///         the unspent curve reserves. The curve must have approved the
+    ///         module for `amount`. Allowed only in {PHASE_REFUNDING}.
+    ///         CEI: the running counter updates before the inbound pull.
+    /// @param  agent   Agent receiving the top-up.
+    /// @param  amount  Amount of `escrowToken` pulled from the curve. Non-zero.
+    function accrueRefundPool(address agent, uint256 amount) external nonReentrant {
+        if (amount == 0) revert ZeroAmount();
+        Config storage cfg = configs[agent];
+        if (msg.sender != cfg.bondingCurve) revert NotBondingCurve();
+        if (cfg.phase != PHASE_REFUNDING) revert NotRefunding();
+
+        uint256 newTotal = cfg.refundPool + amount;
+        cfg.refundPool = newTotal;
+
+        IERC20(cfg.escrowToken).safeTransferFrom(msg.sender, address(this), amount);
+        emit RefundPoolToppedUp(agent, amount, newTotal);
+    }
+
+    /// @notice Pull the caller's pro-rata share of the refund pool for `agent`.
+    /// @dev    CEI: `claimed` is set BEFORE the outbound transfer and a second
+    ///         call from the same address reverts {AlreadyClaimed}.
+    ///         `nonReentrant` belt-and-braces against ERC-20 callbacks.
+    ///         Pro-rata: `share = userContribution * refundPool / totalContributed`,
+    ///         floored. The dust left by the floor stays in the contract until
+    ///         the last claimer takes a slightly-truncated share (no recipient
+    ///         is favoured; the floor strictly under-pays so the module remains
+    ///         solvent against `refundPool`).
+    /// @param  agent  Agent the caller is claiming against.
+    /// @return amount Tokens transferred to the caller (>= 1 wei or revert).
+    function claimRefund(address agent) external nonReentrant returns (uint256 amount) {
+        Config storage cfg = configs[agent];
+        if (cfg.phase != PHASE_REFUNDING) revert NotInRefundPhase();
+        if (claimed[agent][msg.sender]) revert AlreadyClaimed();
+
+        uint256 userContribution = contributed[agent][msg.sender];
+        if (userContribution == 0) revert NoContribution();
+
+        // `totalContributed` is non-zero whenever any user has a non-zero
+        // `userContribution` because the latter only grows under the same
+        // {recordContribution} path that grows the former by the same delta.
+        amount = (userContribution * cfg.refundPool) / cfg.totalContributed;
+        if (amount == 0) revert NoContribution();
+
+        claimed[agent][msg.sender] = true;
+
+        IERC20(cfg.escrowToken).safeTransfer(msg.sender, amount);
+        emit RefundClaimed(agent, msg.sender, amount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice Read-only twin of {claimRefund}. Returns zero for users who have
+    ///         already claimed, never contributed, or whose agent is not in the
+    ///         refund phase.
+    /// @param  agent  Agent to preview against.
+    /// @param  user   Address to preview for.
+    /// @return amount Tokens the user would receive if they claimed now.
+    function previewRefund(address agent, address user) external view returns (uint256 amount) {
+        Config storage cfg = configs[agent];
+        if (cfg.phase != PHASE_REFUNDING) return 0;
+        if (claimed[agent][user]) return 0;
+        uint256 userContribution = contributed[agent][user];
+        if (userContribution == 0) return 0;
+        amount = (userContribution * cfg.refundPool) / cfg.totalContributed;
+    }
+
+    /// @notice Convenience accessor for the agent's current phase.
+    /// @return phase 0 = open, 1 = committed, 2 = refunding.
+    function phaseOf(address agent) external view returns (uint8 phase) {
+        return configs[agent].phase;
+    }
+}

--- a/contracts/evm/test/unit/SixtyDaysModule.t.sol
+++ b/contracts/evm/test/unit/SixtyDaysModule.t.sol
@@ -1,0 +1,703 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {SixtyDaysModule} from "../../src/launchpad/modules/SixtyDaysModule.sol";
+
+/// @dev Minimal mintable ERC-20 used as the escrow token in the unit tests.
+///      No transfer tax so claim math is exact at the wei.
+contract TestERC20 is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
+}
+
+/// @dev Reentrant token: on every transfer, calls back into a configured target
+///      with arbitrary calldata. Lets us prove that the module's CEI + guard
+///      stops a re-entrant `claimRefund`.
+contract ReentrantToken is ERC20 {
+    address public target;
+    bytes public reenterData;
+    bool public armed;
+
+    constructor() ERC20("REE", "REE") {}
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
+
+    function arm(address target_, bytes calldata data_) external {
+        target = target_;
+        reenterData = data_;
+        armed = true;
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        super._update(from, to, value);
+        if (armed && to != address(0) && target != address(0)) {
+            armed = false; // single shot
+            // ignore success — we only care that the inner call's revert bubbles.
+            (bool ok, bytes memory ret) = target.call(reenterData);
+            if (!ok) {
+                // bubble revert reason for clearer test diagnostics
+                assembly {
+                    revert(add(ret, 32), mload(ret))
+                }
+            }
+        }
+    }
+}
+
+contract SixtyDaysModuleTest is Test {
+    SixtyDaysModule internal module;
+    TestERC20 internal escrowToken;
+
+    address internal factory = address(0xFAC);
+    address internal agent = address(0xA6E47);
+    address internal curve = address(0xC0E);
+    address internal creator = address(0xC4EA702);
+    address internal alice = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal carol = address(0xCA501);
+
+    uint64 internal constant START = 1_700_000_000;
+    uint64 internal constant WINDOW = 60 days;
+
+    // Phase enum values (must match the constants in the contract)
+    uint8 internal constant PHASE_OPEN = 0;
+    uint8 internal constant PHASE_COMMITTED = 1;
+    uint8 internal constant PHASE_REFUNDING = 2;
+
+    function setUp() public {
+        module = new SixtyDaysModule(factory);
+        escrowToken = new TestERC20("ESCROW", "ESC");
+        vm.warp(START);
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    function _configure() internal {
+        vm.prank(factory);
+        module.configure(agent, address(escrowToken), curve, creator, START);
+    }
+
+    function _accrue(uint256 amt) internal {
+        escrowToken.mint(curve, amt);
+        vm.prank(curve);
+        escrowToken.approve(address(module), amt);
+        vm.prank(curve);
+        module.accrueEscrow(agent, amt);
+    }
+
+    function _contribute(address user, uint256 amt) internal {
+        vm.prank(curve);
+        module.recordContribution(agent, user, amt);
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    function test_constructor_sets_owner_and_window() public view {
+        assertEq(module.owner(), factory);
+        assertEq(uint256(module.WINDOW()), uint256(WINDOW));
+    }
+
+    function test_constructor_reverts_zero_owner() public {
+        vm.expectRevert(SixtyDaysModule.ZeroAddress.selector);
+        new SixtyDaysModule(address(0));
+    }
+
+    // ---------------------------------------------------------------------
+    // configure
+    // ---------------------------------------------------------------------
+
+    function test_configure_only_owner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        module.configure(agent, address(escrowToken), curve, creator, START);
+    }
+
+    function test_configure_happy_emits_and_writes() public {
+        vm.expectEmit(true, true, true, true, address(module));
+        emit SixtyDaysModule.Configured(agent, address(escrowToken), curve, creator, START, START + WINDOW);
+        vm.prank(factory);
+        module.configure(agent, address(escrowToken), curve, creator, START);
+
+        (
+            uint64 startTime,
+            uint64 windowEnd,
+            address tok,
+            address bc,
+            address cr,
+            uint8 phase,
+            bool configured,
+            uint256 escrowAccum,
+            uint256 pool,
+            uint256 totalContrib
+        ) = module.configs(agent);
+        assertEq(uint256(startTime), uint256(START));
+        assertEq(uint256(windowEnd), uint256(START + WINDOW));
+        assertEq(tok, address(escrowToken));
+        assertEq(bc, curve);
+        assertEq(cr, creator);
+        assertEq(uint256(phase), uint256(PHASE_OPEN));
+        assertTrue(configured);
+        assertEq(escrowAccum, 0);
+        assertEq(pool, 0);
+        assertEq(totalContrib, 0);
+    }
+
+    function test_configure_reverts_already_configured() public {
+        _configure();
+        vm.prank(factory);
+        vm.expectRevert(SixtyDaysModule.AlreadyConfigured.selector);
+        module.configure(agent, address(escrowToken), curve, creator, START);
+    }
+
+    function test_configure_reverts_zero_agent() public {
+        vm.prank(factory);
+        vm.expectRevert(SixtyDaysModule.ZeroAddress.selector);
+        module.configure(address(0), address(escrowToken), curve, creator, START);
+    }
+
+    function test_configure_reverts_zero_token() public {
+        vm.prank(factory);
+        vm.expectRevert(SixtyDaysModule.ZeroAddress.selector);
+        module.configure(agent, address(0), curve, creator, START);
+    }
+
+    function test_configure_reverts_zero_curve() public {
+        vm.prank(factory);
+        vm.expectRevert(SixtyDaysModule.ZeroAddress.selector);
+        module.configure(agent, address(escrowToken), address(0), creator, START);
+    }
+
+    function test_configure_reverts_zero_creator() public {
+        vm.prank(factory);
+        vm.expectRevert(SixtyDaysModule.ZeroAddress.selector);
+        module.configure(agent, address(escrowToken), curve, address(0), START);
+    }
+
+    // ---------------------------------------------------------------------
+    // accrueEscrow
+    // ---------------------------------------------------------------------
+
+    function test_accrueEscrow_only_curve() public {
+        _configure();
+        escrowToken.mint(alice, 100e18);
+        vm.prank(alice);
+        escrowToken.approve(address(module), 100e18);
+        vm.prank(alice);
+        vm.expectRevert(SixtyDaysModule.NotBondingCurve.selector);
+        module.accrueEscrow(agent, 100e18);
+    }
+
+    function test_accrueEscrow_reverts_zero_amount() public {
+        _configure();
+        vm.prank(curve);
+        vm.expectRevert(SixtyDaysModule.ZeroAmount.selector);
+        module.accrueEscrow(agent, 0);
+    }
+
+    function test_accrueEscrow_pulls_and_accumulates() public {
+        _configure();
+        escrowToken.mint(curve, 100e18);
+        vm.prank(curve);
+        escrowToken.approve(address(module), 100e18);
+
+        vm.expectEmit(true, false, false, true, address(module));
+        emit SixtyDaysModule.EscrowAccrued(agent, 30e18, 30e18);
+        vm.prank(curve);
+        module.accrueEscrow(agent, 30e18);
+
+        vm.expectEmit(true, false, false, true, address(module));
+        emit SixtyDaysModule.EscrowAccrued(agent, 70e18, 100e18);
+        vm.prank(curve);
+        module.accrueEscrow(agent, 70e18);
+
+        (,,,,,,, uint256 escrowAccum,,) = module.configs(agent);
+        assertEq(escrowAccum, 100e18);
+        assertEq(escrowToken.balanceOf(address(module)), 100e18);
+    }
+
+    function test_accrueEscrow_reverts_after_commit() public {
+        _configure();
+        _accrue(100e18);
+        vm.warp(START + WINDOW);
+        vm.prank(creator);
+        module.commit(agent);
+
+        // further accrual blocked
+        escrowToken.mint(curve, 1e18);
+        vm.prank(curve);
+        escrowToken.approve(address(module), 1e18);
+        vm.prank(curve);
+        vm.expectRevert(SixtyDaysModule.NotOpen.selector);
+        module.accrueEscrow(agent, 1e18);
+    }
+
+    function test_accrueEscrow_reverts_after_refund() public {
+        _configure();
+        _accrue(100e18);
+        _contribute(alice, 1e18);
+        vm.prank(creator);
+        module.refund(agent);
+
+        escrowToken.mint(curve, 1e18);
+        vm.prank(curve);
+        escrowToken.approve(address(module), 1e18);
+        vm.prank(curve);
+        vm.expectRevert(SixtyDaysModule.NotOpen.selector);
+        module.accrueEscrow(agent, 1e18);
+    }
+
+    // ---------------------------------------------------------------------
+    // recordContribution
+    // ---------------------------------------------------------------------
+
+    function test_recordContribution_only_curve() public {
+        _configure();
+        vm.prank(alice);
+        vm.expectRevert(SixtyDaysModule.NotBondingCurve.selector);
+        module.recordContribution(agent, alice, 1e18);
+    }
+
+    function test_recordContribution_reverts_zero_amount() public {
+        _configure();
+        vm.prank(curve);
+        vm.expectRevert(SixtyDaysModule.ZeroAmount.selector);
+        module.recordContribution(agent, alice, 0);
+    }
+
+    function test_recordContribution_reverts_zero_user() public {
+        _configure();
+        vm.prank(curve);
+        vm.expectRevert(SixtyDaysModule.ZeroAddress.selector);
+        module.recordContribution(agent, address(0), 1e18);
+    }
+
+    function test_recordContribution_accumulates() public {
+        _configure();
+        _contribute(alice, 30e18);
+        _contribute(alice, 20e18);
+        _contribute(bob, 50e18);
+
+        assertEq(module.contributed(agent, alice), 50e18);
+        assertEq(module.contributed(agent, bob), 50e18);
+        (,,,,,,,,, uint256 totalContrib) = module.configs(agent);
+        assertEq(totalContrib, 100e18);
+    }
+
+    function test_recordContribution_reverts_after_refund() public {
+        _configure();
+        _contribute(alice, 1e18);
+        vm.prank(creator);
+        module.refund(agent);
+        vm.prank(curve);
+        vm.expectRevert(SixtyDaysModule.NotOpen.selector);
+        module.recordContribution(agent, bob, 1e18);
+    }
+
+    // ---------------------------------------------------------------------
+    // commit
+    // ---------------------------------------------------------------------
+
+    function test_commit_only_creator() public {
+        _configure();
+        _accrue(100e18);
+        vm.warp(START + WINDOW);
+        vm.prank(alice);
+        vm.expectRevert(SixtyDaysModule.NotCreator.selector);
+        module.commit(agent);
+    }
+
+    function test_commit_reverts_too_early() public {
+        _configure();
+        _accrue(100e18);
+        vm.warp(START + WINDOW - 1);
+        vm.prank(creator);
+        vm.expectRevert(SixtyDaysModule.WindowNotElapsed.selector);
+        module.commit(agent);
+    }
+
+    function test_commit_happy_at_window_boundary() public {
+        _configure();
+        _accrue(100e18);
+        vm.warp(START + WINDOW);
+
+        vm.expectEmit(true, true, false, true, address(module));
+        emit SixtyDaysModule.Committed(agent, creator, 100e18);
+        vm.prank(creator);
+        module.commit(agent);
+
+        assertEq(escrowToken.balanceOf(creator), 100e18);
+        assertEq(escrowToken.balanceOf(address(module)), 0);
+        assertEq(uint256(module.phaseOf(agent)), uint256(PHASE_COMMITTED));
+    }
+
+    function test_commit_zero_escrow_succeeds() public {
+        _configure();
+        // No accrual — escrow is zero. Commit still flips the phase.
+        vm.warp(START + WINDOW);
+        vm.expectEmit(true, true, false, true, address(module));
+        emit SixtyDaysModule.Committed(agent, creator, 0);
+        vm.prank(creator);
+        module.commit(agent);
+        assertEq(escrowToken.balanceOf(creator), 0);
+        assertEq(uint256(module.phaseOf(agent)), uint256(PHASE_COMMITTED));
+    }
+
+    function test_commit_reverts_double_commit() public {
+        _configure();
+        _accrue(100e18);
+        vm.warp(START + WINDOW);
+        vm.prank(creator);
+        module.commit(agent);
+        vm.prank(creator);
+        vm.expectRevert(SixtyDaysModule.NotOpen.selector);
+        module.commit(agent);
+    }
+
+    function test_commit_reverts_after_refund() public {
+        _configure();
+        _accrue(100e18);
+        _contribute(alice, 1e18);
+        vm.prank(creator);
+        module.refund(agent);
+        vm.warp(START + WINDOW);
+        vm.prank(creator);
+        vm.expectRevert(SixtyDaysModule.NotOpen.selector);
+        module.commit(agent);
+    }
+
+    // ---------------------------------------------------------------------
+    // refund
+    // ---------------------------------------------------------------------
+
+    function test_refund_only_creator() public {
+        _configure();
+        _accrue(100e18);
+        vm.prank(alice);
+        vm.expectRevert(SixtyDaysModule.NotCreator.selector);
+        module.refund(agent);
+    }
+
+    function test_refund_happy_before_window_seeds_pool() public {
+        _configure();
+        _accrue(100e18);
+        _contribute(alice, 30e18);
+        _contribute(bob, 70e18);
+
+        vm.expectEmit(true, true, false, true, address(module));
+        emit SixtyDaysModule.Refunded(agent, creator, 100e18);
+        vm.prank(creator);
+        module.refund(agent);
+
+        assertEq(uint256(module.phaseOf(agent)), uint256(PHASE_REFUNDING));
+        (,,,,,,,, uint256 pool,) = module.configs(agent);
+        assertEq(pool, 100e18);
+        assertEq(escrowToken.balanceOf(address(module)), 100e18);
+    }
+
+    function test_refund_happy_after_window_still_works() public {
+        _configure();
+        _accrue(100e18);
+        _contribute(alice, 100e18);
+        vm.warp(START + WINDOW + 100);
+        vm.prank(creator);
+        module.refund(agent);
+        assertEq(uint256(module.phaseOf(agent)), uint256(PHASE_REFUNDING));
+    }
+
+    function test_refund_reverts_double() public {
+        _configure();
+        _accrue(100e18);
+        _contribute(alice, 1e18);
+        vm.prank(creator);
+        module.refund(agent);
+        vm.prank(creator);
+        vm.expectRevert(SixtyDaysModule.NotOpen.selector);
+        module.refund(agent);
+    }
+
+    function test_refund_reverts_after_commit() public {
+        _configure();
+        _accrue(100e18);
+        vm.warp(START + WINDOW);
+        vm.prank(creator);
+        module.commit(agent);
+        vm.prank(creator);
+        vm.expectRevert(SixtyDaysModule.NotOpen.selector);
+        module.refund(agent);
+    }
+
+    // ---------------------------------------------------------------------
+    // accrueRefundPool
+    // ---------------------------------------------------------------------
+
+    function test_accrueRefundPool_only_curve() public {
+        _configure();
+        _accrue(100e18);
+        _contribute(alice, 1e18);
+        vm.prank(creator);
+        module.refund(agent);
+
+        escrowToken.mint(alice, 50e18);
+        vm.prank(alice);
+        escrowToken.approve(address(module), 50e18);
+        vm.prank(alice);
+        vm.expectRevert(SixtyDaysModule.NotBondingCurve.selector);
+        module.accrueRefundPool(agent, 50e18);
+    }
+
+    function test_accrueRefundPool_reverts_when_not_refunding() public {
+        _configure();
+        escrowToken.mint(curve, 50e18);
+        vm.prank(curve);
+        escrowToken.approve(address(module), 50e18);
+        vm.prank(curve);
+        vm.expectRevert(SixtyDaysModule.NotRefunding.selector);
+        module.accrueRefundPool(agent, 50e18);
+    }
+
+    function test_accrueRefundPool_reverts_zero_amount() public {
+        _configure();
+        _accrue(10e18);
+        _contribute(alice, 1e18);
+        vm.prank(creator);
+        module.refund(agent);
+        vm.prank(curve);
+        vm.expectRevert(SixtyDaysModule.ZeroAmount.selector);
+        module.accrueRefundPool(agent, 0);
+    }
+
+    function test_accrueRefundPool_pulls_and_emits() public {
+        _configure();
+        _accrue(100e18); // escrow = 100
+        _contribute(alice, 1e18);
+        vm.prank(creator);
+        module.refund(agent); // pool seeded at 100
+
+        escrowToken.mint(curve, 50e18);
+        vm.prank(curve);
+        escrowToken.approve(address(module), 50e18);
+
+        vm.expectEmit(true, false, false, true, address(module));
+        emit SixtyDaysModule.RefundPoolToppedUp(agent, 50e18, 150e18);
+        vm.prank(curve);
+        module.accrueRefundPool(agent, 50e18);
+
+        (,,,,,,,, uint256 pool,) = module.configs(agent);
+        assertEq(pool, 150e18);
+        assertEq(escrowToken.balanceOf(address(module)), 150e18);
+    }
+
+    // ---------------------------------------------------------------------
+    // claimRefund
+    // ---------------------------------------------------------------------
+
+    function _setupRefundScenario(uint256 a, uint256 b, uint256 escrow) internal {
+        _configure();
+        _accrue(escrow);
+        _contribute(alice, a);
+        _contribute(bob, b);
+        vm.prank(creator);
+        module.refund(agent);
+    }
+
+    function test_claimRefund_pro_rata_split() public {
+        // Alice 30, Bob 70 → escrow 100 → Alice 30, Bob 70.
+        _setupRefundScenario(30e18, 70e18, 100e18);
+
+        vm.expectEmit(true, true, false, true, address(module));
+        emit SixtyDaysModule.RefundClaimed(agent, alice, 30e18);
+        vm.prank(alice);
+        uint256 a = module.claimRefund(agent);
+        assertEq(a, 30e18);
+        assertEq(escrowToken.balanceOf(alice), 30e18);
+
+        vm.prank(bob);
+        uint256 b = module.claimRefund(agent);
+        assertEq(b, 70e18);
+        assertEq(escrowToken.balanceOf(bob), 70e18);
+
+        // Pool fully drained (no rounding dust at these magnitudes).
+        assertEq(escrowToken.balanceOf(address(module)), 0);
+    }
+
+    function test_claimRefund_includes_topup() public {
+        _setupRefundScenario(50e18, 50e18, 100e18);
+
+        // Curve drains 100 of residual reserves into the pool. Total now 200.
+        escrowToken.mint(curve, 100e18);
+        vm.prank(curve);
+        escrowToken.approve(address(module), 100e18);
+        vm.prank(curve);
+        module.accrueRefundPool(agent, 100e18);
+
+        vm.prank(alice);
+        uint256 a = module.claimRefund(agent);
+        vm.prank(bob);
+        uint256 b = module.claimRefund(agent);
+        assertEq(a, 100e18);
+        assertEq(b, 100e18);
+        assertEq(escrowToken.balanceOf(address(module)), 0);
+    }
+
+    function test_claimRefund_reverts_when_not_in_refund_phase() public {
+        _configure();
+        _contribute(alice, 100e18);
+        vm.prank(alice);
+        vm.expectRevert(SixtyDaysModule.NotInRefundPhase.selector);
+        module.claimRefund(agent);
+    }
+
+    function test_claimRefund_reverts_already_claimed() public {
+        _setupRefundScenario(50e18, 50e18, 80e18);
+        vm.prank(alice);
+        module.claimRefund(agent);
+        vm.prank(alice);
+        vm.expectRevert(SixtyDaysModule.AlreadyClaimed.selector);
+        module.claimRefund(agent);
+    }
+
+    function test_claimRefund_reverts_no_contribution() public {
+        _setupRefundScenario(50e18, 50e18, 80e18);
+        vm.prank(carol);
+        vm.expectRevert(SixtyDaysModule.NoContribution.selector);
+        module.claimRefund(agent);
+    }
+
+    function test_claimRefund_reverts_zero_share_floors() public {
+        // Single buyer of 1 wei against a refund pool of 0 -> share = 0 -> revert.
+        _configure();
+        // No accrue — escrow stays 0. Contributor present.
+        _contribute(alice, 1e18);
+        vm.prank(creator);
+        module.refund(agent); // pool = 0
+
+        vm.prank(alice);
+        vm.expectRevert(SixtyDaysModule.NoContribution.selector);
+        module.claimRefund(agent);
+    }
+
+    // ---------------------------------------------------------------------
+    // previewRefund
+    // ---------------------------------------------------------------------
+
+    function test_previewRefund_matches_claim() public {
+        _setupRefundScenario(40e18, 60e18, 100e18);
+        uint256 pa = module.previewRefund(agent, alice);
+        uint256 pb = module.previewRefund(agent, bob);
+        uint256 pc = module.previewRefund(agent, carol);
+        assertEq(pa, 40e18);
+        assertEq(pb, 60e18);
+        assertEq(pc, 0);
+
+        vm.prank(alice);
+        uint256 actual = module.claimRefund(agent);
+        assertEq(actual, pa);
+        assertEq(module.previewRefund(agent, alice), 0);
+    }
+
+    function test_previewRefund_zero_when_not_refunding() public {
+        _configure();
+        _contribute(alice, 100e18);
+        assertEq(module.previewRefund(agent, alice), 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Reentrancy probe
+    // ---------------------------------------------------------------------
+
+    function test_reentrancy_blocked_on_claimRefund() public {
+        // Use a reentrant token as the escrow asset; arm it to call
+        // claimRefund again from inside the outbound transfer.
+        ReentrantToken r = new ReentrantToken();
+
+        SixtyDaysModule m = new SixtyDaysModule(factory);
+
+        vm.prank(factory);
+        m.configure(agent, address(r), curve, creator, START);
+
+        // Curve accrues 100 of the reentrant token.
+        r.mint(curve, 100e18);
+        vm.prank(curve);
+        r.approve(address(m), 100e18);
+        vm.prank(curve);
+        m.accrueEscrow(agent, 100e18);
+
+        // Alice and Bob each contribute 50 quote.
+        vm.prank(curve);
+        m.recordContribution(agent, alice, 50e18);
+        vm.prank(curve);
+        m.recordContribution(agent, bob, 50e18);
+
+        // Creator opens refund.
+        vm.prank(creator);
+        m.refund(agent);
+
+        // Arm the token so the next transfer to alice triggers a re-entrant
+        // claimRefund(agent) from alice. The inner call must revert via the
+        // ReentrancyGuard, and that revert must bubble up.
+        r.arm(address(m), abi.encodeCall(m.claimRefund, (agent)));
+
+        vm.prank(alice);
+        // OZ ReentrancyGuard reverts with `ReentrancyGuardReentrantCall()`.
+        vm.expectRevert();
+        m.claimRefund(agent);
+
+        // State unchanged: alice did not actually claim because the outer call
+        // reverted atomically.
+        assertEq(r.balanceOf(alice), 0);
+        assertFalse(m.claimed(agent, alice));
+    }
+
+    // ---------------------------------------------------------------------
+    // Fuzz: pull-pattern solvency
+    // ---------------------------------------------------------------------
+
+    /// @dev Five buyers with fuzzed contributions, escrow pool fuzzed too. The
+    ///      sum of all paid-out claims must never exceed the seeded refund pool
+    ///      (rounding floors are in the contract's favour).
+    function testFuzz_sum_claims_le_pool(uint96[5] memory contribs, uint96 escrow) public {
+        address[5] memory users = [address(0xA1), address(0xA2), address(0xA3), address(0xA4), address(0xA5)];
+        _configure();
+
+        uint256 esc = bound(uint256(escrow), 0, 1_000_000e18);
+        if (esc != 0) {
+            escrowToken.mint(curve, esc);
+            vm.prank(curve);
+            escrowToken.approve(address(module), esc);
+            vm.prank(curve);
+            module.accrueEscrow(agent, esc);
+        }
+
+        for (uint256 i = 0; i < 5; i++) {
+            uint256 a = bound(uint256(contribs[i]), 1, 1_000_000e18);
+            vm.prank(curve);
+            module.recordContribution(agent, users[i], a);
+        }
+
+        vm.prank(creator);
+        module.refund(agent);
+
+        uint256 paid;
+        for (uint256 i = 0; i < 5; i++) {
+            uint256 preview = module.previewRefund(agent, users[i]);
+            if (preview == 0) continue;
+            vm.prank(users[i]);
+            paid += module.claimRefund(agent);
+        }
+        assertLe(paid, esc, "sum of claims exceeds pool");
+        // Module retains only the floor-dust; never goes negative.
+        assertEq(escrowToken.balanceOf(address(module)), esc - paid);
+    }
+}


### PR DESCRIPTION
## Summary
- New `SixtyDaysModule.sol` — per-agent escrow of the 70% creator-leg fee for 60 days, shared across the agent fleet.
- After day 60 the creator either `commit()` (unlocks fee to creator) or `refund()` (opens a pull-pattern claim; buyers pull pro-rata; curve drains pre-graduation reserves into the same pool via `accrueRefundPool`).
- One shared deployment, per-agent config like the existing modules; one-shot phase transitions; CEI + ReentrancyGuard on every token-moving path.

## Why
Gives creators a reversible-launch escape valve so they cannot rug fees instantly while still giving good-faith launches a clean unlock path. Required for M2 module parity with the spec.

## Test plan
- [x] `forge fmt --check`
- [x] `forge test --match-path test/unit/SixtyDaysModule.t.sol` — 44/44 pass (incl. 256-run fuzz + reentrancy probe)
- [x] full suite `forge test` — 249/249 pass
- [x] `forge coverage` on the new contract — 100% lines / statements / branches / functions
- [x] `slither src/launchpad/modules/SixtyDaysModule.sol` — 0 findings
- [ ] integration with FeeRouter + BondingCurve in follow-up PR

Closes #34