### PR TITLE
feat(launchpad): add pre-buy module with vesting

### DIFF
--- a/contracts/evm/src/launchpad/interfaces/IBondingCurve.sol
+++ b/contracts/evm/src/launchpad/interfaces/IBondingCurve.sol
@@ -1,19 +1,37 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-/// @title IBondingCurve
-/// @notice Minimal view + graduation surface of `BondingCurve` that downstream
-///         modules (graduator, fee router, launch-radar indexer) bind against
-///         without importing the full implementation and its OZ dependencies.
+/// @title  IBondingCurve
+/// @notice Minimal trade + view + graduation surface of `BondingCurve` that
+///         downstream modules (graduator, fee router, launch-radar indexer,
+///         pre-buy module) bind against without importing the full
+///         implementation and its OZ dependencies.
 /// @dev    Mirrors the subset of public/external signatures on
 ///         `src/launchpad/BondingCurve.sol` that live callers consume. Keep
-///         signatures and return ordering in lockstep.
+///         signatures and return ordering in lockstep with the implementation.
 interface IBondingCurve {
+    // ---------------------------------------------------------------------
+    // Token bindings
+    // ---------------------------------------------------------------------
+
     /// @notice Agent ERC-20 traded by this curve.
     function agentToken() external view returns (address);
 
     /// @notice Quote ERC-20 (TITU) used for trading and the LP seed.
     function quoteToken() external view returns (address);
+
+    // ---------------------------------------------------------------------
+    // Trading
+    // ---------------------------------------------------------------------
+
+    /// @notice Buy agent tokens from the curve.
+    /// @param  minAgentOut Slippage floor on agent tokens delivered to caller.
+    /// @param  quoteIn     Quote (TITU) wei pulled from the caller.
+    function buy(uint256 minAgentOut, uint256 quoteIn) external;
+
+    // ---------------------------------------------------------------------
+    // Graduation surface
+    // ---------------------------------------------------------------------
 
     /// @notice Flipped once `requestGraduation` has fired. Trading halts and
     ///         the graduator is permitted to pull reserves exactly once.

--- a/contracts/evm/src/launchpad/modules/PreBuyModule.sol
+++ b/contracts/evm/src/launchpad/modules/PreBuyModule.sol
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
+import {IBondingCurve} from "../interfaces/IBondingCurve.sol";
+import {TokenVesting} from "./TokenVesting.sol";
+
+/// @title  PreBuyModule
+/// @notice Per-agent creator pre-buy with custom vesting. The launchpad
+///         factory funds this module with `titanIn` quote (TITU) and calls
+///         {configure}; the module routes the buy through the agent's bonding
+///         curve, then drops the bought agent tokens into a fresh
+///         EIP-1167 minimal-proxy {TokenVesting} clone keyed by the agent
+///         address. The clone vests linearly to the creator after a
+///         configurable cliff. One-shot per agent.
+/// @dev    Single deployment per protocol, many agents. Owner is expected to
+///         be the launchpad factory (or the Safe acting as it). The vesting
+///         implementation is deployed once at construction; per-agent state
+///         lives entirely on cheap minimal-proxy clones. CEI is enforced on
+///         {configure}: state writes (config + clone deploy) land before any
+///         external buy / transfer / init call, and {ReentrancyGuard} closes
+///         the configure path against malicious tokens or curves.
+///
+///         Funding model: this module never custodies TITU. The owner
+///         transfers exactly `titanIn` TITU to this contract immediately
+///         before each {configure} call (or atomically in the same tx), and
+///         the module forwards it to the curve. Any leftover quote on the
+///         contract is swept by the owner via {sweep} so an aborted call
+///         cannot strand funds.
+contract PreBuyModule is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+    using Clones for address;
+
+    // ---------------------------------------------------------------------
+    // Types
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent pre-buy record. Written exactly once on {configure}.
+    /// @param  creator       Beneficiary of the vesting clone.
+    /// @param  vestingClone  EIP-1167 minimal proxy for {TokenVesting}.
+    /// @param  vestAmount    Agent tokens transferred into the clone (= curve
+    ///                       output, with slippage floor `vestAmount`).
+    /// @param  cliffSeconds  Cliff measured from {start}, in seconds.
+    /// @param  durationSeconds Total vesting window in seconds.
+    /// @param  start         Unix timestamp at which the vesting curve begins.
+    /// @param  configured    Sentinel set true on first {configure}.
+    struct Config {
+        address creator;
+        address vestingClone;
+        uint256 vestAmount;
+        uint64 cliffSeconds;
+        uint64 durationSeconds;
+        uint64 start;
+        bool configured;
+    }
+
+    // ---------------------------------------------------------------------
+    // Immutables
+    // ---------------------------------------------------------------------
+
+    /// @notice {TokenVesting} implementation pointed at by every clone.
+    address public immutable vestingImplementation;
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice Per-agent pre-buy state. Empty until the factory calls
+    ///         {configure} for that agent.
+    mapping(address agent => Config) public configs;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @dev Emitted exactly once per agent on {configure}. Indexers key on
+    ///      `agent` to surface the creator's vesting bag and clone address.
+    event Configured(
+        address indexed agent,
+        address indexed creator,
+        address indexed vestingClone,
+        uint256 vestAmount,
+        uint64 cliffSeconds,
+        uint64 durationSeconds
+    );
+
+    /// @dev Mirror of the clone's own {TokenVesting.Released} event so a
+    ///      single subscription on this module is enough to follow every
+    ///      creator's pull. Anyone may trigger {release} (gas arbitrage).
+    event Released(address indexed agent, address indexed clone, uint256 amount);
+
+    /// @dev Emitted when the owner sweeps stranded quote off the module.
+    event QuoteSwept(address indexed token, address indexed to, uint256 amount);
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Thrown when an address argument is the zero address.
+    error ZeroAddress();
+    /// @dev Thrown when `vestAmount`, `titanIn`, or `durationSeconds` is zero.
+    error ZeroAmount();
+    /// @dev Thrown when `cliffSeconds > durationSeconds`.
+    error CliffExceedsDuration();
+    /// @dev Thrown when {configure} is called twice for the same agent.
+    error AlreadyConfigured();
+    /// @dev Thrown when the curve's `agentToken()` does not match the `agent`
+    ///      argument passed to {configure}. Catches a misconfigured factory
+    ///      from binding the wrong curve to an agent.
+    error AgentMismatch();
+    /// @dev Thrown when the curve actually delivered fewer tokens than the
+    ///      caller requested as the vest target. The curve's own slippage
+    ///      check should pre-empt this, but we re-assert before the clone is
+    ///      funded so a buggy curve cannot under-fund the grant.
+    error InsufficientBuyOutput();
+    /// @dev Thrown when {release} is called for an agent that has not been
+    ///      registered via {configure}.
+    error NotConfigured();
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @param owner_ Initial owner. Expected to be the launchpad factory or a
+    ///               Safe multisig acting on its behalf — only that party is
+    ///               trusted to bind a creator's pre-buy bag.
+    constructor(address owner_) Ownable(_validatedOwner(owner_)) {
+        // Deploy the immutable vesting implementation once. Every per-agent
+        // clone is a 45-byte EIP-1167 minimal proxy delegating to this code,
+        // keeping per-agent deployment cost ~32k gas vs. ~600k for a fresh
+        // copy.
+        vestingImplementation = address(new TokenVesting());
+    }
+
+    /// @dev Wrap OZ Ownable's zero-owner check so callers see our canonical
+    ///      {ZeroAddress} error instead of OZ's `OwnableInvalidOwner`.
+    function _validatedOwner(address owner_) private pure returns (address) {
+        if (owner_ == address(0)) revert ZeroAddress();
+        return owner_;
+    }
+
+    // ---------------------------------------------------------------------
+    // Configure
+    // ---------------------------------------------------------------------
+
+    /// @notice Bind a pre-buy + vesting plan to `agent`. Owner-only, one-shot.
+    /// @dev    Pre-conditions:
+    ///           - `titanIn` TITU has been transferred into this contract by
+    ///             the owner (or atomically in the same tx).
+    ///           - `curve.agentToken() == agent` (asserted).
+    ///         Effects:
+    ///           1. Validate args + look up curve token bindings.
+    ///           2. Deploy a deterministic {TokenVesting} clone (salt =
+    ///              keccak256(agent)). Storage write (`configs[agent]`)
+    ///              lands before any external call so a malicious token cannot
+    ///              re-enter into a half-configured agent.
+    ///           3. Approve the curve for exactly `titanIn`, call `buy`, then
+    ///              clear the approval — leaves no standing allowance on a
+    ///              long-lived module.
+    ///           4. Re-read this contract's agent-token balance, assert
+    ///              `received >= vestAmount`, transfer the actually-received
+    ///              amount into the clone, initialize the clone with the
+    ///              vesting schedule.
+    ///         Reverts (any) leave the module's storage clean and the TITU
+    ///         pull-through unspent (owner can {sweep} it).
+    /// @param  agent           Agent token (clone key).
+    /// @param  creator         Creator address — sole vesting beneficiary.
+    /// @param  vestAmount      Slippage floor on agent tokens out of the buy
+    ///                         AND nominal grant size. Curve will deliver at
+    ///                         least this, often slightly more (curve does
+    ///                         not refund excess); the module forwards the
+    ///                         entire received balance into the clone.
+    /// @param  cliffSeconds    Vesting cliff offset (seconds).
+    /// @param  durationSeconds Total vesting window (seconds). Non-zero.
+    /// @param  titanIn         Quote (TITU) the curve will pull from this
+    ///                         module. Must already be on this contract.
+    /// @param  curve           Bonding curve for `agent`.
+    /// @return clone           Address of the newly-deployed vesting clone.
+    /// @dev    {nonReentrant} closes the curve / token re-entry surface; the
+    ///         pre-/post-call balance read is safe because the call is wrapped
+    ///         in the guard (slither's reentrancy-balance is a false positive
+    ///         in that context).
+    // slither-disable-next-line reentrancy-no-eth,reentrancy-benign,reentrancy-events,reentrancy-balance
+    function configure(
+        address agent,
+        address creator,
+        uint256 vestAmount,
+        uint64 cliffSeconds,
+        uint64 durationSeconds,
+        uint256 titanIn,
+        IBondingCurve curve
+    ) external onlyOwner nonReentrant returns (address clone) {
+        // -------------------- Validation --------------------
+        if (agent == address(0) || creator == address(0) || address(curve) == address(0)) revert ZeroAddress();
+        if (vestAmount == 0 || titanIn == 0) revert ZeroAmount();
+        if (durationSeconds == 0) revert ZeroAmount();
+        if (cliffSeconds > durationSeconds) revert CliffExceedsDuration();
+        if (configs[agent].configured) revert AlreadyConfigured();
+        if (curve.agentToken() != agent) revert AgentMismatch();
+
+        IERC20 quote = IERC20(curve.quoteToken());
+        IERC20 agentToken = IERC20(agent);
+
+        // -------------------- Effects (clone deploy + storage) --------------------
+        // Salt = agent address ensures a single canonical clone per agent
+        // and lets the FE compute the address ahead of the launch tx.
+        clone = vestingImplementation.cloneDeterministic(_salt(agent));
+
+        // Snapshot balance BEFORE the buy so we can compute exactly what the
+        // curve delivered, even if the module already held some agent tokens
+        // from a prior transfer (defensive — should always be 0 on a
+        // freshly-launched agent).
+        uint256 balBefore = agentToken.balanceOf(address(this));
+
+        uint64 startTs = uint64(block.timestamp);
+        configs[agent] = Config({
+            creator: creator,
+            vestingClone: clone,
+            vestAmount: vestAmount,
+            cliffSeconds: cliffSeconds,
+            durationSeconds: durationSeconds,
+            start: startTs,
+            configured: true
+        });
+
+        // -------------------- Interactions --------------------
+        // Approve the curve for exactly `titanIn`. We use a tight, transient
+        // approval rather than `type(uint256).max` per protocol policy.
+        quote.forceApprove(address(curve), titanIn);
+        // BondingCurve.buy(minAgentOut, quoteIn) — note arg order.
+        curve.buy(vestAmount, titanIn);
+        // Drop any residual allowance so this module never sits on standing
+        // approvals between configures.
+        quote.forceApprove(address(curve), 0);
+
+        // Verify what the curve actually delivered. The curve's own slippage
+        // floor mirrors `vestAmount`, but we re-check here so a buggy or
+        // malicious curve cannot under-fund the grant.
+        uint256 received = agentToken.balanceOf(address(this)) - balBefore;
+        if (received < vestAmount) revert InsufficientBuyOutput();
+
+        // Forward the full received amount into the clone, then initialize
+        // it with the vesting schedule. The clone reads its balance lazily on
+        // {release}, so funding-before-init is the safe ordering.
+        agentToken.safeTransfer(clone, received);
+        TokenVesting(clone).initialize(agentToken, creator, received, startTs, cliffSeconds, durationSeconds);
+
+        emit Configured(agent, creator, clone, received, cliffSeconds, durationSeconds);
+    }
+
+    /// @notice Trigger {TokenVesting.release} on `agent`'s clone. Anyone may
+    ///         call (gas arbitrage); the released tokens always go to the
+    ///         creator stored on the clone.
+    /// @dev    Convenience wrapper so a single ABI on this module is enough
+    ///         to drive every creator's vest. Reverts with the clone's own
+    ///         errors (`NothingToRelease`, etc.) if the call is a no-op.
+    /// @param  agent Agent whose clone should release.
+    /// @return amount Tokens transferred to the creator this call.
+    /// @dev    The clone is a contract we deployed with a known, immutable
+    ///         implementation; its only outbound call is a `safeTransfer` of
+    ///         the agent token to a stored beneficiary. Emitting after the
+    ///         call (slither: reentrancy-events) is safe because no module
+    ///         storage is mutated post-call.
+    // slither-disable-next-line reentrancy-events
+    function release(address agent) external nonReentrant returns (uint256 amount) {
+        Config memory cfg = configs[agent];
+        if (!cfg.configured) revert NotConfigured();
+        amount = TokenVesting(cfg.vestingClone).release();
+        emit Released(agent, cfg.vestingClone, amount);
+    }
+
+    /// @notice Predict the deterministic clone address for `agent` without
+    ///         deploying. Useful for FE pre-flight rendering.
+    function predictCloneAddress(address agent) external view returns (address) {
+        return Clones.predictDeterministicAddress(vestingImplementation, _salt(agent), address(this));
+    }
+
+    // ---------------------------------------------------------------------
+    // Recovery
+    // ---------------------------------------------------------------------
+
+    /// @notice Owner-only sweep for any quote / dust left on the module after
+    ///         an aborted {configure}. Cannot drain a clone — clones hold
+    ///         their own balance under their own contract, not this one.
+    /// @dev    Whitelisted to ERC-20 only (no native sweep) because the
+    ///         module never accepts ETH. We do not restrict the token
+    ///         argument: the owner is the factory / Safe and may need to
+    ///         recover any token mistakenly sent here.
+    function sweep(IERC20 token, address to, uint256 amount) external onlyOwner {
+        if (to == address(0)) revert ZeroAddress();
+        token.safeTransfer(to, amount);
+        emit QuoteSwept(address(token), to, amount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal
+    // ---------------------------------------------------------------------
+
+    /// @dev Deterministic salt derivation. Hashing the address (rather than
+    ///      casting it directly to bytes32) gives uniform distribution and
+    ///      future-proofs us against ever wanting to mix in a chain-id or
+    ///      version byte.
+    function _salt(address agent) private pure returns (bytes32) {
+        return keccak256(abi.encode(agent));
+    }
+}

--- a/contracts/evm/src/launchpad/modules/TokenVesting.sol
+++ b/contracts/evm/src/launchpad/modules/TokenVesting.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+/// @title  TokenVesting
+/// @notice Minimal cliff + linear vesting target for EIP-1167 minimal-proxy
+///         clones deployed by {PreBuyModule}. One clone per agent: it holds the
+///         creator's pre-buy bag and releases it linearly to the creator after
+///         the cliff elapses.
+/// @dev    Implementation contract — never used directly. {PreBuyModule}
+///         deploys a clone via OZ {Clones.cloneDeterministic} and calls
+///         {initialize} exactly once. The implementation is locked by calling
+///         {_disableInitializers} in the constructor so it cannot itself be
+///         hijacked. State layout is intentionally tight: six storage slots.
+///         All token movements use {SafeERC20} to tolerate non-standard ERC-20
+///         (no return value, USDC-style) implementations.
+contract TokenVesting is Initializable {
+    using SafeERC20 for IERC20;
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice ERC-20 being vested. Bound at {initialize}.
+    IERC20 public token;
+
+    /// @notice Sole recipient of {release} pulls. Bound at {initialize}.
+    address public beneficiary;
+
+    /// @notice Wall-clock start of the vesting schedule.
+    uint64 public start;
+
+    /// @notice Seconds from {start} before any tokens vest. Pre-cliff
+    ///         {releasable} is always zero.
+    uint64 public cliff;
+
+    /// @notice Total vesting window in seconds, measured from {start}. After
+    ///         `start + duration` the entire {total} grant is vested.
+    uint64 public duration;
+
+    /// @notice Total grant size locked at {initialize}. Equals the agent-token
+    ///         balance the module transferred into the clone.
+    uint256 public total;
+
+    /// @notice Cumulative tokens already pulled by {release}. Monotone
+    ///         non-decreasing; bounded above by {total}.
+    uint256 public released;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @dev Emitted exactly once on {initialize}.
+    event Initialized(
+        address indexed token, address indexed beneficiary, uint256 total, uint64 start, uint64 cliff, uint64 duration
+    );
+
+    /// @dev Emitted on every {release} that transfers a non-zero amount.
+    event Released(address indexed beneficiary, uint256 amount);
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Thrown when an address argument is zero.
+    error ZeroAddress();
+    /// @dev Thrown when {initialize} is called with a zero grant.
+    error ZeroAmount();
+    /// @dev Thrown when `duration == 0` (would divide-by-zero in vesting math).
+    error ZeroDuration();
+    /// @dev Thrown when `cliff > duration`.
+    error CliffExceedsDuration();
+    /// @dev Thrown when {release} would transfer zero (idempotent calls revert
+    ///      so callers can distinguish "no-op" from successful release).
+    error NothingToRelease();
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @dev Lock the implementation contract — clones initialize themselves.
+    constructor() {
+        _disableInitializers();
+    }
+
+    // ---------------------------------------------------------------------
+    // Initializer
+    // ---------------------------------------------------------------------
+
+    /// @notice Bind the clone's vesting parameters. Must be called by the
+    ///         deploying module immediately after {Clones.cloneDeterministic}
+    ///         returns the new clone.
+    /// @dev    The caller is expected to have already transferred `total_`
+    ///         tokens of `token_` into this contract. We do not pull here so
+    ///         the deployment + funding + init flow stays atomic in the parent
+    ///         transaction without requiring approvals.
+    /// @param  token_       ERC-20 to vest.
+    /// @param  beneficiary_ Sole recipient of {release}.
+    /// @param  total_       Grant size.
+    /// @param  start_       Vesting start (unix seconds).
+    /// @param  cliff_       Cliff offset from `start_`, in seconds.
+    /// @param  duration_    Total vesting window in seconds.
+    function initialize(
+        IERC20 token_,
+        address beneficiary_,
+        uint256 total_,
+        uint64 start_,
+        uint64 cliff_,
+        uint64 duration_
+    ) external initializer {
+        if (address(token_) == address(0) || beneficiary_ == address(0)) revert ZeroAddress();
+        if (total_ == 0) revert ZeroAmount();
+        if (duration_ == 0) revert ZeroDuration();
+        if (cliff_ > duration_) revert CliffExceedsDuration();
+
+        token = token_;
+        beneficiary = beneficiary_;
+        total = total_;
+        start = start_;
+        cliff = cliff_;
+        duration = duration_;
+
+        emit Initialized(address(token_), beneficiary_, total_, start_, cliff_, duration_);
+    }
+
+    // ---------------------------------------------------------------------
+    // Release
+    // ---------------------------------------------------------------------
+
+    /// @notice Transfer the currently-releasable amount to {beneficiary}.
+    /// @dev    Anyone may call (gas arbitrage). CEI: storage update before
+    ///         {SafeERC20.safeTransfer}. Reverts on a zero-amount call so the
+    ///         caller cannot silently pay gas for a no-op.
+    /// @return amount Tokens transferred to {beneficiary} this call.
+    /// @dev    Strict `amount == 0` is the documented no-op sentinel; not a
+    ///         real `incorrect-equality` finding. The pre-call read is
+    ///         time-based — `block.timestamp` drift of seconds is
+    ///         immaterial against multi-month vest schedules.
+    // slither-disable-next-line incorrect-equality,timestamp
+    function release() external returns (uint256 amount) {
+        uint256 vestedNow = _vested(uint64(block.timestamp));
+        amount = vestedNow - released;
+        if (amount == 0) revert NothingToRelease();
+
+        // --- Effects ---
+        released = vestedNow;
+
+        // --- Interactions ---
+        token.safeTransfer(beneficiary, amount);
+        emit Released(beneficiary, amount);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice Cumulative tokens vested as of `block.timestamp`. Monotone
+    ///         non-decreasing in time.
+    function vested() external view returns (uint256) {
+        return _vested(uint64(block.timestamp));
+    }
+
+    /// @notice Tokens currently claimable via {release}.
+    function releasable() external view returns (uint256) {
+        return _vested(uint64(block.timestamp)) - released;
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal
+    // ---------------------------------------------------------------------
+
+    /// @dev Cliff + linear vesting curve.
+    ///      - Pre-cliff (`nowTs < start + cliff`) -> 0.
+    ///      - Post-end  (`nowTs >= start + duration`) -> {total}.
+    ///      - In-window -> `total * (nowTs - start) / duration` (floor).
+    ///
+    ///      Time-based gating uses `block.timestamp` by design: vesting is
+    ///      expressed in wall-clock seconds (cliffs measured in days/years).
+    ///      A miner's ~15s timestamp drift is immaterial against grants that
+    ///      vest over months. The slither `timestamp` warning is therefore
+    ///      not actionable here.
+    // slither-disable-next-line timestamp
+    function _vested(uint64 nowTs) internal view returns (uint256) {
+        uint64 startMem = start;
+        uint64 durationMem = duration;
+        if (nowTs < startMem + cliff) return 0;
+        uint256 end = uint256(startMem) + uint256(durationMem);
+        if (uint256(nowTs) >= end) return total;
+        // multiplication-before-division; integer floor leaves dust on the
+        // contract until the final tick when `nowTs >= end` returns the full
+        // `total`.
+        uint256 elapsed = uint256(nowTs) - uint256(startMem);
+        return (total * elapsed) / uint256(durationMem);
+    }
+}

--- a/contracts/evm/test/mocks/MockBondingCurve.sol
+++ b/contracts/evm/test/mocks/MockBondingCurve.sol
@@ -6,14 +6,30 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IBondingCurve} from "../../src/launchpad/interfaces/IBondingCurve.sol";
 
 /// @title MockBondingCurve
-/// @notice Test double implementing the `IBondingCurve` surface that the
-///         graduator binds against. Holds both tokens as balances, tracks a
-///         mutable `graduated` flag, and exposes `pullForGraduation` that
-///         transfers the configured reserves to `msg.sender` (the graduator).
+/// @notice Test double implementing the full `IBondingCurve` surface used by
+///         module unit tests: the trade entry point ({buy}) consumed by the
+///         pre-buy module, and the graduation accessors + reserve drain
+///         consumed by the graduator.
+/// @dev    Two independent fixture surfaces share one mock to avoid drift:
+///
+///         - Pre-buy path: construct with `(agent_, quote_)`, pre-fund the
+///           mock with the agent token, and let modules call {buy}. The
+///           `payoutOverride` and `revertOnBuy` knobs let a single test
+///           exercise the under-fund / over-deliver / revert paths without
+///           swapping the mock implementation.
+///
+///         - Graduator path: construct with `(address(0), address(0))`, then
+///           use {set} to rebind tokens and seed the recorded reserves. The
+///           graduator calls {pullForGraduation} to drain into itself.
+///
 ///         Never enforces CEI or reentrancy — those behaviours are verified
 ///         by the real `BondingCurve` tests. Here we only need a deterministic
-///         source of tokens for add-liquidity assertions.
+///         source of tokens for module-level assertions.
 contract MockBondingCurve is IBondingCurve {
+    // ---------------------------------------------------------------------
+    // IBondingCurve state
+    // ---------------------------------------------------------------------
+
     address public override agentToken;
     address public override quoteToken;
     bool public override graduated;
@@ -21,11 +37,40 @@ contract MockBondingCurve is IBondingCurve {
     uint256 public override realQuoteReserve;
     uint256 public override realAgentReserve;
 
+    // ---------------------------------------------------------------------
+    // Pre-buy buy() shim
+    // ---------------------------------------------------------------------
+
+    /// @notice If non-zero, used as the literal agent-out delivered to the
+    ///         buyer instead of `minAgentOut`. Lets a single test exercise
+    ///         the under-fund or over-deliver paths.
+    uint256 public payoutOverride;
+
+    /// @notice If true, {buy} reverts with a string the test recognises.
+    bool public revertOnBuy;
+
+    // ---------------------------------------------------------------------
+    // Graduator instrumentation
+    // ---------------------------------------------------------------------
+
+    /// @notice Number of times {pullForGraduation} has been invoked. Used by
+    ///         the graduator tests to assert one-shot semantics.
     uint256 public pullCalls;
 
-    /// @notice Configure the curve fixture. Tokens are transferred into the
-    ///         mock up-front; `pullForGraduation` forwards exactly the
-    ///         recorded reserves to the graduator.
+    // ---------------------------------------------------------------------
+    // Construction + configuration
+    // ---------------------------------------------------------------------
+
+    /// @notice Bind the trade tokens at deploy time. Pass `(address(0),
+    ///         address(0))` and call {set} when the test fixture (e.g. the
+    ///         graduator) needs to seed reserves separately.
+    constructor(address agent_, address quote_) {
+        agentToken = agent_;
+        quoteToken = quote_;
+    }
+
+    /// @notice Rebind tokens and seed reserves in one call. Used by the
+    ///         graduator fixture; pre-buy tests do not need this entry point.
     function set(
         address agentToken_,
         address quoteToken_,
@@ -47,6 +92,30 @@ contract MockBondingCurve is IBondingCurve {
     function setGraduated(bool g) external {
         graduated = g;
     }
+
+    function setPayoutOverride(uint256 v) external {
+        payoutOverride = v;
+    }
+
+    function setRevertOnBuy(bool v) external {
+        revertOnBuy = v;
+    }
+
+    // ---------------------------------------------------------------------
+    // IBondingCurve trade surface
+    // ---------------------------------------------------------------------
+
+    /// @inheritdoc IBondingCurve
+    function buy(uint256 minAgentOut, uint256 quoteIn) external override {
+        require(!revertOnBuy, "curve: forced revert");
+        IERC20(quoteToken).transferFrom(msg.sender, address(this), quoteIn);
+        uint256 out = payoutOverride == 0 ? minAgentOut : payoutOverride;
+        IERC20(agentToken).transfer(msg.sender, out);
+    }
+
+    // ---------------------------------------------------------------------
+    // IBondingCurve graduation surface
+    // ---------------------------------------------------------------------
 
     /// @inheritdoc IBondingCurve
     function pullForGraduation() external override returns (uint256 quoteAmount, uint256 agentAmount) {

--- a/contracts/evm/test/mocks/MockERC20.sol
+++ b/contracts/evm/test/mocks/MockERC20.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @dev Plain ERC-20 with arbitrary supply minting for unit tests. Not for
+///      production use — the {mint} entry point is unrestricted.
+contract MockMintableERC20 is ERC20 {
+    constructor(string memory n, string memory s) ERC20(n, s) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/evm/test/unit/Graduator.t.sol
+++ b/contracts/evm/test/unit/Graduator.t.sol
@@ -47,7 +47,7 @@ contract GraduatorTest is Test {
 
         grad = new Graduator(IUniswapV2Router02(address(router)), owner);
 
-        curve = new MockBondingCurve();
+        curve = new MockBondingCurve(address(0), address(0));
         curve.set(address(agent), address(quote), QUOTE_RESERVE, AGENT_RESERVE, false);
         curve.setGraduator(address(grad));
 

--- a/contracts/evm/test/unit/PreBuyModule.t.sol
+++ b/contracts/evm/test/unit/PreBuyModule.t.sol
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+
+import {PreBuyModule} from "../../src/launchpad/modules/PreBuyModule.sol";
+import {TokenVesting} from "../../src/launchpad/modules/TokenVesting.sol";
+import {IBondingCurve} from "../../src/launchpad/interfaces/IBondingCurve.sol";
+import {MockMintableERC20} from "../mocks/MockERC20.sol";
+import {MockBondingCurve} from "../mocks/MockBondingCurve.sol";
+
+/// @dev Unit coverage for {PreBuyModule} + its companion {TokenVesting}
+///      clone target. Validates: ownership + one-shot + arg validation on
+///      {configure}; correct funding of the deterministic clone; the full
+///      vesting curve (pre-cliff zero, cliff pro-rata, post-duration full,
+///      idempotent over-release); clone independence across agents.
+contract PreBuyModuleTest is Test {
+    PreBuyModule internal module;
+    MockMintableERC20 internal titu;
+    MockMintableERC20 internal agentA;
+    MockMintableERC20 internal agentB;
+    MockBondingCurve internal curveA;
+    MockBondingCurve internal curveB;
+
+    address internal owner = address(0xF1);
+    address internal creator = address(0xC0FFEE);
+    address internal stranger = address(0xBAD);
+
+    uint256 internal constant TITAN_IN = 1000e18;
+    uint256 internal constant VEST_AMOUNT = 100_000_000e18; // 10% of 1B supply
+    uint64 internal constant CLIFF = 30 days;
+    uint64 internal constant DURATION = 180 days;
+
+    // Re-declare events for `vm.expectEmit` matchers.
+    event Configured(
+        address indexed agent,
+        address indexed creator,
+        address indexed vestingClone,
+        uint256 vestAmount,
+        uint64 cliffSeconds,
+        uint64 durationSeconds
+    );
+    event Released(address indexed agent, address indexed clone, uint256 amount);
+
+    function setUp() public {
+        titu = new MockMintableERC20("Titan", "TITU");
+        agentA = new MockMintableERC20("AgentA", "AGTA");
+        agentB = new MockMintableERC20("AgentB", "AGTB");
+
+        curveA = new MockBondingCurve(address(agentA), address(titu));
+        curveB = new MockBondingCurve(address(agentB), address(titu));
+
+        // Pre-fund the mock curves with the agent token they will deliver on
+        // buy. The full 1B supply mirrors the real launchpad's curve seed.
+        agentA.mint(address(curveA), 1_000_000_000e18);
+        agentB.mint(address(curveB), 1_000_000_000e18);
+
+        module = new PreBuyModule(owner);
+
+        // Park enough TITU on the module up front for both planned configures.
+        titu.mint(address(module), 10 * TITAN_IN);
+
+        // Stable wall-clock so vesting timestamps are easy to reason about.
+        vm.warp(1_700_000_000);
+    }
+
+    // ----- Constructor -----
+
+    function test_constructor_reverts_zero_owner() public {
+        vm.expectRevert(PreBuyModule.ZeroAddress.selector);
+        new PreBuyModule(address(0));
+    }
+
+    function test_constructor_deploys_implementation() public view {
+        address impl = module.vestingImplementation();
+        assertTrue(impl != address(0));
+    }
+
+    function test_implementation_is_initialization_locked() public {
+        TokenVesting impl = TokenVesting(module.vestingImplementation());
+        vm.expectRevert(); // OZ Initializable: InvalidInitialization
+        impl.initialize(IERC20(address(titu)), creator, 1, uint64(block.timestamp), 0, 1);
+    }
+
+    // ----- configure: access control + validation -----
+
+    function test_configure_only_owner() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stranger));
+        module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+    }
+
+    function test_configure_reverts_zero_agent() public {
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.ZeroAddress.selector);
+        module.configure(address(0), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA)));
+    }
+
+    function test_configure_reverts_zero_creator() public {
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.ZeroAddress.selector);
+        module.configure(
+            address(agentA), address(0), VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+    }
+
+    function test_configure_reverts_zero_curve() public {
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.ZeroAddress.selector);
+        module.configure(address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(0)));
+    }
+
+    function test_configure_reverts_zero_vest_amount() public {
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.ZeroAmount.selector);
+        module.configure(address(agentA), creator, 0, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA)));
+    }
+
+    function test_configure_reverts_zero_titan_in() public {
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.ZeroAmount.selector);
+        module.configure(address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, 0, IBondingCurve(address(curveA)));
+    }
+
+    function test_configure_reverts_zero_duration() public {
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.ZeroAmount.selector);
+        module.configure(address(agentA), creator, VEST_AMOUNT, CLIFF, 0, TITAN_IN, IBondingCurve(address(curveA)));
+    }
+
+    function test_configure_reverts_cliff_gt_duration() public {
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.CliffExceedsDuration.selector);
+        module.configure(
+            address(agentA), creator, VEST_AMOUNT, DURATION + 1, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+    }
+
+    function test_configure_reverts_agent_mismatch() public {
+        // Curve's agentToken() reports agentA, but we claim agentB is the agent.
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.AgentMismatch.selector);
+        module.configure(
+            address(agentB), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+    }
+
+    function test_configure_reverts_double_config() public {
+        vm.startPrank(owner);
+        module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+        vm.expectRevert(PreBuyModule.AlreadyConfigured.selector);
+        module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+        vm.stopPrank();
+    }
+
+    function test_configure_reverts_curve_under_funds() public {
+        // Force the mock curve to deliver less than the slippage floor so the
+        // module's defensive check fires.
+        curveA.setPayoutOverride(VEST_AMOUNT - 1);
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.InsufficientBuyOutput.selector);
+        module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+    }
+
+    function test_configure_bubbles_curve_revert() public {
+        curveA.setRevertOnBuy(true);
+        vm.prank(owner);
+        vm.expectRevert(bytes("curve: forced revert"));
+        module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+    }
+
+    // ----- configure: happy path -----
+
+    function test_configure_happy_path_writes_state_and_funds_clone() public {
+        address predicted = module.predictCloneAddress(address(agentA));
+
+        vm.expectEmit(true, true, true, true, address(module));
+        emit Configured(address(agentA), creator, predicted, VEST_AMOUNT, CLIFF, DURATION);
+
+        vm.prank(owner);
+        address clone = module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+
+        assertEq(clone, predicted, "clone deterministic mismatch");
+
+        (
+            address gotCreator,
+            address gotClone,
+            uint256 gotVest,
+            uint64 gotCliff,
+            uint64 gotDur,
+            uint64 gotStart,
+            bool gotConfigured
+        ) = module.configs(address(agentA));
+        assertEq(gotCreator, creator);
+        assertEq(gotClone, clone);
+        assertEq(gotVest, VEST_AMOUNT);
+        assertEq(uint256(gotCliff), uint256(CLIFF));
+        assertEq(uint256(gotDur), uint256(DURATION));
+        assertEq(uint256(gotStart), block.timestamp);
+        assertTrue(gotConfigured);
+
+        // Curve received TITU; clone received agent tokens.
+        assertEq(titu.balanceOf(address(curveA)), TITAN_IN);
+        assertEq(agentA.balanceOf(clone), VEST_AMOUNT);
+        // Module retained no agent tokens.
+        assertEq(agentA.balanceOf(address(module)), 0);
+
+        // Clone initialized correctly.
+        TokenVesting v = TokenVesting(clone);
+        assertEq(address(v.token()), address(agentA));
+        assertEq(v.beneficiary(), creator);
+        assertEq(v.total(), VEST_AMOUNT);
+        assertEq(uint256(v.cliff()), uint256(CLIFF));
+        assertEq(uint256(v.duration()), uint256(DURATION));
+
+        // Clone is itself initialization-locked against re-init.
+        vm.expectRevert();
+        v.initialize(IERC20(address(agentA)), creator, VEST_AMOUNT, uint64(block.timestamp), CLIFF, DURATION);
+    }
+
+    function test_configure_no_residual_allowance() public {
+        vm.prank(owner);
+        module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+        assertEq(titu.allowance(address(module), address(curveA)), 0);
+    }
+
+    function test_configure_curve_over_delivers_full_balance_into_clone() public {
+        // Curve delivers slightly more than the floor (e.g. real bonding-curve
+        // math rounding up). The module forwards the full received amount.
+        uint256 over = VEST_AMOUNT + 12_345e18;
+        curveA.setPayoutOverride(over);
+
+        vm.prank(owner);
+        address clone = module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+
+        assertEq(agentA.balanceOf(clone), over);
+        TokenVesting v = TokenVesting(clone);
+        assertEq(v.total(), over);
+    }
+
+    // ----- vesting math via clone -----
+
+    function _configureA() internal returns (TokenVesting) {
+        vm.prank(owner);
+        address clone = module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+        return TokenVesting(clone);
+    }
+
+    function test_release_before_cliff_is_zero() public {
+        TokenVesting v = _configureA();
+        vm.warp(block.timestamp + uint256(CLIFF) - 1);
+        assertEq(v.releasable(), 0);
+        vm.expectRevert(TokenVesting.NothingToRelease.selector);
+        v.release();
+        assertEq(agentA.balanceOf(creator), 0);
+    }
+
+    function test_release_at_cliff_pro_rata() public {
+        TokenVesting v = _configureA();
+        // At exactly `start + cliff` the linear curve has accrued
+        // `total * cliff / duration` (clone uses elapsed-from-start basis).
+        vm.warp(block.timestamp + uint256(CLIFF));
+        uint256 expected = (VEST_AMOUNT * uint256(CLIFF)) / uint256(DURATION);
+        assertEq(v.releasable(), expected);
+
+        v.release();
+        assertEq(agentA.balanceOf(creator), expected);
+        assertEq(v.released(), expected);
+        // Immediate re-release is a no-op revert (no time passed).
+        vm.expectRevert(TokenVesting.NothingToRelease.selector);
+        v.release();
+    }
+
+    function test_release_after_duration_full() public {
+        TokenVesting v = _configureA();
+        vm.warp(block.timestamp + uint256(DURATION));
+        assertEq(v.releasable(), VEST_AMOUNT);
+        v.release();
+        assertEq(agentA.balanceOf(creator), VEST_AMOUNT);
+        assertEq(v.released(), VEST_AMOUNT);
+    }
+
+    function test_release_after_duration_far_future_still_caps_at_total() public {
+        TokenVesting v = _configureA();
+        vm.warp(block.timestamp + 10 * uint256(DURATION));
+        v.release();
+        assertEq(agentA.balanceOf(creator), VEST_AMOUNT);
+    }
+
+    function test_release_double_release_safe() public {
+        TokenVesting v = _configureA();
+        vm.warp(block.timestamp + uint256(DURATION) / 4);
+        v.release();
+        uint256 first = agentA.balanceOf(creator);
+
+        vm.warp(block.timestamp + uint256(DURATION) / 4);
+        v.release();
+        uint256 second = agentA.balanceOf(creator) - first;
+
+        // Two quarters released; total should be ~half.
+        uint256 totalReleased = agentA.balanceOf(creator);
+        assertEq(totalReleased, v.released());
+        assertApproxEqAbs(totalReleased, VEST_AMOUNT / 2, 1);
+        assertGt(second, 0);
+    }
+
+    function test_release_via_module_emits_and_forwards() public {
+        TokenVesting v = _configureA();
+        vm.warp(block.timestamp + uint256(DURATION));
+
+        vm.expectEmit(true, true, false, true, address(module));
+        emit Released(address(agentA), address(v), VEST_AMOUNT);
+        uint256 amount = module.release(address(agentA));
+        assertEq(amount, VEST_AMOUNT);
+        assertEq(agentA.balanceOf(creator), VEST_AMOUNT);
+    }
+
+    function test_release_via_module_reverts_unconfigured() public {
+        vm.expectRevert(PreBuyModule.NotConfigured.selector);
+        module.release(address(agentB));
+    }
+
+    // ----- clone independence -----
+
+    function test_configure_two_agents_yields_distinct_clones() public {
+        vm.startPrank(owner);
+        address cloneA = module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+        address cloneB = module.configure(
+            address(agentB), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveB))
+        );
+        vm.stopPrank();
+
+        assertTrue(cloneA != cloneB);
+        // Each clone holds its own bag.
+        assertEq(agentA.balanceOf(cloneA), VEST_AMOUNT);
+        assertEq(agentB.balanceOf(cloneB), VEST_AMOUNT);
+        // Cross-funding is zero.
+        assertEq(agentA.balanceOf(cloneB), 0);
+        assertEq(agentB.balanceOf(cloneA), 0);
+
+        // A release on cloneA does not touch cloneB.
+        vm.warp(block.timestamp + uint256(DURATION));
+        TokenVesting(cloneA).release();
+        assertEq(agentA.balanceOf(creator), VEST_AMOUNT);
+        assertEq(agentB.balanceOf(creator), 0);
+        TokenVesting(cloneB).release();
+        assertEq(agentB.balanceOf(creator), VEST_AMOUNT);
+    }
+
+    function test_predictCloneAddress_matches_deployment() public {
+        address predicted = module.predictCloneAddress(address(agentA));
+        vm.prank(owner);
+        address actual = module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+        assertEq(predicted, actual);
+    }
+
+    // ----- sweep -----
+
+    function test_sweep_only_owner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(this)));
+        module.sweep(IERC20(address(titu)), address(this), 1);
+    }
+
+    function test_sweep_zero_to_reverts() public {
+        vm.prank(owner);
+        vm.expectRevert(PreBuyModule.ZeroAddress.selector);
+        module.sweep(IERC20(address(titu)), address(0), 1);
+    }
+
+    function test_sweep_drains_residual_titu() public {
+        // The setUp pre-funded the module with 10x TITAN_IN. After one
+        // configure, 9x should remain.
+        vm.prank(owner);
+        module.configure(
+            address(agentA), creator, VEST_AMOUNT, CLIFF, DURATION, TITAN_IN, IBondingCurve(address(curveA))
+        );
+        uint256 residual = titu.balanceOf(address(module));
+        assertEq(residual, 9 * TITAN_IN);
+
+        vm.prank(owner);
+        module.sweep(IERC20(address(titu)), owner, residual);
+        assertEq(titu.balanceOf(owner), residual);
+        assertEq(titu.balanceOf(address(module)), 0);
+    }
+
+    // ----- TokenVesting initialize validation (via fresh clones) -----
+    //
+    // The implementation contract is initializer-locked, so to exercise
+    // initialize's revert branches we deploy bare clones in the test and
+    // call them directly.
+
+    function _bareClone() internal returns (TokenVesting) {
+        return TokenVesting(Clones.clone(module.vestingImplementation()));
+    }
+
+    function test_tokenVesting_initialize_reverts_zero_token() public {
+        TokenVesting v = _bareClone();
+        vm.expectRevert(TokenVesting.ZeroAddress.selector);
+        v.initialize(IERC20(address(0)), creator, 1, uint64(block.timestamp), 0, DURATION);
+    }
+
+    function test_tokenVesting_initialize_reverts_zero_beneficiary() public {
+        TokenVesting v = _bareClone();
+        vm.expectRevert(TokenVesting.ZeroAddress.selector);
+        v.initialize(IERC20(address(agentA)), address(0), 1, uint64(block.timestamp), 0, DURATION);
+    }
+
+    function test_tokenVesting_initialize_reverts_zero_total() public {
+        TokenVesting v = _bareClone();
+        vm.expectRevert(TokenVesting.ZeroAmount.selector);
+        v.initialize(IERC20(address(agentA)), creator, 0, uint64(block.timestamp), 0, DURATION);
+    }
+
+    function test_tokenVesting_initialize_reverts_zero_duration() public {
+        TokenVesting v = _bareClone();
+        vm.expectRevert(TokenVesting.ZeroDuration.selector);
+        v.initialize(IERC20(address(agentA)), creator, 1, uint64(block.timestamp), 0, 0);
+    }
+
+    function test_tokenVesting_initialize_reverts_cliff_gt_duration() public {
+        TokenVesting v = _bareClone();
+        vm.expectRevert(TokenVesting.CliffExceedsDuration.selector);
+        v.initialize(IERC20(address(agentA)), creator, 1, uint64(block.timestamp), DURATION + 1, DURATION);
+    }
+
+    // ----- vesting view fuzz -----
+
+    /// @dev `vested` is monotone non-decreasing in time and bounded above by
+    ///      `total` for any timestamp choice.
+    function testFuzz_vested_bounded_and_monotone(uint64 t1, uint64 t2) public {
+        TokenVesting v = _configureA();
+        uint256 baseline = block.timestamp;
+        uint256 cap = uint256(DURATION) * 2;
+        uint256 e1 = bound(uint256(t1), 0, cap);
+        uint256 e2 = bound(uint256(t2), 0, cap);
+        if (e1 > e2) (e1, e2) = (e2, e1);
+
+        vm.warp(baseline + e1);
+        uint256 vested1 = v.vested();
+        vm.warp(baseline + e2);
+        uint256 vested2 = v.vested();
+
+        assertLe(vested1, vested2);
+        assertLe(vested2, VEST_AMOUNT);
+    }
+}


### PR DESCRIPTION
## Summary
- New `PreBuyModule.sol` — creator pre-buys at launch, tokens routed into per-agent EIP-1167 vesting clone.
- Configurable cliff + linear duration.

## Why
Lets creators bootstrap their own bag without front-running snipers, with a public vest that demonstrates skin in the game. Required for M2 module parity.

## Test plan
- [x] `forge fmt --check`
- [x] `forge test --match-path test/unit/PreBuyModule.t.sol`
- [x] full `forge test` green
- [x] `slither` — 0 medium+ findings

Closes #38