### PR TITLE
feat(launchpad): add capital formation milestone payouts

### DIFF
--- a/contracts/evm/src/launchpad/interfaces/IUniswapV2Pair.sol
+++ b/contracts/evm/src/launchpad/interfaces/IUniswapV2Pair.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title  IUniswapV2Pair
+/// @notice Minimal Uniswap V2 pair interface. Only the read methods consumed
+///         by launchpad modules are declared.
+/// @dev    The pair stores `price0CumulativeLast` and `price1CumulativeLast`
+///         as UQ112x112 fixed-point cumulatives integrated over time. To
+///         derive a Time-Weighted Average Price (TWAP), a consumer takes two
+///         snapshots `(cumulative_t0, t0)` and `(cumulative_t1, t1)` and
+///         computes:
+///             priceAvg = (cumulative_t1 - cumulative_t0) / (t1 - t0)
+///         The cumulatives are intentionally allowed to overflow modulo
+///         2^256: the subtraction wraps cleanly so consumers MUST use
+///         unchecked subtraction when reading them.
+interface IUniswapV2Pair {
+    /// @notice Address of `token0`, the lexicographically smaller token in
+    ///         the pair.
+    function token0() external view returns (address);
+
+    /// @notice Address of `token1`, the lexicographically larger token in
+    ///         the pair.
+    function token1() external view returns (address);
+
+    /// @notice Current reserves and the block timestamp of the last sync.
+    /// @return reserve0           Reserve of `token0`.
+    /// @return reserve1           Reserve of `token1`.
+    /// @return blockTimestampLast uint32-wrapped timestamp of the last
+    ///                            state-mutating interaction with the pair.
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+
+    /// @notice Cumulative `price0 = reserve1/reserve0` integrated over time
+    ///         in UQ112x112 fixed-point. Wraps modulo 2^256 by design.
+    function price0CumulativeLast() external view returns (uint256);
+
+    /// @notice Cumulative `price1 = reserve0/reserve1` integrated over time
+    ///         in UQ112x112 fixed-point. Wraps modulo 2^256 by design.
+    function price1CumulativeLast() external view returns (uint256);
+}

--- a/contracts/evm/src/launchpad/modules/CapitalFormationModule.sol
+++ b/contracts/evm/src/launchpad/modules/CapitalFormationModule.sol
@@ -1,0 +1,540 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {IUniswapV2Pair} from "../interfaces/IUniswapV2Pair.sol";
+
+/// @title  CapitalFormationModule
+/// @notice Per-agent USDC payouts released to the agent creator when the post-
+///         graduation Uniswap V2 pair's TWAP-implied FDV crosses a milestone
+///         tier. Up to four tiers per agent (matching the protocol-level
+///         $2M / $10M / $50M / $160M FDV ladder); each tier may be claimed
+///         exactly once.
+/// @dev    Single shared deployment across the agent fleet; the launchpad
+///         factory owns it and binds per-agent state via {configure}. The
+///         module is fully self-contained: it does not hit any external
+///         oracle and does not depend on the rest of the launchpad. It pulls
+///         the FDV from one place — the agent's V2 pair — and pays out from
+///         a USDC balance pre-deposited by the configurer.
+///
+///         ## Funding model — pre-deposit
+///         The module is funded via direct ERC-20 transfer of the payout
+///         token at configure time. {configure}'s caller MUST `transfer`
+///         the full sum of `payoutsUsdc[i]` to this contract before (or in
+///         the same tx as) the configure call. We deliberately picked
+///         pre-deposit over a pull-from-treasury model:
+///           - one fewer external integration (no allowance dance, no
+///             treasury contract dependency at module deploy time);
+///           - escrow solvency is a pure on-chain invariant
+///             (`balance >= sum(unclaimed payouts)` per agent ledger);
+///           - permissionless {claim} can never be DoS'd by a treasury
+///             rugging its allowance.
+///         The trade-off is that the operator must front the worst-case
+///         payout up front, but that is acceptable for a milestone-payout
+///         system whose entire point is committed-stake credibility.
+///
+///         ## TWAP — two-step claim
+///         Spot reserves are sandwich-vulnerable, so {claim} reads a TWAP
+///         derived from `priceCumulativeLast` between two snapshots:
+///           1. Anyone calls {snapshot(agent)} — stores
+///              `(priceCumulative, blockTimestampLast, blockNumber)` from
+///              the pair, capped at the current block.
+///           2. After at least {MIN_TWAP_BLOCKS} new blocks AND a non-zero
+///              elapsed-second window, anyone calls {claim(agent, tier)}.
+///         The 32-block / ~64s window on Base raises the cost of pair
+///         manipulation to ~32 blocks of held inventory, which any flash
+///         loan path cannot bridge. After a successful claim the snapshot
+///         is consumed; subsequent claims must take a fresh snapshot.
+///
+///         ## CEI + reentrancy
+///         {claim} sets the tier-claimed bit BEFORE the outbound USDC
+///         transfer and is wrapped in {ReentrancyGuard}. {SafeERC20} is
+///         used so non-standard ERC-20s (e.g. USDC) cannot silently fail.
+contract CapitalFormationModule is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ---------------------------------------------------------------------
+    // Types
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent immutable parameters bound at {configure}.
+    /// @param  agentToken     The agent ERC-20 (FDV multiplier).
+    /// @param  payoutToken    Token transferred to the creator on each
+    ///                        successful claim. USDC in production.
+    /// @param  pair           Uniswap V2 pair created at graduation; the
+    ///                        sole TWAP source.
+    /// @param  agentIsToken0  Cached side of the pair to spare a `token0()`
+    ///                        call on every claim.
+    /// @param  creator        Recipient of every claim.
+    /// @param  agentAdmin     Reserved for future admin operations (unused
+    ///                        in v1; stored to mirror the LaunchRadar /
+    ///                        Anti-Sniper module ABI shape).
+    /// @param  configured     One-shot flag.
+    /// @param  claimedBitmap  Four-bit bitmap, one bit per tier index.
+    ///                        Bit `i` set => tier `i` already paid.
+    struct Config {
+        address agentToken;
+        address payoutToken;
+        address pair;
+        bool agentIsToken0;
+        address creator;
+        address agentAdmin;
+        bool configured;
+        uint8 claimedBitmap;
+    }
+
+    /// @notice Per-agent TWAP cursor.
+    /// @param  priceCumulative      Consolidated cumulative at snapshot
+    ///                              time, cast to uint256 (UQ112x112
+    ///                              integrated over seconds).
+    /// @param  blockTimestampLast   Pair-reported timestamp at snapshot.
+    /// @param  blockNumber          `block.number` at snapshot. Used to
+    ///                              enforce the {MIN_TWAP_BLOCKS} window.
+    /// @param  exists               True iff a snapshot is currently held.
+    struct Snapshot {
+        uint256 priceCumulative;
+        uint32 blockTimestampLast;
+        uint64 blockNumber;
+        bool exists;
+    }
+
+    // ---------------------------------------------------------------------
+    // Constants
+    // ---------------------------------------------------------------------
+
+    /// @notice Hard upper bound on the per-agent tier count. The four-bit
+    ///         {Config.claimedBitmap} is sized to this.
+    uint8 public constant MAX_TIERS = 4;
+
+    /// @notice Minimum number of blocks that must elapse between a
+    ///         {snapshot} and the matching {claim}. ~64 seconds on Base.
+    ///         Picked to make a one-block sandwich impossible and to
+    ///         price out a multi-block manipulation by requiring an
+    ///         attacker to hold a lopsided pair for the full window.
+    uint64 public constant MIN_TWAP_BLOCKS = 32;
+
+    /// @dev   2**112. Uniswap V2 cumulatives are in UQ112x112 fixed point;
+    ///        dividing by `Q112` returns the raw integer ratio.
+    uint256 private constant Q112 = 0x10000000000000000000000000000;
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent configuration. Empty until {configure}.
+    mapping(address agent => Config) public configs;
+
+    /// @notice Per-agent FDV thresholds, in `payoutToken`-equivalent units
+    ///         derived from the pair quote side. Index `i` corresponds to
+    ///         claimed-bit `i`. Length is bounded by {MAX_TIERS}.
+    mapping(address agent => uint256[]) private _fdvThresholds;
+
+    /// @notice Per-agent payout amounts. Parallel to {_fdvThresholds}.
+    mapping(address agent => uint256[]) private _payouts;
+
+    /// @notice Per-agent live TWAP snapshot. Consumed on successful {claim}.
+    mapping(address agent => Snapshot) public snapshots;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @dev Emitted exactly once per agent on {configure}. `totalDeposit`
+    ///      is the sum of payouts the configurer must have transferred to
+    ///      this contract on or before this call.
+    event Configured(
+        address indexed agent,
+        address agentToken,
+        address payoutToken,
+        address pair,
+        address creator,
+        address agentAdmin,
+        uint256 tierCount,
+        uint256 totalDeposit
+    );
+
+    /// @dev Emitted on every {snapshot}. `blockNumber` is the soonest block
+    ///      from which a {claim} can succeed (after {MIN_TWAP_BLOCKS} more
+    ///      blocks).
+    event Snapshotted(address indexed agent, uint256 priceCumulative, uint32 blockTimestampLast, uint64 blockNumber);
+
+    /// @dev Emitted on every successful {claim}. `fdvUsd` is the TWAP-
+    ///      derived FDV at claim time; `payoutUsd` is the released amount.
+    event MilestoneClaimed(address indexed agent, uint8 indexed tier, uint256 fdvUsd, uint256 payoutUsd);
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev {configure} called twice for the same agent.
+    error AlreadyConfigured();
+    /// @dev A constructor / config argument was the zero address.
+    error ZeroAddress();
+    /// @dev `agent` was never configured.
+    error NotConfigured();
+    /// @dev Tier arrays were of different length.
+    error LengthMismatch();
+    /// @dev Tier count was zero or above {MAX_TIERS}.
+    error InvalidTierCount();
+    /// @dev FDV thresholds were not strictly increasing.
+    error ThresholdsNotIncreasing();
+    /// @dev A tier specified a zero payout.
+    error ZeroPayout();
+    /// @dev `agentToken_` was not one of the pair's tokens.
+    error PairTokenMismatch();
+    /// @dev `pair_` returned zero reserves at configure time.
+    error PairUninitialized();
+    /// @dev Caller did not pre-fund the configured payout sum.
+    error InsufficientFunding(uint256 expected, uint256 actual);
+    /// @dev Tier index was outside `[0, tierCount)`.
+    error TierOutOfRange();
+    /// @dev Tier was already paid.
+    error TierAlreadyClaimed();
+    /// @dev {claim} called without a live {snapshot}.
+    error SnapshotMissing();
+    /// @dev {claim} called too soon after {snapshot}; window not met.
+    error TwapWindowTooShort(uint64 elapsedBlocks, uint64 required);
+    /// @dev Pair did not advance its `blockTimestampLast` between snapshot
+    ///      and claim — TWAP would divide by zero.
+    error PairTooYoung();
+    /// @dev TWAP-implied FDV is below the tier threshold.
+    error FdvBelowThreshold(uint256 fdv, uint256 threshold);
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @param owner_ Initial owner. Expected to be the launchpad factory
+    ///               (or a Safe acting as it) so that only the factory
+    ///               binds milestone schedules to live agents.
+    constructor(address owner_) Ownable(_validatedOwner(owner_)) {}
+
+    /// @dev Surface our canonical {ZeroAddress} instead of OZ's
+    ///      `OwnableInvalidOwner` for missing addresses at construction.
+    function _validatedOwner(address owner_) private pure returns (address) {
+        if (owner_ == address(0)) revert ZeroAddress();
+        return owner_;
+    }
+
+    // ---------------------------------------------------------------------
+    // Admin
+    // ---------------------------------------------------------------------
+
+    /// @notice Bind an agent's milestone schedule. One-shot per agent.
+    /// @dev    Caller MUST have transferred `sum(payoutsUsdc) - alreadyHeld`
+    ///         of `payoutToken_` to this contract before this call (where
+    ///         `alreadyHeld` is the contract's pre-existing balance net of
+    ///         every other agent's outstanding obligations — but in the
+    ///         common case the configurer just transfers the full sum
+    ///         atomically). We do NOT track per-agent sub-balances on-chain
+    ///         beyond the global `balanceOf(this)`; the invariant is:
+    ///
+    ///             balanceOf(this) >= sum over all agents of
+    ///                 sum over unclaimed tiers of payouts[agent][tier]
+    ///
+    ///         Off-chain monitors enforce this. The module is owner-gated
+    ///         specifically so the operator can guarantee total deposit
+    ///         covers total liability across agents.
+    /// @param  agent          Agent contract being configured.
+    /// @param  agentToken_    The agent ERC-20.
+    /// @param  payoutToken_   USDC (or whatever the protocol denominates
+    ///                        milestone payouts in).
+    /// @param  pair_          Uniswap V2 pair created for this agent at
+    ///                        graduation. MUST already hold non-zero
+    ///                        reserves on both sides.
+    /// @param  creator_       Recipient of every claim.
+    /// @param  agentAdmin_    Per-agent admin address. Stored for future
+    ///                        ABI parity with sister modules; unused in v1.
+    /// @param  fdvThresholds  Strictly increasing FDV thresholds, in pair-
+    ///                        quote-token units (the configurer is
+    ///                        responsible for picking quote-units that
+    ///                        match how the protocol denominates "USD",
+    ///                        e.g. 1:1 with USDC if pair quote is USDC,
+    ///                        or pre-converted via the launch oracle if
+    ///                        pair quote is TITU).
+    /// @param  payoutsUsdc    Parallel array of payout amounts, in
+    ///                        `payoutToken_` wei.
+    function configure(
+        address agent,
+        address agentToken_,
+        address payoutToken_,
+        address pair_,
+        address creator_,
+        address agentAdmin_,
+        uint256[] calldata fdvThresholds,
+        uint256[] calldata payoutsUsdc
+    ) external onlyOwner {
+        if (
+            agent == address(0) || agentToken_ == address(0) || payoutToken_ == address(0) || pair_ == address(0)
+                || creator_ == address(0) || agentAdmin_ == address(0)
+        ) revert ZeroAddress();
+        if (configs[agent].configured) revert AlreadyConfigured();
+        if (fdvThresholds.length != payoutsUsdc.length) revert LengthMismatch();
+        if (fdvThresholds.length == 0 || fdvThresholds.length > MAX_TIERS) revert InvalidTierCount();
+
+        bool agentIsToken0 = _validatePair(pair_, agentToken_);
+        uint256 totalDeposit = _writeTiers(agent, fdvThresholds, payoutsUsdc);
+        _reserveFunding(payoutToken_, totalDeposit);
+
+        configs[agent] = Config({
+            agentToken: agentToken_,
+            payoutToken: payoutToken_,
+            pair: pair_,
+            agentIsToken0: agentIsToken0,
+            creator: creator_,
+            agentAdmin: agentAdmin_,
+            configured: true,
+            claimedBitmap: 0
+        });
+
+        emit Configured(
+            agent, agentToken_, payoutToken_, pair_, creator_, agentAdmin_, fdvThresholds.length, totalDeposit
+        );
+    }
+
+    /// @dev Resolve which side of the pair the agent token is on and
+    ///      assert the pair has non-zero reserves. Reverts with
+    ///      {PairTokenMismatch} or {PairUninitialized}. The
+    ///      `blockTimestampLast` returned by `getReserves()` is intentionally
+    ///      ignored — staleness is only relevant on the TWAP path. The
+    ///      tuple destructure is the Uniswap V2 idiom; slither's
+    ///      unused-return warning is not actionable.
+    // slither-disable-next-line unused-return
+    function _validatePair(address pair_, address agentToken_) private view returns (bool agentIsToken0) {
+        IUniswapV2Pair pair = IUniswapV2Pair(pair_);
+        address t0 = pair.token0();
+        if (t0 == agentToken_) {
+            agentIsToken0 = true;
+        } else if (pair.token1() == agentToken_) {
+            agentIsToken0 = false;
+        } else {
+            revert PairTokenMismatch();
+        }
+        (uint112 r0, uint112 r1,) = pair.getReserves();
+        if (r0 == 0 || r1 == 0) revert PairUninitialized();
+    }
+
+    /// @dev Validate + persist tier arrays. Returns the sum of payouts so
+    ///      the caller can reserve funding atomically.
+    function _writeTiers(address agent, uint256[] calldata fdvThresholds, uint256[] calldata payoutsUsdc)
+        private
+        returns (uint256 totalDeposit)
+    {
+        // Explicit zero init silences slither's uninitialized-local warning;
+        // the strictly-increasing check on i == 0 also rejects threshold == 0.
+        uint256 prev = 0;
+        uint256 n = fdvThresholds.length;
+        for (uint256 i; i < n; ++i) {
+            uint256 thr = fdvThresholds[i];
+            uint256 pay = payoutsUsdc[i];
+            if (i == 0) {
+                if (thr == 0) revert ThresholdsNotIncreasing();
+            } else if (thr <= prev) {
+                revert ThresholdsNotIncreasing();
+            }
+            if (pay == 0) revert ZeroPayout();
+            prev = thr;
+            totalDeposit += pay;
+            _fdvThresholds[agent].push(thr);
+            _payouts[agent].push(pay);
+        }
+    }
+
+    /// @dev Increment the per-token outstanding-obligation ledger after
+    ///      asserting the contract holds enough free balance to cover it.
+    function _reserveFunding(address payoutToken_, uint256 totalDeposit) private {
+        uint256 free = IERC20(payoutToken_).balanceOf(address(this)) - _outstanding[payoutToken_];
+        if (free < totalDeposit) revert InsufficientFunding(totalDeposit, free);
+        _outstanding[payoutToken_] += totalDeposit;
+    }
+
+    // ---------------------------------------------------------------------
+    // Snapshot / claim
+    // ---------------------------------------------------------------------
+
+    /// @notice Take a fresh TWAP snapshot for `agent`. Permissionless. The
+    ///         next {claim} for this agent uses the difference between
+    ///         this snapshot and a fresh on-chain read, so a {snapshot}
+    ///         must precede every {claim} by at least {MIN_TWAP_BLOCKS}
+    ///         blocks. Calling {snapshot} again before claiming overwrites
+    ///         the prior snapshot.
+    /// @dev    Reads `priceCumulativeLast` and `blockTimestampLast`
+    ///         directly from the pair without extrapolating to
+    ///         `block.timestamp`. We deliberately do NOT extrapolate:
+    ///         consuming the pair's last-sync timestamp keeps the snapshot
+    ///         math symmetric with {claim} and means a stale pair
+    ///         (no swaps in the window) is detected via {PairTooYoung}
+    ///         rather than silently averaging over the wrong window.
+    // slither-disable-next-line unused-return
+    function snapshot(address agent) external {
+        Config memory cfg = configs[agent];
+        if (!cfg.configured) revert NotConfigured();
+
+        IUniswapV2Pair pair = IUniswapV2Pair(cfg.pair);
+        // Reserves are intentionally dropped; only the timestamp matters
+        // for snapshot freshness. See {_validatePair} for the same pattern.
+        (,, uint32 ts) = pair.getReserves();
+        uint256 cum = cfg.agentIsToken0 ? pair.price0CumulativeLast() : pair.price1CumulativeLast();
+
+        snapshots[agent] =
+            Snapshot({priceCumulative: cum, blockTimestampLast: ts, blockNumber: uint64(block.number), exists: true});
+
+        emit Snapshotted(agent, cum, ts, uint64(block.number));
+    }
+
+    /// @notice Release tier `tier`'s payout to the agent's creator.
+    /// @dev    Permissionless poke. Funds always route to the creator
+    ///         recorded at configure time. Steps:
+    ///           1. Validate config + tier index + not-already-claimed.
+    ///           2. Require a live snapshot at least {MIN_TWAP_BLOCKS}
+    ///              blocks old.
+    ///           3. Read fresh `priceCumulative` + `blockTimestampLast`;
+    ///              compute the TWAP. The pair's timestamp is used (not
+    ///              `block.timestamp`) so that a pair that has not synced
+    ///              since the snapshot reverts via {PairTooYoung} instead
+    ///              of pretending an updated price.
+    ///           4. Compute FDV = `twap * agentTotalSupply / Q112`.
+    ///           5. Require FDV >= tier threshold.
+    ///           6. Effects: flip claimed bit, decrement outstanding ledger,
+    ///              consume snapshot.
+    ///           7. Interactions: `safeTransfer` payout to creator.
+    function claim(address agent, uint8 tier) external nonReentrant {
+        Config storage cfg = configs[agent];
+        if (!cfg.configured) revert NotConfigured();
+
+        uint256[] storage thresholds = _fdvThresholds[agent];
+        if (tier >= thresholds.length) revert TierOutOfRange();
+
+        uint8 mask = uint8(1) << tier;
+        if (cfg.claimedBitmap & mask != 0) revert TierAlreadyClaimed();
+
+        // TWAP + FDV reads pulled into a helper to keep the stack shallow
+        // here: solc 0.8.26 hits stack-too-deep otherwise.
+        uint256 fdvUsd = _twapFdv(cfg, agent);
+
+        uint256 threshold = thresholds[tier];
+        if (fdvUsd < threshold) revert FdvBelowThreshold(fdvUsd, threshold);
+
+        uint256 payout = _payouts[agent][tier];
+
+        // --- Effects ---
+        cfg.claimedBitmap |= mask;
+        delete snapshots[agent];
+        _outstanding[cfg.payoutToken] -= payout;
+
+        // --- Interactions ---
+        IERC20(cfg.payoutToken).safeTransfer(cfg.creator, payout);
+
+        emit MilestoneClaimed(agent, tier, fdvUsd, payout);
+    }
+
+    /// @dev Compute the TWAP-derived FDV for `agent`. Reverts with
+    ///      {SnapshotMissing}, {TwapWindowTooShort}, or {PairTooYoung}
+    ///      if the snapshot/pair state cannot produce a valid TWAP. See
+    ///      {claim} for the rationale on each revert path.
+    /// @dev Uses the pair's own `blockTimestampLast` rather than
+    ///      `block.timestamp`, mirroring the official Uniswap V2 oracle
+    ///      pattern; slither flags the read but the value is consumed
+    ///      only as a divisor and an explicit zero-divisor check below
+    ///      handles the freshness case.
+    /// @dev Multiple slither warnings are intentional and benign:
+    ///      - `unused-return` on `getReserves()`: only the timestamp is
+    ///        consumed here; reserves are not needed because the TWAP
+    ///        comes from `priceXCumulativeLast`, not the spot ratio.
+    ///      - `incorrect-equality` on `elapsedSecs == 0`: we are
+    ///        deliberately gating on a precise zero-second delta to
+    ///        detect a stale pair (`tsNow == s.blockTimestampLast`),
+    ///        which is exactly what {PairTooYoung} signals.
+    ///      - `divide-before-multiply` on the FDV math: the cumulative
+    ///        delta is a UQ112x112-times-seconds quantity that exceeds
+    ///        2^225, so multiplying it by `supply` (~2^90) before
+    ///        dividing by `elapsedSecs` overflows uint256. The
+    ///        cumulative-divided-then-multiplied ordering is the
+    ///        standard Uniswap V2 oracle recipe and the precision loss
+    ///        on the second step is the same fixed-point floor the
+    ///        protocol accepts elsewhere.
+    // slither-disable-next-line timestamp,incorrect-equality,divide-before-multiply,unused-return
+    function _twapFdv(Config storage cfg, address agent) private view returns (uint256 fdvUsd) {
+        Snapshot memory s = snapshots[agent];
+        if (!s.exists) revert SnapshotMissing();
+
+        uint64 elapsedBlocks = uint64(block.number) - s.blockNumber;
+        if (elapsedBlocks < MIN_TWAP_BLOCKS) {
+            revert TwapWindowTooShort(elapsedBlocks, MIN_TWAP_BLOCKS);
+        }
+
+        // Re-read the pair. Use its OWN last-sync timestamp; if the pair
+        // has not been touched since the snapshot, ts == s.blockTimestampLast
+        // and the divisor is zero → revert {PairTooYoung}.
+        IUniswapV2Pair pair = IUniswapV2Pair(cfg.pair);
+        (,, uint32 tsNow) = pair.getReserves();
+        // uint32 wraparound is allowed by Uniswap V2 spec; mirror with
+        // unchecked subtraction so a wrap during the window still yields
+        // the correct delta.
+        uint32 elapsedSecs;
+        unchecked {
+            elapsedSecs = tsNow - s.blockTimestampLast;
+        }
+        if (elapsedSecs == 0) revert PairTooYoung();
+
+        uint256 cumNow = cfg.agentIsToken0 ? pair.price0CumulativeLast() : pair.price1CumulativeLast();
+        // Cumulative is allowed to overflow modulo 2^256; mirror with
+        // unchecked subtraction so the wrap-around is preserved.
+        uint256 cumDelta;
+        unchecked {
+            cumDelta = cumNow - s.priceCumulative;
+        }
+
+        // priceAvgQ112 is "quote per agent" in UQ112x112.
+        uint256 priceAvgQ112 = cumDelta / uint256(elapsedSecs);
+
+        // FDV in quote-token wei = priceAvg * totalSupply.
+        uint256 supply = IERC20(cfg.agentToken).totalSupply();
+        fdvUsd = (priceAvgQ112 * supply) / Q112;
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice True iff tier `tier` has been claimed for `agent`.
+    function isClaimed(address agent, uint8 tier) external view returns (bool) {
+        if (tier >= MAX_TIERS) return false;
+        return configs[agent].claimedBitmap & (uint8(1) << tier) != 0;
+    }
+
+    /// @notice Number of tiers configured for `agent`.
+    function tierCount(address agent) external view returns (uint256) {
+        return _fdvThresholds[agent].length;
+    }
+
+    /// @notice Read tier `tier`'s threshold + payout for `agent`.
+    /// @return threshold FDV threshold in pair-quote units.
+    /// @return payout    Payout amount in `payoutToken` wei.
+    function tierAt(address agent, uint8 tier) external view returns (uint256 threshold, uint256 payout) {
+        uint256[] storage thresholds = _fdvThresholds[agent];
+        if (tier >= thresholds.length) revert TierOutOfRange();
+        threshold = thresholds[tier];
+        payout = _payouts[agent][tier];
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal — escrow ledger
+    // ---------------------------------------------------------------------
+
+    /// @dev Sum of unclaimed payouts denominated in each payout token.
+    ///      Lets {configure} reject configurations that would over-commit
+    ///      the on-hand balance, while still supporting many agents
+    ///      sharing the same payout-token balance.
+    mapping(address payoutToken => uint256) internal _outstanding;
+
+    /// @notice Public view of the per-token escrow ledger for off-chain
+    ///         solvency checks.
+    function outstanding(address payoutToken) external view returns (uint256) {
+        return _outstanding[payoutToken];
+    }
+}

--- a/contracts/evm/test/mocks/MockUniswapV2Pair.sol
+++ b/contracts/evm/test/mocks/MockUniswapV2Pair.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IUniswapV2Pair} from "../../src/launchpad/interfaces/IUniswapV2Pair.sol";
+
+/// @title  MockUniswapV2Pair
+/// @notice Minimal Uniswap V2 pair stand-in for launchpad unit tests.
+///         Exposes the `IUniswapV2Pair` read surface plus setters so tests
+///         can deterministically drive reserves AND the
+///         `priceXCumulativeLast` accumulators consumed by TWAP-based
+///         consumers like `CapitalFormationModule`.
+/// @dev    Cumulative semantics mirror the real pair: each call to
+///         {sync} advances the cumulatives by `priceX * timeElapsed` where
+///         `timeElapsed` is `currentTimestamp - blockTimestampLast`.
+///         Tests can either:
+///           (a) call {setReserves} for spot-only consumers that ignore
+///               the cumulatives;
+///           (b) call {sync} repeatedly across `vm.warp` jumps to grow
+///               the cumulatives the way a live pair would.
+///         Does NOT implement swap / mint / burn.
+contract MockUniswapV2Pair is IUniswapV2Pair {
+    uint256 private constant Q112 = 0x10000000000000000000000000000;
+
+    address private _token0;
+    address private _token1;
+    uint112 private _reserve0;
+    uint112 private _reserve1;
+    uint32 private _blockTimestampLast;
+    uint256 private _price0CumulativeLast;
+    uint256 private _price1CumulativeLast;
+
+    constructor(address tokenA, address tokenB) {
+        // Mirror the real pair's lexicographic ordering: token0 is the
+        // numerically smaller address.
+        (address t0, address t1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        _token0 = t0;
+        _token1 = t1;
+    }
+
+    /// @notice Hard-set reserves WITHOUT advancing cumulatives. Used by
+    ///         spot-only tests; callers that need TWAP semantics should
+    ///         use {sync} instead.
+    /// @dev    Stamps `block.timestamp` as last-sync time so the returned
+    ///         tuple looks fresh.
+    function setReserves(uint112 reserve0_, uint112 reserve1_) external {
+        _reserve0 = reserve0_;
+        _reserve1 = reserve1_;
+        _blockTimestampLast = uint32(block.timestamp);
+    }
+
+    /// @notice Update reserves AND advance the cumulatives over the time
+    ///         elapsed since the last {sync} / {setReserves} using the
+    ///         PRE-update reserves — i.e. the price the pair held during
+    ///         the elapsed window.
+    /// @dev    Models the real pair's `_update`. Cumulatives wrap modulo
+    ///         2^256 the same way: we use unchecked addition.
+    function sync(uint112 reserve0_, uint112 reserve1_) external {
+        uint32 blockTimestamp = uint32(block.timestamp);
+        uint32 timeElapsed;
+        unchecked {
+            // uint32 wrap mirrors Uniswap V2 behaviour.
+            timeElapsed = blockTimestamp - _blockTimestampLast;
+        }
+        if (timeElapsed > 0 && _reserve0 != 0 && _reserve1 != 0) {
+            // price0 = reserve1/reserve0 in UQ112x112 → (reserve1 << 112) / reserve0.
+            // price1 = reserve0/reserve1 in UQ112x112 → (reserve0 << 112) / reserve1.
+            unchecked {
+                _price0CumulativeLast += (uint256(_reserve1) * Q112 / uint256(_reserve0)) * uint256(timeElapsed);
+                _price1CumulativeLast += (uint256(_reserve0) * Q112 / uint256(_reserve1)) * uint256(timeElapsed);
+            }
+        }
+        _reserve0 = reserve0_;
+        _reserve1 = reserve1_;
+        _blockTimestampLast = blockTimestamp;
+    }
+
+    /// @notice Direct-write the cumulatives. Convenience for tests that
+    ///         want to skip the `sync`-warp dance and inject a precomputed
+    ///         delta straight into the accumulator.
+    function setCumulatives(uint256 p0, uint256 p1, uint32 ts) external {
+        _price0CumulativeLast = p0;
+        _price1CumulativeLast = p1;
+        _blockTimestampLast = ts;
+    }
+
+    function token0() external view returns (address) {
+        return _token0;
+    }
+
+    function token1() external view returns (address) {
+        return _token1;
+    }
+
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast) {
+        return (_reserve0, _reserve1, _blockTimestampLast);
+    }
+
+    function price0CumulativeLast() external view returns (uint256) {
+        return _price0CumulativeLast;
+    }
+
+    function price1CumulativeLast() external view returns (uint256) {
+        return _price1CumulativeLast;
+    }
+}

--- a/contracts/evm/test/unit/CapitalFormationModule.t.sol
+++ b/contracts/evm/test/unit/CapitalFormationModule.t.sol
@@ -1,0 +1,591 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import {CapitalFormationModule} from "../../src/launchpad/modules/CapitalFormationModule.sol";
+import {MockUniswapV2Pair} from "../mocks/MockUniswapV2Pair.sol";
+
+/// @dev Plain ERC-20 stand-in for USDC / agent token in unit tests.
+contract TestERC20 is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
+}
+
+/// @dev ERC-20 whose `transfer` re-enters the module. Used to confirm
+///      {ReentrancyGuard} stops a malicious payout token from re-entering
+///      {claim} during the outbound transfer.
+contract ReentrantPayoutToken is ERC20 {
+    CapitalFormationModule public target;
+    address public agent;
+    uint8 public tier;
+    bool public armed;
+
+    constructor() ERC20("Reenter", "RNT") {}
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
+
+    function arm(CapitalFormationModule t, address a, uint8 ti) external {
+        target = t;
+        agent = a;
+        tier = ti;
+        armed = true;
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        super._update(from, to, value);
+        if (armed && from == address(target)) {
+            armed = false; // single-shot to avoid recursion blow-up
+            target.claim(agent, tier);
+        }
+    }
+}
+
+/// @dev Unit tests for `CapitalFormationModule`. Exercises every external
+///      entrypoint, every revert path, the TWAP window, and the escrow
+///      ledger. Coverage target ≥ 90%.
+contract CapitalFormationModuleTest is Test {
+    CapitalFormationModule internal mod;
+    MockUniswapV2Pair internal pair;
+    TestERC20 internal usdc;
+    TestERC20 internal agentTok;
+
+    address internal owner = address(0xA0);
+    address internal attacker = address(0xBAD);
+    address internal creator = address(0xC0FFEE);
+    address internal agentAdmin = address(0xAD);
+    address internal agent = address(0xA1);
+
+    // FDV milestones: $2M, $10M, $50M, $160M (USDC = 6 decimals).
+    uint256 internal constant T1 = 2_000_000e6;
+    uint256 internal constant T2 = 10_000_000e6;
+    uint256 internal constant T3 = 50_000_000e6;
+    uint256 internal constant T4 = 160_000_000e6;
+
+    // Per-tier USDC payouts (illustrative).
+    uint256 internal constant P1 = 5000e6;
+    uint256 internal constant P2 = 25_000e6;
+    uint256 internal constant P3 = 100_000e6;
+    uint256 internal constant P4 = 500_000e6;
+
+    uint256 internal constant TOTAL_PAY = P1 + P2 + P3 + P4;
+
+    // 1B agent supply, 18 decimals.
+    uint256 internal constant SUPPLY = 1_000_000_000e18;
+
+    function setUp() public {
+        mod = new CapitalFormationModule(owner);
+        usdc = new TestERC20("USD Coin", "USDC");
+        agentTok = new TestERC20("Agent", "AGT");
+        agentTok.mint(address(this), SUPPLY); // owner-of-supply doesn't matter; we only read totalSupply.
+
+        // Build a pair with reserves seeded so {configure} passes the
+        // PairUninitialized check. Spot ratio ≈ $0.001 per agent token →
+        // FDV ≈ $1M (below T1 by default).
+        pair = new MockUniswapV2Pair(address(agentTok), address(usdc));
+        // Seed the pair with non-zero reserves so {configure} passes the
+        // PairUninitialized check. Spot ratio matches a tiny "$1M FDV"
+        // baseline; tests that need a specific FDV call {_setFdvUsd}.
+        // Reserves must fit in uint112; well within bounds.
+        _syncByRole(100_000_000e18, 100_000e6);
+    }
+
+    // ---------------------------------------------------------------------
+    // configure — happy + reverts
+    // ---------------------------------------------------------------------
+
+    function test_configure_happy_path_records_state_and_locks_escrow() public {
+        // Pre-fund.
+        usdc.mint(address(this), TOTAL_PAY);
+        usdc.transfer(address(mod), TOTAL_PAY);
+
+        vm.expectEmit(true, false, false, true, address(mod));
+        emit CapitalFormationModule.Configured(
+            agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, 4, TOTAL_PAY
+        );
+
+        vm.prank(owner);
+        mod.configure(
+            agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, _thresholds(), _payouts()
+        );
+
+        (address aTok, address pTok, address pr, bool isT0, address cr, address adm, bool configured, uint8 bitmap) =
+            mod.configs(agent);
+        assertEq(aTok, address(agentTok));
+        assertEq(pTok, address(usdc));
+        assertEq(pr, address(pair));
+        // token0 is whichever address is numerically smaller; we check
+        // against the pair's own report.
+        assertEq(isT0, pair.token0() == address(agentTok));
+        assertEq(cr, creator);
+        assertEq(adm, agentAdmin);
+        assertTrue(configured);
+        assertEq(uint256(bitmap), 0);
+
+        assertEq(mod.tierCount(agent), 4);
+        (uint256 thr0, uint256 pay0) = mod.tierAt(agent, 0);
+        assertEq(thr0, T1);
+        assertEq(pay0, P1);
+
+        assertEq(mod.outstanding(address(usdc)), TOTAL_PAY);
+    }
+
+    function test_configure_only_owner() public {
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        mod.configure(
+            agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, _thresholds(), _payouts()
+        );
+    }
+
+    function test_configure_reverts_already_configured() public {
+        _fundAndConfigure();
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.AlreadyConfigured.selector);
+        mod.configure(
+            agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, _thresholds(), _payouts()
+        );
+    }
+
+    function test_configure_reverts_zero_address() public {
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.ZeroAddress.selector);
+        mod.configure(
+            address(0), address(agentTok), address(usdc), address(pair), creator, agentAdmin, _thresholds(), _payouts()
+        );
+    }
+
+    function test_configure_reverts_length_mismatch() public {
+        usdc.mint(address(this), TOTAL_PAY);
+        usdc.transfer(address(mod), TOTAL_PAY);
+        uint256[] memory thrs = _thresholds();
+        uint256[] memory pays = new uint256[](3);
+        pays[0] = P1;
+        pays[1] = P2;
+        pays[2] = P3;
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.LengthMismatch.selector);
+        mod.configure(agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, thrs, pays);
+    }
+
+    function test_configure_reverts_tier_count_zero() public {
+        usdc.mint(address(this), TOTAL_PAY);
+        usdc.transfer(address(mod), TOTAL_PAY);
+        uint256[] memory empty = new uint256[](0);
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.InvalidTierCount.selector);
+        mod.configure(agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, empty, empty);
+    }
+
+    function test_configure_reverts_tier_count_exceeds_max() public {
+        uint256[] memory thrs = new uint256[](5);
+        uint256[] memory pays = new uint256[](5);
+        for (uint256 i; i < 5; ++i) {
+            thrs[i] = (i + 1) * 1e6;
+            pays[i] = 1e6;
+        }
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.InvalidTierCount.selector);
+        mod.configure(agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, thrs, pays);
+    }
+
+    function test_configure_reverts_thresholds_not_increasing() public {
+        usdc.mint(address(this), TOTAL_PAY);
+        usdc.transfer(address(mod), TOTAL_PAY);
+        uint256[] memory thrs = new uint256[](2);
+        thrs[0] = T2;
+        thrs[1] = T1; // descending
+        uint256[] memory pays = new uint256[](2);
+        pays[0] = P1;
+        pays[1] = P2;
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.ThresholdsNotIncreasing.selector);
+        mod.configure(agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, thrs, pays);
+    }
+
+    function test_configure_reverts_first_threshold_zero() public {
+        usdc.mint(address(this), TOTAL_PAY);
+        usdc.transfer(address(mod), TOTAL_PAY);
+        uint256[] memory thrs = new uint256[](2);
+        thrs[0] = 0;
+        thrs[1] = T1;
+        uint256[] memory pays = new uint256[](2);
+        pays[0] = P1;
+        pays[1] = P2;
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.ThresholdsNotIncreasing.selector);
+        mod.configure(agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, thrs, pays);
+    }
+
+    function test_configure_reverts_zero_payout() public {
+        usdc.mint(address(this), TOTAL_PAY);
+        usdc.transfer(address(mod), TOTAL_PAY);
+        uint256[] memory thrs = _thresholds();
+        uint256[] memory pays = new uint256[](4);
+        pays[0] = P1;
+        pays[1] = 0;
+        pays[2] = P3;
+        pays[3] = P4;
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.ZeroPayout.selector);
+        mod.configure(agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, thrs, pays);
+    }
+
+    function test_configure_reverts_pair_token_mismatch() public {
+        usdc.mint(address(this), TOTAL_PAY);
+        usdc.transfer(address(mod), TOTAL_PAY);
+        // Wrong agent token: pass an unrelated address.
+        TestERC20 stranger = new TestERC20("Stranger", "STR");
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.PairTokenMismatch.selector);
+        mod.configure(
+            agent, address(stranger), address(usdc), address(pair), creator, agentAdmin, _thresholds(), _payouts()
+        );
+    }
+
+    function test_configure_reverts_pair_uninitialized() public {
+        usdc.mint(address(this), TOTAL_PAY);
+        usdc.transfer(address(mod), TOTAL_PAY);
+        MockUniswapV2Pair freshPair = new MockUniswapV2Pair(address(agentTok), address(usdc));
+        // Reserves are zero by default.
+        vm.prank(owner);
+        vm.expectRevert(CapitalFormationModule.PairUninitialized.selector);
+        mod.configure(
+            agent, address(agentTok), address(usdc), address(freshPair), creator, agentAdmin, _thresholds(), _payouts()
+        );
+    }
+
+    function test_configure_reverts_insufficient_funding() public {
+        // Underfund: only P1 deposited, but configuring all four tiers.
+        usdc.mint(address(this), P1);
+        usdc.transfer(address(mod), P1);
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(CapitalFormationModule.InsufficientFunding.selector, TOTAL_PAY, P1));
+        mod.configure(
+            agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, _thresholds(), _payouts()
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // claim — happy paths per tier
+    // ---------------------------------------------------------------------
+
+    function test_claim_happy_each_tier_in_sequence() public {
+        _fundAndConfigure();
+
+        // Drive the pair to ~$3M FDV → tier 0 only.
+        _setFdvUsd(3_000_000);
+        _runTwap();
+        vm.expectEmit(true, true, false, true, address(mod));
+        emit CapitalFormationModule.MilestoneClaimed(agent, 0, _expectedFdvUsd(3_000_000), P1);
+        mod.claim(agent, 0);
+        assertEq(usdc.balanceOf(creator), P1);
+        assertTrue(mod.isClaimed(agent, 0));
+
+        // Drive to $12M → tier 1.
+        _setFdvUsd(12_000_000);
+        _runTwap();
+        mod.claim(agent, 1);
+        assertEq(usdc.balanceOf(creator), P1 + P2);
+        assertTrue(mod.isClaimed(agent, 1));
+
+        // Drive to $60M → tier 2.
+        _setFdvUsd(60_000_000);
+        _runTwap();
+        mod.claim(agent, 2);
+        assertEq(usdc.balanceOf(creator), P1 + P2 + P3);
+        assertTrue(mod.isClaimed(agent, 2));
+
+        // Drive to $200M → tier 3.
+        _setFdvUsd(200_000_000);
+        _runTwap();
+        mod.claim(agent, 3);
+        assertEq(usdc.balanceOf(creator), TOTAL_PAY);
+        assertTrue(mod.isClaimed(agent, 3));
+
+        // Escrow drained.
+        assertEq(mod.outstanding(address(usdc)), 0);
+        assertEq(usdc.balanceOf(address(mod)), 0);
+    }
+
+    function test_claim_higher_tier_first_pays_only_that_tier() public {
+        _fundAndConfigure();
+        _setFdvUsd(60_000_000); // covers T1, T2, T3 but tier 2 only this call.
+        _runTwap();
+        mod.claim(agent, 2);
+        assertEq(usdc.balanceOf(creator), P3);
+        assertTrue(mod.isClaimed(agent, 2));
+        assertFalse(mod.isClaimed(agent, 0));
+        assertFalse(mod.isClaimed(agent, 1));
+    }
+
+    function test_claim_reverts_double_claim() public {
+        _fundAndConfigure();
+        _setFdvUsd(3_000_000);
+        _runTwap();
+        mod.claim(agent, 0);
+
+        // Need a fresh snapshot for the second attempt.
+        _setFdvUsd(3_000_000);
+        _runTwap();
+        vm.expectRevert(CapitalFormationModule.TierAlreadyClaimed.selector);
+        mod.claim(agent, 0);
+    }
+
+    function test_claim_reverts_fdv_below_threshold() public {
+        _fundAndConfigure();
+        // FDV $1.5M, below T1 $2M.
+        _setFdvUsd(1_500_000);
+        _runTwap();
+        uint256 expectedFdv = _expectedFdvUsd(1_500_000);
+        vm.expectRevert(abi.encodeWithSelector(CapitalFormationModule.FdvBelowThreshold.selector, expectedFdv, T1));
+        mod.claim(agent, 0);
+    }
+
+    function test_claim_reverts_tier_out_of_range() public {
+        _fundAndConfigure();
+        _setFdvUsd(200_000_000);
+        _runTwap();
+        vm.expectRevert(CapitalFormationModule.TierOutOfRange.selector);
+        mod.claim(agent, 4);
+    }
+
+    function test_claim_reverts_not_configured() public {
+        vm.expectRevert(CapitalFormationModule.NotConfigured.selector);
+        mod.claim(agent, 0);
+    }
+
+    function test_claim_reverts_snapshot_missing() public {
+        _fundAndConfigure();
+        _setFdvUsd(3_000_000);
+        // No snapshot taken.
+        vm.expectRevert(CapitalFormationModule.SnapshotMissing.selector);
+        mod.claim(agent, 0);
+    }
+
+    function test_claim_reverts_window_too_short() public {
+        _fundAndConfigure();
+        _setFdvUsd(3_000_000);
+
+        mod.snapshot(agent);
+        // Advance only 10 blocks (< MIN_TWAP_BLOCKS).
+        vm.roll(block.number + 10);
+        vm.warp(block.timestamp + 20);
+        // Re-sync the pair to update its block timestamp.
+        _setFdvUsd(3_000_000);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(CapitalFormationModule.TwapWindowTooShort.selector, uint64(10), uint64(32))
+        );
+        mod.claim(agent, 0);
+    }
+
+    function test_claim_reverts_pair_too_young_no_sync_after_snapshot() public {
+        _fundAndConfigure();
+        _setFdvUsd(3_000_000);
+
+        mod.snapshot(agent);
+        // Advance blocks past the window without syncing the pair so the
+        // pair's blockTimestampLast does not advance.
+        vm.roll(block.number + 50);
+        vm.warp(block.timestamp + 100);
+
+        vm.expectRevert(CapitalFormationModule.PairTooYoung.selector);
+        mod.claim(agent, 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // snapshot
+    // ---------------------------------------------------------------------
+
+    function test_snapshot_reverts_not_configured() public {
+        vm.expectRevert(CapitalFormationModule.NotConfigured.selector);
+        mod.snapshot(agent);
+    }
+
+    function test_snapshot_overwrites_prior() public {
+        _fundAndConfigure();
+        _setFdvUsd(3_000_000);
+        mod.snapshot(agent);
+        (,, uint64 first,) = mod.snapshots(agent);
+
+        vm.roll(block.number + 5);
+        vm.warp(block.timestamp + 10);
+        _setFdvUsd(3_000_000);
+        mod.snapshot(agent);
+        (,, uint64 second, bool exists) = mod.snapshots(agent);
+        assertGt(uint256(second), uint256(first));
+        assertTrue(exists);
+    }
+
+    // ---------------------------------------------------------------------
+    // Reentrancy
+    // ---------------------------------------------------------------------
+
+    function test_claim_reentrancy_blocked() public {
+        // Use a payout token that re-enters {claim}.
+        ReentrantPayoutToken evilUsdc = new ReentrantPayoutToken();
+        evilUsdc.mint(address(this), TOTAL_PAY);
+        evilUsdc.transfer(address(mod), TOTAL_PAY);
+
+        vm.prank(owner);
+        mod.configure(
+            agent, address(agentTok), address(evilUsdc), address(pair), creator, agentAdmin, _thresholds(), _payouts()
+        );
+
+        _setFdvUsd(3_000_000);
+        _runTwap();
+        evilUsdc.arm(mod, agent, 0);
+
+        // The outer call should bubble the inner ReentrancyGuardReentrantCall
+        // (OZ v5 selector) up through the malicious _update.
+        vm.expectRevert();
+        mod.claim(agent, 0);
+
+        // No payout, no claimed bit.
+        assertEq(evilUsdc.balanceOf(creator), 0);
+        assertFalse(mod.isClaimed(agent, 0));
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    function test_isClaimed_out_of_range_returns_false() public view {
+        assertFalse(mod.isClaimed(agent, 7));
+    }
+
+    function test_tierAt_reverts_out_of_range() public {
+        _fundAndConfigure();
+        vm.expectRevert(CapitalFormationModule.TierOutOfRange.selector);
+        mod.tierAt(agent, 5);
+    }
+
+    function test_outstanding_drains_with_claims() public {
+        _fundAndConfigure();
+        assertEq(mod.outstanding(address(usdc)), TOTAL_PAY);
+        _setFdvUsd(3_000_000);
+        _runTwap();
+        mod.claim(agent, 0);
+        assertEq(mod.outstanding(address(usdc)), TOTAL_PAY - P1);
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    function test_constructor_reverts_zero_owner() public {
+        vm.expectRevert(CapitalFormationModule.ZeroAddress.selector);
+        new CapitalFormationModule(address(0));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    function _thresholds() internal pure returns (uint256[] memory thrs) {
+        thrs = new uint256[](4);
+        thrs[0] = T1;
+        thrs[1] = T2;
+        thrs[2] = T3;
+        thrs[3] = T4;
+    }
+
+    function _payouts() internal pure returns (uint256[] memory pays) {
+        pays = new uint256[](4);
+        pays[0] = P1;
+        pays[1] = P2;
+        pays[2] = P3;
+        pays[3] = P4;
+    }
+
+    function _fundAndConfigure() internal {
+        usdc.mint(address(this), TOTAL_PAY);
+        usdc.transfer(address(mod), TOTAL_PAY);
+        vm.prank(owner);
+        mod.configure(
+            agent, address(agentTok), address(usdc), address(pair), creator, agentAdmin, _thresholds(), _payouts()
+        );
+    }
+
+    /// @dev Drive the pair reserves so that the implied FDV in USD is
+    ///      `targetFdvUsd` (pre-decimal). Keeps the agent reserve constant
+    ///      and adjusts the USDC reserve so that
+    ///         usdcReserve / agentReserve = priceUsdcPerAgent.
+    function _setFdvUsd(uint256 targetFdvUsdMillionsScale) internal {
+        // We treat `targetFdvUsdMillionsScale` as the raw USD figure (no
+        // decimals). Convert into USDC wei by multiplying by 1e6.
+        // Price in USDC-wei per agent-wei = (FDV_usdc) / supply.
+        uint256 fdvUsdc = targetFdvUsdMillionsScale * 1e6;
+        // We choose agent reserve = SUPPLY_PORTION_FOR_PAIR (constant) so
+        // supply / agentReserve is fixed; then usdcReserve must equal
+        //   priceUsdcPerAgent * agentReserve = (fdvUsdc / SUPPLY) * agentReserve
+        // = fdvUsdc * (agentReserve / SUPPLY).
+        uint256 agentReserve = 100_000_000e18; // 10% of supply in pair
+        uint256 usdcReserve = fdvUsdc * agentReserve / SUPPLY;
+        // Both reserves must fit in uint112: max = 2^112 ≈ 5.19e33.
+        // agentReserve = 1e26 — fine. usdcReserve up to 1.6e13 — fine.
+        _syncByRole(agentReserve, usdcReserve);
+    }
+
+    /// @dev Expected FDV the module will compute for a given target USD
+    ///      figure. Mirrors the contract's math after lossy integer ops:
+    ///      we re-derive from the same reserves the contract reads.
+    function _expectedFdvUsd(uint256 targetFdvUsdMillionsScale) internal view returns (uint256) {
+        // The contract reads cumulative-derived TWAP. With our `_runTwap`
+        // helper holding constant reserves over the full window, TWAP =
+        // spot, so the expected FDV equals the spot FDV computed exactly
+        // the way the contract does:
+        //   priceQ112 = (reserveQuote * Q112) / reserveAgent;
+        //   fdv       = priceQ112 * supply / Q112.
+        uint256 fdvUsdc = targetFdvUsdMillionsScale * 1e6;
+        uint256 agentReserve = 100_000_000e18;
+        uint256 usdcReserve = fdvUsdc * agentReserve / SUPPLY;
+        uint256 q112 = 0x10000000000000000000000000000;
+        uint256 priceQ112 = (usdcReserve * q112) / agentReserve;
+        return (priceQ112 * SUPPLY) / q112;
+    }
+
+    /// @dev Sync helper that arranges reserves into the correct (token0,
+    ///      token1) slots regardless of which token is which.
+    function _syncByRole(uint256 agentAmt, uint256 usdcAmt) internal {
+        if (pair.token0() == address(agentTok)) {
+            pair.sync(uint112(agentAmt), uint112(usdcAmt));
+        } else {
+            pair.sync(uint112(usdcAmt), uint112(agentAmt));
+        }
+    }
+
+    /// @dev Walk through a TWAP window:
+    ///   1. Advance time so the cumulative grows from the LAST {sync} (the
+    ///      one driven by {_setFdvUsd}) at the held price.
+    ///   2. Take a {snapshot}.
+    ///   3. Roll {MIN_TWAP_BLOCKS} blocks + matching seconds.
+    ///   4. Re-sync the pair at the SAME reserves so the cumulative bumps
+    ///      with our held TWAP price.
+    function _runTwap() internal {
+        // Read held reserves out of the pair.
+        (uint112 r0, uint112 r1,) = pair.getReserves();
+
+        // Advance time so the cumulative grows.
+        vm.warp(block.timestamp + 64);
+        // Re-sync: this rolls the cumulative forward by `priceHeld * 64`.
+        pair.sync(r0, r1);
+
+        // Snapshot.
+        mod.snapshot(agent);
+
+        // Now wait the TWAP window.
+        vm.roll(block.number + 32);
+        vm.warp(block.timestamp + 64);
+        // Re-sync at SAME reserves so cumulative grows by `priceHeld * 64`.
+        pair.sync(r0, r1);
+    }
+}


### PR DESCRIPTION
## Summary
- New `CapitalFormationModule.sol` — per-agent TWAP-gated USDC payouts at FDV tiers ($2M/$10M/$50M/$160M).
- Pre-deposited USDC; one claim per tier; pair TWAP read with min observation window.
- One shared deployment, per-agent config like existing modules.

## Why
Aligns creator incentives with sustained price discovery, not instant pump-dump. Required for M2 module parity.

## Test plan
- [x] `forge fmt --check`
- [x] `forge test --match-path test/unit/CapitalFormationModule.t.sol`
- [x] full `forge test` green
- [x] `slither` — 0 medium+ findings

Closes #35