### PR TITLE
feat(launchpad): add factory for clone launches

### DIFF
--- a/contracts/evm/src/launchpad/LaunchpadFactory.sol
+++ b/contracts/evm/src/launchpad/LaunchpadFactory.sol
@@ -1,0 +1,671 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {AgentToken} from "./AgentToken.sol";
+import {BondingCurve} from "./BondingCurve.sol";
+import {LPLock} from "./LPLock.sol";
+import {Graduator} from "./Graduator.sol";
+
+import {IBondingCurve} from "./interfaces/IBondingCurve.sol";
+import {IUniswapV2Factory} from "./interfaces/IUniswapV2Factory.sol";
+import {IUniswapV2Router02} from "./interfaces/IUniswapV2Router02.sol";
+
+import {IAntiSniperModule} from "./interfaces/IAntiSniperModule.sol";
+import {ILaunchRadarModule} from "./interfaces/ILaunchRadarModule.sol";
+import {ISixtyDaysModule} from "./interfaces/ISixtyDaysModule.sol";
+import {IAirdropModule} from "./interfaces/IAirdropModule.sol";
+import {ICapitalFormationModule} from "./interfaces/ICapitalFormationModule.sol";
+import {IPreBuyModule} from "./interfaces/IPreBuyModule.sol";
+import {IExistingTokenModule} from "./interfaces/IExistingTokenModule.sol";
+
+/// @title LaunchpadFactory
+/// @notice Single audited launch entry point for the Titular launchpad fleet.
+///         A `launchAgent` call atomically:
+///           1. Clones an `AgentToken` via EIP-1167 minimal proxy (45-byte
+///              runtime), so every per-agent ERC-20 carries identical bytecode
+///              and the deploy gas cost stays bounded.
+///           2. Deploys a fresh `BondingCurve` via `new BondingCurve(...)`.
+///              The curve is constructor-bound (immutables for token sides,
+///              reserves, threshold) and therefore not eligible for cloning
+///              today; this is documented as a deferred refactor and is the
+///              only `new` site on the launch path. The `bondingCurveImpl`
+///              constructor argument is reserved for the future cloneable
+///              variant so deploy scripts can pin the impl in advance.
+///           3. Pre-creates the Uniswap V2 pair so the per-agent {LPLock} can
+///              bind the LP ERC-20 immutably at construction.
+///           4. Deploys a per-agent {LPLock} whose beneficiary is the creator.
+///           5. Wires the curve to the shared {Graduator} via
+///              {BondingCurve.setGraduator} and registers the lock via
+///              {Graduator.registerLPLock} so the graduator knows where to
+///              mint LP at threshold.
+///           6. Dispatches `configure(...)` into every enabled module in the
+///              registry, using a typed interface per known module id and an
+///              explicit `if/else` block — no generic decoder.
+///         Free to launch (gas-only). Per-module fees, if any, are collected
+///         inside the modules themselves on their own configure paths.
+/// @dev    Owner is expected to be a Safe multisig that ALSO holds Ownable
+///         rights on every module the factory dispatches into AND on the
+///         shared {Graduator}. Wiring those ownerships is a deploy-script
+///         responsibility and is deliberately out of scope here so the
+///         factory's surface stays minimal. If the factory is not the
+///         Graduator's owner at {launchAgent} time, the inner
+///         {Graduator.registerLPLock} reverts with `OwnableUnauthorizedAccount`
+///         — fail-loud by design.
+///
+///         Modules are bound to ids by {setModule} so new modules can be
+///         added (or hot-swapped, after audit) without redeploying. Module
+///         dispatch is implemented with explicit `if/else` branches on the
+///         canonical id rather than a generic `bytes` decoder, so each path
+///         is statically auditable. Adding a new module means adding a new
+///         `MODULE_ID_*` constant and a new branch.
+///
+///         CEI is preserved on {launchAgent}: validate -> deploy -> wire ->
+///         persist record + emit -> dispatch into modules. The agent record
+///         is stored before any module call, so an indexer following the
+///         {AgentLaunched} event can rely on {getAgent} immediately. A
+///         per-module revert bubbles up and rolls the whole launch back —
+///         atomicity is preserved. {ReentrancyGuard} covers the pathological
+///         case of a malicious module re-entering {launchAgent} from inside
+///         its own `configure`.
+contract LaunchpadFactory is Ownable, ReentrancyGuard {
+    // ---------------------------------------------------------------------
+    // Types
+    // ---------------------------------------------------------------------
+
+    /// @notice On-chain record of every agent the factory has launched.
+    /// @param token      ERC-20 clone for this agent.
+    /// @param curve      Bonding curve paired with `token`.
+    /// @param lpLock     Per-agent LP lock holding the post-graduation LP.
+    /// @param pair       Uniswap V2 pair pre-created at launch (empty until
+    ///                   graduation seeds it).
+    /// @param creator    Account that called {launchAgent}; recipient of the
+    ///                   locked LP at unlock.
+    /// @param createdAt  Unix timestamp at which the agent was launched.
+    /// @param modules    Module ids the factory dispatched at launch.
+    struct Agent {
+        address token;
+        address curve;
+        address lpLock;
+        address pair;
+        address creator;
+        uint64 createdAt;
+        bytes32[] modules;
+    }
+
+    /// @notice Inbound launch parameters. `enabledModules` and `moduleData`
+    ///         are parallel arrays of equal length; `moduleData[i]` is the
+    ///         abi-encoded configure payload for `enabledModules[i]`.
+    /// @param name            ERC-20 name; non-empty, <= {MAX_NAME_LEN}.
+    /// @param symbol          ERC-20 symbol; non-empty, <= {MAX_SYMBOL_LEN}.
+    /// @param imageURI        Off-chain image pointer (may be empty).
+    /// @param soulURI         Off-chain persona pointer (may be empty).
+    /// @param enabledModules  Canonical module ids to dispatch at launch.
+    /// @param moduleData      Per-module abi-encoded configure payloads.
+    struct LaunchParams {
+        string name;
+        string symbol;
+        string imageURI;
+        string soulURI;
+        bytes32[] enabledModules;
+        bytes[] moduleData;
+    }
+
+    // ---------------------------------------------------------------------
+    // Module ids
+    // ---------------------------------------------------------------------
+
+    /// @notice Canonical id for the AntiSniper module (`keccak256("AntiSniper")`).
+    bytes32 public constant MODULE_ID_ANTI_SNIPER = keccak256("AntiSniper");
+
+    /// @notice Canonical id for the LaunchRadar module (`keccak256("LaunchRadar")`).
+    bytes32 public constant MODULE_ID_LAUNCH_RADAR = keccak256("LaunchRadar");
+
+    /// @notice Canonical id for the SixtyDays module (`keccak256("SixtyDays")`).
+    bytes32 public constant MODULE_ID_SIXTY_DAYS = keccak256("SixtyDays");
+
+    /// @notice Canonical id for the Airdrop module (`keccak256("Airdrop")`).
+    bytes32 public constant MODULE_ID_AIRDROP = keccak256("Airdrop");
+
+    /// @notice Canonical id for the CapitalFormation module
+    ///         (`keccak256("CapitalFormation")`).
+    bytes32 public constant MODULE_ID_CAPITAL_FORMATION = keccak256("CapitalFormation");
+
+    /// @notice Canonical id for the PreBuy module (`keccak256("PreBuy")`).
+    bytes32 public constant MODULE_ID_PRE_BUY = keccak256("PreBuy");
+
+    /// @notice Canonical id for the ExistingToken module
+    ///         (`keccak256("ExistingToken")`).
+    bytes32 public constant MODULE_ID_EXISTING_TOKEN = keccak256("ExistingToken");
+
+    // ---------------------------------------------------------------------
+    // Bounds
+    // ---------------------------------------------------------------------
+
+    /// @notice Hard upper bound on the ERC-20 name length, in bytes. The OZ
+    ///         ERC-20 implementation does not bound `name` itself; we cap
+    ///         here so an attacker cannot pad the name with megabytes of
+    ///         calldata to grief the launch path's gas cost.
+    uint256 public constant MAX_NAME_LEN = 64;
+
+    /// @notice Hard upper bound on the ERC-20 symbol length, in bytes.
+    uint256 public constant MAX_SYMBOL_LEN = 16;
+
+    /// @notice Spec-pinned graduation threshold: real TITU at which trading
+    ///         freezes and graduation may fire. 42_000 TITU at 18 decimals.
+    uint256 public constant GRADUATION_THRESHOLD = 42_000e18;
+
+    /// @notice Virtual quote reserve seeded into every curve. Bounds the
+    ///         initial slope so the first buy does not deliver an absurd
+    ///         agent allocation.
+    uint256 public constant VIRTUAL_QUOTE_RESERVE = 30_000e18;
+
+    /// @notice Virtual agent reserve seeded into every curve. Strictly
+    ///         greater than {INITIAL_AGENT_RESERVE} so the curve always has
+    ///         LP seed left at graduation.
+    uint256 public constant VIRTUAL_AGENT_RESERVE = 1_073_000_000e18;
+
+    /// @notice Real agent inventory the curve is loaded with at construction.
+    ///         Equals the AgentToken total supply (1B) since the entire
+    ///         minted balance lands on the curve.
+    uint256 public constant INITIAL_AGENT_RESERVE = 1_000_000_000e18;
+
+    // ---------------------------------------------------------------------
+    // Immutables
+    // ---------------------------------------------------------------------
+
+    /// @notice TITU quote token used by every bonding curve as the base asset.
+    address public immutable tituToken;
+
+    /// @notice Protocol treasury — surfaced for downstream consumers; not
+    ///         used on the launch path itself (FeeRouter holds the route).
+    address public immutable treasury;
+
+    /// @notice EIP-1167 implementation that every per-agent ERC-20 clones from.
+    address public immutable agentTokenImpl;
+
+    /// @notice EIP-1167 implementation slot reserved for a future cloneable
+    ///         BondingCurve. Stored even though we currently `new` the curve
+    ///         so the constructor signature matches the brief's wiring and
+    ///         the deploy script can pin a real impl when the refactor lands.
+    address public immutable bondingCurveImpl;
+
+    /// @notice Shared FeeRouter every agent token routes its 1% transfer
+    ///         tax to. Bound on every curve and every clone at launch.
+    address public immutable feeRouter;
+
+    /// @notice Shared graduation engine. The factory must already be (or be
+    ///         made) the Ownable owner of this contract before any
+    ///         {launchAgent} call lands; otherwise the inner
+    ///         {Graduator.registerLPLock} reverts.
+    Graduator public immutable graduator;
+
+    /// @notice Uniswap V2 factory used to pre-create the (agentToken, TITU)
+    ///         pair so the LP token address is known at LPLock construction.
+    IUniswapV2Factory public immutable uniV2Factory;
+
+    /// @notice Uniswap V2 router; surfaced for downstream consumers / future
+    ///         modules. The graduator already binds its own router immutably.
+    IUniswapV2Router02 public immutable uniV2Router;
+
+    // ---------------------------------------------------------------------
+    // Storage
+    // ---------------------------------------------------------------------
+
+    /// @notice Module id -> module address. Set by owner via {setModule}.
+    ///         Empty mapping on deploy: the owner registers modules as they
+    ///         go live so the factory can ship before every module exists.
+    mapping(bytes32 moduleId => address module) public modules;
+
+    /// @notice Sequential agent identifier. Always > 0; 0 is reserved for
+    ///         "unset" so `getAgent(0)` reverts.
+    uint256 private _agentIdCounter;
+
+    /// @notice agentId -> on-chain record.
+    mapping(uint256 agentId => Agent) private _agents;
+
+    // ---------------------------------------------------------------------
+    // Events
+    // ---------------------------------------------------------------------
+
+    /// @dev Emitted on {setModule}. `prev` is `address(0)` on first bind.
+    event ModuleSet(bytes32 indexed moduleId, address indexed prev, address indexed module);
+
+    /// @dev Emitted exactly once per successful {launchAgent}. EVM caps at
+    ///      three indexed args, so we index the three values external
+    ///      indexers most commonly query by — `agentId`, `token`, `curve`
+    ///      — and pass the rest as data. `creator` is left non-indexed
+    ///      because creators are queried via the agent record, not by
+    ///      iterating launch events.
+    event AgentLaunched(
+        uint256 indexed agentId,
+        address indexed token,
+        address indexed curve,
+        address creator,
+        address lpLock,
+        address pair,
+        bytes32[] modules
+    );
+
+    // ---------------------------------------------------------------------
+    // Errors
+    // ---------------------------------------------------------------------
+
+    /// @dev Thrown when a constructor or setter receives `address(0)`.
+    error ZeroAddress();
+    /// @dev Thrown when {LaunchParams.name} is empty.
+    error EmptyName();
+    /// @dev Thrown when {LaunchParams.symbol} is empty.
+    error EmptySymbol();
+    /// @dev Thrown when {LaunchParams.name} exceeds {MAX_NAME_LEN}.
+    error NameTooLong();
+    /// @dev Thrown when {LaunchParams.symbol} exceeds {MAX_SYMBOL_LEN}.
+    error SymbolTooLong();
+    /// @dev Thrown when `enabledModules.length != moduleData.length`.
+    error LengthMismatch();
+    /// @dev Thrown when {launchAgent} encounters a module id with no
+    ///      registered address. Carries the offending id for indexer triage.
+    error UnknownModule(bytes32 moduleId);
+    /// @dev Thrown when {launchAgent} encounters the same module id twice in
+    ///      a single launch's `enabledModules` array. Carries the duplicate.
+    error DuplicateModule(bytes32 moduleId);
+    /// @dev Thrown when {setModule} is called with the zero id.
+    error InvalidModuleId();
+    /// @dev Thrown by {getAgent} for an id outside `[1, agentCount]`.
+    error UnknownAgent(uint256 agentId);
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    /// @param tituToken_         TITU quote token. Non-zero.
+    /// @param treasury_          Protocol treasury. Non-zero.
+    /// @param agentTokenImpl_    EIP-1167 implementation for AgentToken.
+    /// @param bondingCurveImpl_  Reserved impl slot for a future cloneable
+    ///                           curve. Required non-zero so deploy scripts
+    ///                           cannot silently leave it unset; not consumed
+    ///                           by the launch path today.
+    /// @param feeRouter_         Shared FeeRouter that receives every
+    ///                           agent's 1% transfer tax. Non-zero.
+    /// @param graduator_         Shared Graduator. The factory must be (or
+    ///                           be made) the Ownable owner of this contract
+    ///                           before {launchAgent} is called.
+    /// @param uniV2Factory_      Uniswap V2 factory used to pre-create pairs.
+    /// @param uniV2Router_       Uniswap V2 router; pinned for downstream use.
+    /// @param owner_             Initial owner; gates {setModule}.
+    constructor(
+        address tituToken_,
+        address treasury_,
+        address agentTokenImpl_,
+        address bondingCurveImpl_,
+        address feeRouter_,
+        address graduator_,
+        address uniV2Factory_,
+        address uniV2Router_,
+        address owner_
+    ) Ownable(_validatedOwner(owner_)) {
+        if (
+            tituToken_ == address(0) || treasury_ == address(0) || agentTokenImpl_ == address(0)
+                || bondingCurveImpl_ == address(0) || feeRouter_ == address(0) || graduator_ == address(0)
+                || uniV2Factory_ == address(0) || uniV2Router_ == address(0)
+        ) revert ZeroAddress();
+
+        tituToken = tituToken_;
+        treasury = treasury_;
+        agentTokenImpl = agentTokenImpl_;
+        bondingCurveImpl = bondingCurveImpl_;
+        feeRouter = feeRouter_;
+        graduator = Graduator(graduator_);
+        uniV2Factory = IUniswapV2Factory(uniV2Factory_);
+        uniV2Router = IUniswapV2Router02(uniV2Router_);
+    }
+
+    /// @dev Hoist the zero-address check above the OZ Ownable constructor so
+    ///      callers see our canonical {ZeroAddress} error instead of OZ's
+    ///      `OwnableInvalidOwner`.
+    function _validatedOwner(address owner_) private pure returns (address) {
+        if (owner_ == address(0)) revert ZeroAddress();
+        return owner_;
+    }
+
+    // ---------------------------------------------------------------------
+    // Admin
+    // ---------------------------------------------------------------------
+
+    /// @notice Bind a module address to a canonical id. Owner-gated.
+    /// @dev    Setting `module = address(0)` is rejected: clearing a binding
+    ///         once a module has gone live is an audit-relevant operation
+    ///         and should go through a deliberate redeploy + governance
+    ///         action rather than a single-tx flip. Reverts on the empty id
+    ///         so `bytes32(0)` cannot be smuggled into a launch as a
+    ///         sentinel.
+    /// @param  moduleId Canonical id (e.g. {MODULE_ID_ANTI_SNIPER}).
+    /// @param  module   Module address to bind. Must be non-zero.
+    function setModule(bytes32 moduleId, address module) external onlyOwner {
+        if (moduleId == bytes32(0)) revert InvalidModuleId();
+        if (module == address(0)) revert ZeroAddress();
+        address prev = modules[moduleId];
+        modules[moduleId] = module;
+        emit ModuleSet(moduleId, prev, module);
+    }
+
+    // ---------------------------------------------------------------------
+    // Launch
+    // ---------------------------------------------------------------------
+
+    /// @notice Atomically launch a new agent.
+    /// @dev    Steps (CEI):
+    ///           1. Validate {LaunchParams} and the enabled-module set.
+    ///           2. Clone AgentToken; deploy BondingCurve, pair, LPLock.
+    ///           3. Initialize the cloned AgentToken (mints supply to curve).
+    ///           4. Wire graduator: register the lock + bind on the curve.
+    ///           5. Persist the agent record and bump the id counter.
+    ///           6. Emit `AgentLaunched`.
+    ///           7. Dispatch into every enabled module via typed interface.
+    ///         Module dispatch is the only block of "external interaction
+    ///         that may revert per-module"; the agent record is already
+    ///         persisted by then so an indexer following `AgentLaunched`
+    ///         sees the agent regardless of which modules ran — and a
+    ///         per-module revert bubbles up and rolls back the entire
+    ///         launch (atomicity preserved). `nonReentrant` covers the
+    ///         pathological case of a malicious module re-entering
+    ///         {launchAgent} from inside its own `configure`.
+    /// @param  params Launch parameters; see {LaunchParams}.
+    /// @return agentToken    The per-agent ERC-20 clone.
+    /// @return bondingCurve  The per-agent BondingCurve.
+    /// @return agentId       Sequential id starting from 1.
+    function launchAgent(LaunchParams calldata params)
+        external
+        nonReentrant
+        returns (address agentToken, address bondingCurve, uint256 agentId)
+    {
+        // --- Checks ---
+        _validateParams(params);
+
+        address creator = msg.sender;
+        address lpLock;
+        address pair;
+
+        // --- Effects (deploy + wire per-agent artifacts) ---
+        // Pulled out of this function so the local-variable footprint of
+        // {launchAgent} fits the EVM's 16-slot stack budget when via-ir
+        // is disabled (the project default; see foundry.toml).
+        (agentToken, bondingCurve, lpLock, pair) = _deployAgentArtifacts(params.name, params.symbol, creator);
+
+        // Persist the record before any module dispatch so an indexer
+        // reading {AgentLaunched} can trust {getAgent} immediately.
+        unchecked {
+            // Counter increments by 1 per launch; cannot overflow within
+            // any realistic block budget (each launch is ~1M gas).
+            agentId = ++_agentIdCounter;
+        }
+        _writeAgentRecord(agentId, agentToken, bondingCurve, lpLock, pair, creator, params.enabledModules);
+
+        emit AgentLaunched(agentId, agentToken, bondingCurve, creator, lpLock, pair, params.enabledModules);
+
+        // --- Interactions (module dispatch) ---
+        // Routed through a private helper to keep this function's stack
+        // under the EVM's 16-slot budget when via-ir is disabled.
+        _dispatchAll(agentToken, bondingCurve, creator, params.enabledModules, params.moduleData);
+    }
+
+    /// @dev Walk the parallel `enabledModules`/`moduleData` arrays and dispatch
+    ///      into each module's typed configure surface. Pulled out of
+    ///      {launchAgent} so the parent stays under the EVM's stack limit.
+    ///      A per-module revert bubbles up and rolls back the entire launch.
+    function _dispatchAll(
+        address agentToken,
+        address bondingCurve,
+        address creator,
+        bytes32[] calldata enabledModules,
+        bytes[] calldata moduleData
+    ) private {
+        uint256 n = enabledModules.length;
+        for (uint256 i = 0; i < n;) {
+            bytes32 id = enabledModules[i];
+            // _validateParams already asserted every id is registered, so a
+            // zero check here would be redundant. We keep the explicit
+            // revert path on dispatch for the case where an unhandled id
+            // sneaks through (defence-in-depth — see {_dispatchModule}).
+            _dispatchModule(id, modules[id], agentToken, bondingCurve, creator, moduleData[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    /// @notice Total number of agents the factory has launched.
+    function agentCount() external view returns (uint256) {
+        return _agentIdCounter;
+    }
+
+    /// @notice Return the on-chain record for `agentId`.
+    /// @dev    Reverts on out-of-range ids (`0` or `> agentCount`) so callers
+    ///         do not have to disambiguate the zero struct from a real record.
+    function getAgent(uint256 agentId) external view returns (Agent memory) {
+        if (agentId == 0 || agentId > _agentIdCounter) revert UnknownAgent(agentId);
+        return _agents[agentId];
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal — deployment helpers
+    // ---------------------------------------------------------------------
+
+    /// @dev Deploy the four per-agent artifacts in dependency order:
+    ///      AgentToken clone -> BondingCurve -> V2 pair -> LPLock, then wire
+    ///      the curve's graduator and the graduator's LP-lock recipient.
+    ///      Pulled out of {launchAgent} purely to keep the caller's stack
+    ///      under the EVM's 16-slot limit; no policy lives here.
+    function _deployAgentArtifacts(string calldata name_, string calldata symbol_, address creator)
+        private
+        returns (address agentToken, address curve, address lpLock, address pair)
+    {
+        // 1) Clone the AgentToken implementation. EIP-1167 minimal proxy:
+        //    constant 45-byte runtime, deterministic deployment cost.
+        agentToken = Clones.clone(agentTokenImpl);
+
+        // 2) Deploy a fresh BondingCurve. NOTE: the merged BondingCurve uses
+        //    constructor + immutables and is therefore not cloneable today.
+        //    The factory's `bondingCurveImpl` slot is reserved for a future
+        //    cloneable refactor; until then `new BondingCurve(...)` is the
+        //    only `new` site on the launch path and is the documented
+        //    deviation from the EIP-1167-everywhere policy.
+        BondingCurve curveContract = new BondingCurve(
+            address(this), // owner — factory will call setGraduator below
+            agentToken,
+            tituToken,
+            feeRouter,
+            VIRTUAL_QUOTE_RESERVE,
+            VIRTUAL_AGENT_RESERVE,
+            GRADUATION_THRESHOLD,
+            INITIAL_AGENT_RESERVE
+        );
+        curve = address(curveContract);
+
+        // 3) Initialize the AgentToken AFTER the curve exists so the freshly
+        //    minted supply lands directly on the curve. AgentToken's
+        //    `_disableInitializers` call in the impl constructor blocks the
+        //    impl itself from being initialized; only clones see this entry.
+        AgentToken(agentToken).initialize(name_, symbol_, creator, feeRouter, curve);
+
+        // 4) Pre-create the V2 pair so the LP ERC-20 address is known at
+        //    LPLock construction. Idempotent on subsequent runs because we
+        //    gate on `getPair` first.
+        pair = _ensurePair(agentToken);
+
+        // 5) Per-agent LPLock binds the LP token immutably; the beneficiary
+        //    is the creator (sole withdrawal recipient at unlock).
+        lpLock = address(new LPLock(IERC20(pair), creator));
+
+        // 6) Wire the graduator: bind the lock target so {Graduator.graduate}
+        //    knows where to mint LP, then bind the graduator on the curve so
+        //    it is authorized to drain the reserves at graduation.
+        //    NOTE: both calls require the factory to be the respective
+        //    contract's owner. {Graduator.registerLPLock} is `onlyOwner` and
+        //    {BondingCurve.setGraduator} is `onlyOwner` (the curve's
+        //    constructor wired the factory as owner above).
+        graduator.registerLPLock(curve, lpLock);
+        curveContract.setGraduator(address(graduator));
+    }
+
+    /// @dev Returns the V2 pair address for `(agentToken, tituToken)`,
+    ///      creating it via the Uniswap V2 factory if missing.
+    function _ensurePair(address agentToken_) private returns (address pair) {
+        pair = uniV2Factory.getPair(agentToken_, tituToken);
+        if (pair == address(0)) {
+            pair = uniV2Factory.createPair(agentToken_, tituToken);
+        }
+    }
+
+    /// @dev Persist the on-chain agent record. Pulled out of {launchAgent}
+    ///      so the parent stays under the stack limit; copies the enabled
+    ///      module ids one-by-one because Solidity does not let us assign
+    ///      a calldata `bytes32[]` directly into a storage `bytes32[]`.
+    function _writeAgentRecord(
+        uint256 agentId,
+        address agentToken,
+        address curve,
+        address lpLock,
+        address pair,
+        address creator,
+        bytes32[] calldata enabledModules
+    ) private {
+        Agent storage rec = _agents[agentId];
+        rec.token = agentToken;
+        rec.curve = curve;
+        rec.lpLock = lpLock;
+        rec.pair = pair;
+        rec.creator = creator;
+        // `block.timestamp` truncated to uint64. Won't wrap before year ~2554.
+        // slither-disable-next-line timestamp
+        rec.createdAt = uint64(block.timestamp);
+        uint256 n = enabledModules.length;
+        for (uint256 i = 0; i < n;) {
+            rec.modules.push(enabledModules[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal — validation
+    // ---------------------------------------------------------------------
+
+    /// @dev Validate {LaunchParams} up-front. Splits into a private function
+    ///      to keep the caller's stack small and group the revert paths.
+    ///      O(n^2) duplicate scan is acceptable: launches are gas-bounded
+    ///      and `n` is bounded by the registry size (<10 today, no
+    ///      realistic growth path that would push it past a few dozen).
+    function _validateParams(LaunchParams calldata params) private view {
+        bytes calldata nameBytes = bytes(params.name);
+        bytes calldata symbolBytes = bytes(params.symbol);
+        if (nameBytes.length == 0) revert EmptyName();
+        if (symbolBytes.length == 0) revert EmptySymbol();
+        if (nameBytes.length > MAX_NAME_LEN) revert NameTooLong();
+        if (symbolBytes.length > MAX_SYMBOL_LEN) revert SymbolTooLong();
+
+        uint256 n = params.enabledModules.length;
+        if (n != params.moduleData.length) revert LengthMismatch();
+        for (uint256 i = 0; i < n;) {
+            bytes32 id = params.enabledModules[i];
+            if (modules[id] == address(0)) revert UnknownModule(id);
+            for (uint256 j = i + 1; j < n;) {
+                if (params.enabledModules[j] == id) revert DuplicateModule(id);
+                unchecked {
+                    ++j;
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal — module dispatch
+    // ---------------------------------------------------------------------
+
+    /// @dev Decode `data` per `id` and forward to the module's typed
+    ///      configure surface. Adding a new module means adding a new
+    ///      branch here AND a `MODULE_ID_*` constant — by design, so that
+    ///      every dispatch path is statically auditable.
+    /// @param  id           Canonical module id.
+    /// @param  module       Registered module address.
+    /// @param  agentToken_  Agent address — first argument to every module's
+    ///                      `configure` (except {ExistingTokenModule}).
+    /// @param  curve        Bonding curve for this launch; passed to modules
+    ///                      that need a per-agent curve binding.
+    /// @param  creator      Agent creator; used as the agent admin for
+    ///                      modules that delegate per-agent control.
+    /// @param  data         abi-encoded module-specific payload.
+    function _dispatchModule(
+        bytes32 id,
+        address module,
+        address agentToken_,
+        address curve,
+        address creator,
+        bytes calldata data
+    ) private {
+        if (id == MODULE_ID_ANTI_SNIPER) {
+            (uint64 startTime, uint32 duration, uint16 startBps, uint16 endBps) =
+                abi.decode(data, (uint64, uint32, uint16, uint16));
+            IAntiSniperModule(module).configure(agentToken_, startTime, duration, startBps, endBps);
+        } else if (id == MODULE_ID_LAUNCH_RADAR) {
+            // LaunchRadar takes a per-agent admin; the factory hands the
+            // creator full mutation rights post-bootstrap so the protocol
+            // owner does not hold per-agent keys.
+            (uint64 startTime, bool whitelistOn) = abi.decode(data, (uint64, bool));
+            ILaunchRadarModule(module).configure(agentToken_, startTime, whitelistOn, creator);
+        } else if (id == MODULE_ID_SIXTY_DAYS) {
+            // SixtyDays binds the curve as the only authorized accrual / contribution
+            // source and the creator as the sole party authorized to commit/refund.
+            (address escrowToken, uint64 startTime) = abi.decode(data, (address, uint64));
+            ISixtyDaysModule(module).configure(agentToken_, escrowToken, curve, creator, startTime);
+        } else if (id == MODULE_ID_AIRDROP) {
+            // Airdrop pre-supply MUST already sit on the module before this dispatch
+            // lands; the module's configure validates the balance covers `allocation`.
+            (bytes32 root, uint64 snapshotBlock, uint128 allocation, uint64 deadline) =
+                abi.decode(data, (bytes32, uint64, uint128, uint64));
+            IAirdropModule(module).configure(agentToken_, root, snapshotBlock, allocation, deadline, creator);
+        } else if (id == MODULE_ID_CAPITAL_FORMATION) {
+            // CapitalFormation needs the V2 pair as its FDV oracle. The factory
+            // does not know which payout token / threshold schedule the creator
+            // wants, so the full payload is abi-decoded from `data`.
+            (address payoutToken, address pair, uint256[] memory thresholds, uint256[] memory payouts) =
+                abi.decode(data, (address, address, uint256[], uint256[]));
+            ICapitalFormationModule(module)
+                .configure(agentToken_, agentToken_, payoutToken, pair, creator, creator, thresholds, payouts);
+        } else if (id == MODULE_ID_PRE_BUY) {
+            // PreBuy requires `titanIn` of TITU to already sit on the module.
+            // The returned vesting-clone address is intentionally discarded —
+            // it is emitted by the module's own `Configured` event so an
+            // indexer can stitch it back to this agent off-chain.
+            (uint256 vestAmount, uint64 cliffSeconds, uint64 durationSeconds, uint256 titanIn) =
+                abi.decode(data, (uint256, uint64, uint64, uint256));
+            // slither-disable-next-line unused-return
+            IPreBuyModule(module)
+                .configure(
+                    agentToken_, creator, vestAmount, cliffSeconds, durationSeconds, titanIn, IBondingCurve(curve)
+                );
+        } else if (id == MODULE_ID_EXISTING_TOKEN) {
+            // ExistingToken's first argument is the external token, not the
+            // agent clone. The supply must already be on the module.
+            (address externalToken, address externalCurve, uint256 supply) =
+                abi.decode(data, (address, address, uint256));
+            IExistingTokenModule(module).configure(externalToken, externalCurve, supply, creator);
+        } else {
+            // Module is registered but no dispatch branch exists yet.
+            // Treat as misconfiguration: revert rather than silently no-op.
+            revert UnknownModule(id);
+        }
+    }
+}

--- a/contracts/evm/src/launchpad/interfaces/IAirdropModule.sol
+++ b/contracts/evm/src/launchpad/interfaces/IAirdropModule.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title  IAirdropModule
+/// @notice Minimal binding the launchpad factory uses to register a per-agent
+///         airdrop manifest on the shared Airdrop module.
+/// @dev    Mirrors {AirdropModule.configure}. Keep in lockstep with
+///         `src/launchpad/modules/AirdropModule.sol`. The configurer (the
+///         factory or a creator script) MUST pre-deposit `allocation` of the
+///         agent token into the module before this call lands; the module
+///         enforces that invariant on `configure`.
+interface IAirdropModule {
+    /// @notice Bind a merkle-proven airdrop manifest to `agent`. One-shot.
+    /// @param  agent          Agent token (the asset airdropped).
+    /// @param  root           Merkle root of `(recipient, amount)` allocations.
+    /// @param  snapshotBlock  Block at which the indexer snapped veTITU.
+    /// @param  allocation     Total airdrop pool, denominated in agent token.
+    /// @param  deadline       Unix timestamp after which dust is sweepable.
+    /// @param  admin          Address authorised to call `sweep`.
+    function configure(
+        address agent,
+        bytes32 root,
+        uint64 snapshotBlock,
+        uint128 allocation,
+        uint64 deadline,
+        address admin
+    ) external;
+}

--- a/contracts/evm/src/launchpad/interfaces/IAntiSniperModule.sol
+++ b/contracts/evm/src/launchpad/interfaces/IAntiSniperModule.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title  IAntiSniperModule
+/// @notice Minimal binding the launchpad factory uses to register a per-agent
+///         decay curve on the shared AntiSniper module at launch.
+/// @dev    Mirrors the public {AntiSniperModule.configure} signature so the
+///         factory can dispatch into the module without importing the full
+///         OZ-laden implementation. Keep this in lockstep with
+///         `src/launchpad/modules/AntiSniperModule.sol` — the module's
+///         `configure` is the one-shot, owner-gated bootstrap path.
+interface IAntiSniperModule {
+    /// @notice Bind a one-shot decay curve to `agent`.
+    /// @param  agent      Agent token address (key).
+    /// @param  startTime  Unix timestamp at which decay begins.
+    /// @param  duration   Decay window in seconds; must be non-zero.
+    /// @param  startBps   Tax rate at `startTime` (<= 10_000).
+    /// @param  endBps     Tax rate at/after `startTime + duration`; <= startBps.
+    function configure(address agent, uint64 startTime, uint32 duration, uint16 startBps, uint16 endBps) external;
+}

--- a/contracts/evm/src/launchpad/interfaces/ICapitalFormationModule.sol
+++ b/contracts/evm/src/launchpad/interfaces/ICapitalFormationModule.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title  ICapitalFormationModule
+/// @notice Minimal binding the launchpad factory uses to register an agent's
+///         FDV-milestone payout schedule on the shared CapitalFormation module.
+/// @dev    Mirrors {CapitalFormationModule.configure}. Keep in lockstep with
+///         `src/launchpad/modules/CapitalFormationModule.sol`. The configurer
+///         MUST pre-deposit the sum of `payoutsUsdc` of `payoutToken` into the
+///         module before this call lands.
+interface ICapitalFormationModule {
+    /// @notice Register an FDV-milestone payout schedule for `agent`.
+    /// @param  agent          Storage key (typically the agent ERC-20).
+    /// @param  agentToken     Agent ERC-20 used to compute FDV.
+    /// @param  payoutToken    Token paid out at each milestone (e.g. USDC).
+    /// @param  pair           Uniswap V2 pair used as the FDV oracle.
+    /// @param  creator        Recipient of the payouts.
+    /// @param  agentAdmin     Per-agent admin authorized post-bootstrap.
+    /// @param  fdvThresholds  Sorted FDV thresholds (in USD wei).
+    /// @param  payoutsUsdc    Parallel array of payout amounts.
+    function configure(
+        address agent,
+        address agentToken,
+        address payoutToken,
+        address pair,
+        address creator,
+        address agentAdmin,
+        uint256[] calldata fdvThresholds,
+        uint256[] calldata payoutsUsdc
+    ) external;
+}

--- a/contracts/evm/src/launchpad/interfaces/IExistingTokenModule.sol
+++ b/contracts/evm/src/launchpad/interfaces/IExistingTokenModule.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title  IExistingTokenModule
+/// @notice Minimal binding the launchpad factory uses to wrap an existing
+///         ERC-20 onto a fresh bonding curve via the shared ExistingToken
+///         module.
+/// @dev    Mirrors {ExistingTokenModule.configure}. Keep in lockstep with
+///         `src/launchpad/modules/ExistingTokenModule.sol`. The configurer
+///         MUST pre-deposit `supply` of `externalToken` into the module before
+///         this call lands.
+interface IExistingTokenModule {
+    /// @notice Wrap `externalToken` onto `curve`. One-shot per token.
+    /// @param  externalToken  ERC-20 being wrapped (storage key).
+    /// @param  curve          Bonding curve to seed with `supply`.
+    /// @param  supply         Tokens to forward into the curve.
+    /// @param  admin          Creator / admin recorded on the wrap.
+    function configure(address externalToken, address curve, uint256 supply, address admin) external;
+}

--- a/contracts/evm/src/launchpad/interfaces/ILaunchRadarModule.sol
+++ b/contracts/evm/src/launchpad/interfaces/ILaunchRadarModule.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title  ILaunchRadarModule
+/// @notice Minimal binding the launchpad factory uses to register an agent on
+///         the shared LaunchRadar module at launch.
+/// @dev    Mirrors the public {LaunchRadarModule.configure} signature so the
+///         factory can dispatch without importing the full OZ-laden module.
+///         Keep in lockstep with `src/launchpad/modules/LaunchRadarModule.sol`.
+interface ILaunchRadarModule {
+    /// @notice Register a brand-new agent on the radar. One-shot per agent.
+    /// @param  agent        Agent token address being registered.
+    /// @param  startTime    Unix timestamp trading unlocks at.
+    /// @param  whitelistOn  Initial state of the whitelist gate.
+    /// @param  agentAdmin   Address authorized to mutate this agent's gating
+    ///                      after the bootstrap configure call.
+    function configure(address agent, uint64 startTime, bool whitelistOn, address agentAdmin) external;
+}

--- a/contracts/evm/src/launchpad/interfaces/IPreBuyModule.sol
+++ b/contracts/evm/src/launchpad/interfaces/IPreBuyModule.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IBondingCurve} from "./IBondingCurve.sol";
+
+/// @title  IPreBuyModule
+/// @notice Minimal binding the launchpad factory uses to bootstrap a creator
+///         pre-buy + vesting clone via the shared PreBuy module.
+/// @dev    Mirrors {PreBuyModule.configure}. Keep in lockstep with
+///         `src/launchpad/modules/PreBuyModule.sol`. `titanIn` of the curve's
+///         quote token MUST be pre-funded onto the module before this call.
+interface IPreBuyModule {
+    /// @notice Configure the pre-buy + vest for `agent`.
+    /// @param  agent            Agent ERC-20 address.
+    /// @param  creator          Vest beneficiary.
+    /// @param  vestAmount       Agent tokens locked into the vesting clone.
+    /// @param  cliffSeconds     Cliff before any vesting unlocks.
+    /// @param  durationSeconds  Total vest duration (must be > 0, >= cliff).
+    /// @param  titanIn          Quote (TITU) the curve will pull.
+    /// @param  curve            Bonding curve for `agent`.
+    /// @return clone            Newly-deployed vesting clone.
+    function configure(
+        address agent,
+        address creator,
+        uint256 vestAmount,
+        uint64 cliffSeconds,
+        uint64 durationSeconds,
+        uint256 titanIn,
+        IBondingCurve curve
+    ) external returns (address clone);
+}

--- a/contracts/evm/src/launchpad/interfaces/ISixtyDaysModule.sol
+++ b/contracts/evm/src/launchpad/interfaces/ISixtyDaysModule.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title  ISixtyDaysModule
+/// @notice Minimal binding the launchpad factory uses to bootstrap the 60-day
+///         creator escrow on the shared SixtyDays module.
+/// @dev    Mirrors {SixtyDaysModule.configure}. Keep in lockstep with
+///         `src/launchpad/modules/SixtyDaysModule.sol`.
+interface ISixtyDaysModule {
+    /// @notice Bootstrap an agent on the 60-day module. One-shot per agent.
+    /// @param  agent          Agent ERC-20 address (storage key).
+    /// @param  escrowToken    Token escrowed (creator-leg fee currency).
+    /// @param  bondingCurve   Curve allowed to push accruals + contributions.
+    /// @param  creator        Creator allowed to commit or refund.
+    /// @param  startTime      Unix seconds the 60-day clock starts at.
+    function configure(address agent, address escrowToken, address bondingCurve, address creator, uint64 startTime)
+        external;
+}

--- a/contracts/evm/test/unit/LaunchpadFactory.t.sol
+++ b/contracts/evm/test/unit/LaunchpadFactory.t.sol
@@ -1,0 +1,880 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {LaunchpadFactory} from "../../src/launchpad/LaunchpadFactory.sol";
+import {AgentToken} from "../../src/launchpad/AgentToken.sol";
+import {BondingCurve} from "../../src/launchpad/BondingCurve.sol";
+import {LPLock} from "../../src/launchpad/LPLock.sol";
+import {Graduator} from "../../src/launchpad/Graduator.sol";
+
+import {IUniswapV2Router02} from "../../src/launchpad/interfaces/IUniswapV2Router02.sol";
+
+import {MockUniswapV2Factory} from "../mocks/MockUniswapV2Factory.sol";
+import {MockUniswapV2Router} from "../mocks/MockUniswapV2Router.sol";
+import {MockMintableERC20} from "../mocks/MockERC20.sol";
+
+/// @dev Per-id mock module that records every `configure(...)` call so the
+///      dispatch matrix can be asserted from tests. Each instance is bound to
+///      a single canonical id so the Solidity ABI shape exactly matches the
+///      typed interface the factory dispatches against. The mock asserts the
+///      caller is the factory (Ownable-style) so we exercise the
+///      "factory holds Ownable on every module" invariant.
+contract MockConfigurableModule {
+    address public immutable owner;
+    bool public shouldRevert;
+    bytes public lastSelector;
+    uint256 public callCount;
+    address public lastAgent;
+    bytes public lastPayload;
+    bool public reentryAttempted;
+    address public reentrancyTarget;
+
+    error NotOwner();
+    error Boom();
+
+    constructor(address owner_) {
+        owner = owner_;
+    }
+
+    /// @dev Switch the next `configure*` call to revert with `Boom()`.
+    function setShouldRevert(bool flag) external {
+        shouldRevert = flag;
+    }
+
+    /// @dev Arm the module to attempt a reentrant `launchAgent` inside its
+    ///      next configure call. Used to verify the factory's
+    ///      `nonReentrant` guard.
+    function armReentry(address factory) external {
+        reentrancyTarget = factory;
+    }
+
+    function _onCall(string memory selector, address agent, bytes memory payload) private {
+        if (msg.sender != owner) revert NotOwner();
+        if (shouldRevert) revert Boom();
+        if (reentrancyTarget != address(0)) {
+            reentryAttempted = true;
+            address t = reentrancyTarget;
+            // Reset so we attempt only once even if the outer tx is retried.
+            reentrancyTarget = address(0);
+            // Build a minimal LaunchParams payload and call back into the
+            // factory. The factory's `nonReentrant` guard MUST revert this.
+            LaunchpadFactory.LaunchParams memory p = LaunchpadFactory.LaunchParams({
+                name: "Reentry",
+                symbol: "REE",
+                imageURI: "",
+                soulURI: "",
+                enabledModules: new bytes32[](0),
+                moduleData: new bytes[](0)
+            });
+            LaunchpadFactory(t).launchAgent(p);
+        }
+        lastSelector = bytes(selector);
+        lastAgent = agent;
+        lastPayload = payload;
+        unchecked {
+            ++callCount;
+        }
+    }
+
+    // --- IAntiSniperModule ---
+    function configure(address agent, uint64 startTime, uint32 duration, uint16 startBps, uint16 endBps) external {
+        _onCall("anti-sniper", agent, abi.encode(startTime, duration, startBps, endBps));
+    }
+
+    // --- ILaunchRadarModule ---
+    function configure(address agent, uint64 startTime, bool whitelistOn, address agentAdmin) external {
+        _onCall("launch-radar", agent, abi.encode(startTime, whitelistOn, agentAdmin));
+    }
+
+    // --- ISixtyDaysModule ---
+    function configure(address agent, address escrowToken, address curve, address creator, uint64 startTime) external {
+        _onCall("sixty-days", agent, abi.encode(escrowToken, curve, creator, startTime));
+    }
+
+    // --- IAirdropModule ---
+    function configure(
+        address agent,
+        bytes32 root,
+        uint64 snapshotBlock,
+        uint128 allocation,
+        uint64 deadline,
+        address admin
+    ) external {
+        _onCall("airdrop", agent, abi.encode(root, snapshotBlock, allocation, deadline, admin));
+    }
+
+    // --- ICapitalFormationModule ---
+    function configure(
+        address agent,
+        address agentToken_,
+        address payoutToken,
+        address pair,
+        address creator,
+        address agentAdmin,
+        uint256[] calldata fdvThresholds,
+        uint256[] calldata payoutsUsdc
+    ) external {
+        _onCall("capital-formation", agent, abi.encode(agentToken_, payoutToken, pair, creator, agentAdmin));
+        // Silence unused params (event-encoded only as a smoke test).
+        fdvThresholds;
+        payoutsUsdc;
+    }
+
+    // --- IPreBuyModule ---
+    function configure(
+        address agent,
+        address creator,
+        uint256 vestAmount,
+        uint64 cliffSeconds,
+        uint64 durationSeconds,
+        uint256 titanIn,
+        address curve
+    ) external returns (address clone) {
+        _onCall("pre-buy", agent, abi.encode(creator, vestAmount, cliffSeconds, durationSeconds, titanIn, curve));
+        return address(this); // sentinel — never read by the factory
+    }
+
+    // --- IExistingTokenModule ---
+    function configure(address externalToken, address curve, uint256 supply, address admin) external {
+        _onCall("existing-token", externalToken, abi.encode(curve, supply, admin));
+    }
+}
+
+contract LaunchpadFactoryTest is Test {
+    // ---------------------------------------------------------------------
+    // Fixtures
+    // ---------------------------------------------------------------------
+    LaunchpadFactory internal factory;
+    AgentToken internal agentTokenImpl;
+    BondingCurve internal bondingCurveImpl; // sentinel; not consumed by launch path
+    Graduator internal graduator;
+    MockMintableERC20 internal titu;
+    MockUniswapV2Factory internal uniFactory;
+    MockUniswapV2Router internal router;
+
+    address internal owner = address(0xA0);
+    address internal treasury = address(0x7);
+    address internal feeRouter = address(0xFEE);
+    address internal alice = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    // ---------------------------------------------------------------------
+    // Events (mirror the contract for vm.expectEmit)
+    // ---------------------------------------------------------------------
+    event ModuleSet(bytes32 indexed moduleId, address indexed prev, address indexed module);
+    event AgentLaunched(
+        uint256 indexed agentId,
+        address indexed token,
+        address indexed curve,
+        address creator,
+        address lpLock,
+        address pair,
+        bytes32[] modules
+    );
+
+    // ---------------------------------------------------------------------
+    // Setup
+    // ---------------------------------------------------------------------
+    function setUp() public {
+        agentTokenImpl = new AgentToken();
+        // Deploy a sentinel bonding-curve impl. Using address(this) as owner
+        // satisfies the constructor's non-zero check; the slot is reserved on
+        // the factory and never invoked by launch.
+        bondingCurveImpl = new BondingCurve(
+            address(this),
+            address(uint160(uint256(keccak256("agent")))),
+            address(uint160(uint256(keccak256("titu")))),
+            address(uint160(uint256(keccak256("router")))),
+            30_000e18,
+            1_073_000_000e18,
+            42_000e18,
+            1_000_000_000e18
+        );
+
+        titu = new MockMintableERC20("TITU", "TITU");
+        uniFactory = new MockUniswapV2Factory();
+        router = new MockUniswapV2Router(address(uniFactory));
+
+        // Graduator owned by the factory-to-be: easiest to construct first
+        // with a placeholder, then transfer ownership after the factory is
+        // up. We use the more direct path: pre-compute the factory address
+        // is unnecessary — the brief explicitly says "deploy script
+        // transfers ownership". So `owner` deploys the graduator and then
+        // hands ownership off in the test path.
+        graduator = new Graduator(IUniswapV2Router02(address(router)), owner);
+
+        factory = new LaunchpadFactory(
+            address(titu),
+            treasury,
+            address(agentTokenImpl),
+            address(bondingCurveImpl),
+            feeRouter,
+            address(graduator),
+            address(uniFactory),
+            address(router),
+            owner
+        );
+
+        // Hand graduator ownership to the factory so the launch path can
+        // call `registerLPLock`.
+        vm.prank(owner);
+        graduator.transferOwnership(address(factory));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    function _bareParams(string memory name, string memory symbol)
+        internal
+        pure
+        returns (LaunchpadFactory.LaunchParams memory p)
+    {
+        p.name = name;
+        p.symbol = symbol;
+        p.imageURI = "ipfs://image";
+        p.soulURI = "ipfs://soul";
+        p.enabledModules = new bytes32[](0);
+        p.moduleData = new bytes[](0);
+    }
+
+    function _setMockModule(bytes32 id) internal returns (MockConfigurableModule m) {
+        m = new MockConfigurableModule(address(factory));
+        vm.prank(owner);
+        factory.setModule(id, address(m));
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor
+    // ---------------------------------------------------------------------
+
+    function test_constructor_sets_state() public view {
+        assertEq(factory.tituToken(), address(titu));
+        assertEq(factory.treasury(), treasury);
+        assertEq(factory.agentTokenImpl(), address(agentTokenImpl));
+        assertEq(factory.bondingCurveImpl(), address(bondingCurveImpl));
+        assertEq(factory.feeRouter(), feeRouter);
+        assertEq(address(factory.graduator()), address(graduator));
+        assertEq(address(factory.uniV2Factory()), address(uniFactory));
+        assertEq(address(factory.uniV2Router()), address(router));
+        assertEq(factory.owner(), owner);
+        assertEq(factory.agentCount(), 0);
+        assertEq(factory.GRADUATION_THRESHOLD(), 42_000e18);
+        assertEq(factory.MAX_NAME_LEN(), 64);
+        assertEq(factory.MAX_SYMBOL_LEN(), 16);
+    }
+
+    function test_constructor_revert_zero_titu() public {
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        new LaunchpadFactory(
+            address(0),
+            treasury,
+            address(agentTokenImpl),
+            address(bondingCurveImpl),
+            feeRouter,
+            address(graduator),
+            address(uniFactory),
+            address(router),
+            owner
+        );
+    }
+
+    function test_constructor_revert_zero_treasury() public {
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        new LaunchpadFactory(
+            address(titu),
+            address(0),
+            address(agentTokenImpl),
+            address(bondingCurveImpl),
+            feeRouter,
+            address(graduator),
+            address(uniFactory),
+            address(router),
+            owner
+        );
+    }
+
+    function test_constructor_revert_zero_agent_token_impl() public {
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        new LaunchpadFactory(
+            address(titu),
+            treasury,
+            address(0),
+            address(bondingCurveImpl),
+            feeRouter,
+            address(graduator),
+            address(uniFactory),
+            address(router),
+            owner
+        );
+    }
+
+    function test_constructor_revert_zero_bonding_curve_impl() public {
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        new LaunchpadFactory(
+            address(titu),
+            treasury,
+            address(agentTokenImpl),
+            address(0),
+            feeRouter,
+            address(graduator),
+            address(uniFactory),
+            address(router),
+            owner
+        );
+    }
+
+    function test_constructor_revert_zero_fee_router() public {
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        new LaunchpadFactory(
+            address(titu),
+            treasury,
+            address(agentTokenImpl),
+            address(bondingCurveImpl),
+            address(0),
+            address(graduator),
+            address(uniFactory),
+            address(router),
+            owner
+        );
+    }
+
+    function test_constructor_revert_zero_graduator() public {
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        new LaunchpadFactory(
+            address(titu),
+            treasury,
+            address(agentTokenImpl),
+            address(bondingCurveImpl),
+            feeRouter,
+            address(0),
+            address(uniFactory),
+            address(router),
+            owner
+        );
+    }
+
+    function test_constructor_revert_zero_uni_factory() public {
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        new LaunchpadFactory(
+            address(titu),
+            treasury,
+            address(agentTokenImpl),
+            address(bondingCurveImpl),
+            feeRouter,
+            address(graduator),
+            address(0),
+            address(router),
+            owner
+        );
+    }
+
+    function test_constructor_revert_zero_uni_router() public {
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        new LaunchpadFactory(
+            address(titu),
+            treasury,
+            address(agentTokenImpl),
+            address(bondingCurveImpl),
+            feeRouter,
+            address(graduator),
+            address(uniFactory),
+            address(0),
+            owner
+        );
+    }
+
+    function test_constructor_revert_zero_owner() public {
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        new LaunchpadFactory(
+            address(titu),
+            treasury,
+            address(agentTokenImpl),
+            address(bondingCurveImpl),
+            feeRouter,
+            address(graduator),
+            address(uniFactory),
+            address(router),
+            address(0)
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // setModule
+    // ---------------------------------------------------------------------
+
+    function test_setModule_happy_path_emits_event() public {
+        MockConfigurableModule m = new MockConfigurableModule(address(factory));
+        bytes32 id = factory.MODULE_ID_ANTI_SNIPER();
+
+        vm.expectEmit(true, true, true, true, address(factory));
+        emit ModuleSet(id, address(0), address(m));
+
+        vm.prank(owner);
+        factory.setModule(id, address(m));
+
+        assertEq(factory.modules(id), address(m));
+    }
+
+    function test_setModule_overwrite_emits_prev() public {
+        MockConfigurableModule a = new MockConfigurableModule(address(factory));
+        MockConfigurableModule b = new MockConfigurableModule(address(factory));
+        bytes32 id = factory.MODULE_ID_ANTI_SNIPER();
+
+        vm.prank(owner);
+        factory.setModule(id, address(a));
+
+        vm.expectEmit(true, true, true, true, address(factory));
+        emit ModuleSet(id, address(a), address(b));
+
+        vm.prank(owner);
+        factory.setModule(id, address(b));
+
+        assertEq(factory.modules(id), address(b));
+    }
+
+    function test_setModule_revert_when_not_owner() public {
+        MockConfigurableModule m = new MockConfigurableModule(address(factory));
+        bytes32 id = factory.MODULE_ID_ANTI_SNIPER();
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        factory.setModule(id, address(m));
+    }
+
+    function test_setModule_revert_zero_address() public {
+        bytes32 id = factory.MODULE_ID_ANTI_SNIPER();
+        vm.prank(owner);
+        vm.expectRevert(LaunchpadFactory.ZeroAddress.selector);
+        factory.setModule(id, address(0));
+    }
+
+    function test_setModule_revert_zero_id() public {
+        MockConfigurableModule m = new MockConfigurableModule(address(factory));
+        vm.prank(owner);
+        vm.expectRevert(LaunchpadFactory.InvalidModuleId.selector);
+        factory.setModule(bytes32(0), address(m));
+    }
+
+    // ---------------------------------------------------------------------
+    // launchAgent — happy paths
+    // ---------------------------------------------------------------------
+
+    function test_launchAgent_no_modules_wires_state() public {
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+
+        vm.prank(alice);
+        (address agentToken, address curve, uint256 agentId) = factory.launchAgent(p);
+
+        assertEq(agentId, 1);
+        assertEq(factory.agentCount(), 1);
+
+        // AgentToken state.
+        AgentToken at = AgentToken(agentToken);
+        assertEq(at.name(), "Agent A");
+        assertEq(at.symbol(), "AGA");
+        assertEq(at.creator(), alice);
+        assertEq(at.feeRouter(), feeRouter);
+        assertEq(at.bondingCurve(), curve);
+        assertEq(at.totalSupply(), at.TOTAL_SUPPLY());
+        assertEq(at.balanceOf(curve), at.TOTAL_SUPPLY());
+
+        // BondingCurve state.
+        BondingCurve bc = BondingCurve(curve);
+        assertEq(bc.agentToken(), agentToken);
+        assertEq(bc.quoteToken(), address(titu));
+        assertEq(bc.feeRouter(), feeRouter);
+        assertEq(bc.graduationThreshold(), 42_000e18);
+        assertEq(bc.graduator(), address(graduator));
+        assertEq(bc.realAgentReserve(), 1_000_000_000e18);
+
+        // Per-agent record.
+        LaunchpadFactory.Agent memory rec = factory.getAgent(1);
+        assertEq(rec.token, agentToken);
+        assertEq(rec.curve, curve);
+        assertEq(rec.creator, alice);
+        assertTrue(rec.lpLock != address(0));
+        assertTrue(rec.pair != address(0));
+        assertEq(rec.modules.length, 0);
+
+        // LPLock binds the pair as its LP token, beneficiary = creator.
+        LPLock lock = LPLock(rec.lpLock);
+        assertEq(address(lock.lpToken()), rec.pair);
+        assertEq(lock.beneficiary(), alice);
+
+        // Graduator wired to the right lock.
+        assertEq(graduator.lpLocks(curve), rec.lpLock);
+    }
+
+    function test_launchAgent_emits_event() public {
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+
+        // We only assert the indexed fields strictly because the address
+        // values for `lpLock` / `pair` aren't known until launch.
+        vm.recordLogs();
+        vm.prank(alice);
+        (address agentToken, address curve, uint256 agentId) = factory.launchAgent(p);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 sig = keccak256("AgentLaunched(uint256,address,address,address,address,address,bytes32[])");
+        bool found;
+        for (uint256 i = 0; i < logs.length; ++i) {
+            if (logs[i].topics.length == 0) continue;
+            if (logs[i].topics[0] != sig) continue;
+            // topics: [sig, agentId, token, curve]
+            assertEq(uint256(logs[i].topics[1]), agentId);
+            assertEq(address(uint160(uint256(logs[i].topics[2]))), agentToken);
+            assertEq(address(uint160(uint256(logs[i].topics[3]))), curve);
+            // data: (creator, lpLock, pair, modules)
+            (address creator, address lpLock_, address pair_, bytes32[] memory mods) =
+                abi.decode(logs[i].data, (address, address, address, bytes32[]));
+            assertEq(creator, alice);
+            assertEq(mods.length, 0);
+            assertGt(uint160(lpLock_), 0);
+            assertGt(uint160(pair_), 0);
+            found = true;
+            break;
+        }
+        assertTrue(found, "AgentLaunched event missing");
+    }
+
+    function test_launchAgent_two_consecutive_increment_id() public {
+        LaunchpadFactory.LaunchParams memory p1 = _bareParams("Agent A", "AGA");
+        LaunchpadFactory.LaunchParams memory p2 = _bareParams("Agent B", "AGB");
+
+        vm.prank(alice);
+        (,, uint256 id1) = factory.launchAgent(p1);
+        vm.prank(bob);
+        (,, uint256 id2) = factory.launchAgent(p2);
+
+        assertEq(id1, 1);
+        assertEq(id2, 2);
+        assertEq(factory.agentCount(), 2);
+
+        LaunchpadFactory.Agent memory rec1 = factory.getAgent(1);
+        LaunchpadFactory.Agent memory rec2 = factory.getAgent(2);
+        assertEq(rec1.creator, alice);
+        assertEq(rec2.creator, bob);
+        assertTrue(rec1.token != rec2.token, "tokens must differ");
+        assertTrue(rec1.curve != rec2.curve, "curves must differ");
+    }
+
+    function test_launchAgent_creates_eip1167_clone_with_45_byte_runtime() public {
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+        vm.prank(alice);
+        (address agentToken,,) = factory.launchAgent(p);
+
+        bytes memory rt = agentToken.code;
+        assertEq(rt.length, 45, "EIP-1167 clone runtime must be 45 bytes");
+
+        // EIP-1167 minimal proxy bytes:
+        //   3d602d80600a3d3981f3 363d3d373d3d3d363d73 <impl 20 bytes> 5af43d82803e903d91602b57fd5bf3
+        // Verify the prefix and suffix; the middle 20 bytes are the impl.
+        bytes memory prefix = hex"363d3d373d3d3d363d73";
+        bytes memory suffix = hex"5af43d82803e903d91602b57fd5bf3";
+        // Skip the leading constructor (10 bytes) since we read runtime, not creation.
+        for (uint256 i = 0; i < prefix.length; ++i) {
+            assertEq(rt[i], prefix[i]);
+        }
+        bytes20 impl;
+        assembly {
+            // rt[10..30] is the impl address. rt is `bytes memory`, so its
+            // payload starts at offset 0x20 from the pointer.
+            impl := mload(add(add(rt, 0x20), 10))
+        }
+        assertEq(address(impl), address(agentTokenImpl));
+        for (uint256 i = 0; i < suffix.length; ++i) {
+            assertEq(rt[30 + i], suffix[i]);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // launchAgent — module dispatch
+    // ---------------------------------------------------------------------
+
+    function test_launchAgent_with_one_module_dispatches() public {
+        MockConfigurableModule m = _setMockModule(factory.MODULE_ID_ANTI_SNIPER());
+
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = factory.MODULE_ID_ANTI_SNIPER();
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encode(uint64(100), uint32(60), uint16(9900), uint16(100));
+        p.enabledModules = ids;
+        p.moduleData = data;
+
+        vm.prank(alice);
+        (address agentToken,,) = factory.launchAgent(p);
+
+        assertEq(m.callCount(), 1);
+        assertEq(m.lastAgent(), agentToken);
+        assertEq(string(m.lastSelector()), "anti-sniper");
+    }
+
+    function test_launchAgent_dispatch_all_seven_modules() public {
+        // Bind one mock per id and dispatch all seven in a single launch.
+        MockConfigurableModule mAS = _setMockModule(factory.MODULE_ID_ANTI_SNIPER());
+        MockConfigurableModule mLR = _setMockModule(factory.MODULE_ID_LAUNCH_RADAR());
+        MockConfigurableModule m60 = _setMockModule(factory.MODULE_ID_SIXTY_DAYS());
+        MockConfigurableModule mAD = _setMockModule(factory.MODULE_ID_AIRDROP());
+        MockConfigurableModule mCF = _setMockModule(factory.MODULE_ID_CAPITAL_FORMATION());
+        MockConfigurableModule mPB = _setMockModule(factory.MODULE_ID_PRE_BUY());
+        MockConfigurableModule mET = _setMockModule(factory.MODULE_ID_EXISTING_TOKEN());
+
+        bytes32[] memory ids = new bytes32[](7);
+        ids[0] = factory.MODULE_ID_ANTI_SNIPER();
+        ids[1] = factory.MODULE_ID_LAUNCH_RADAR();
+        ids[2] = factory.MODULE_ID_SIXTY_DAYS();
+        ids[3] = factory.MODULE_ID_AIRDROP();
+        ids[4] = factory.MODULE_ID_CAPITAL_FORMATION();
+        ids[5] = factory.MODULE_ID_PRE_BUY();
+        ids[6] = factory.MODULE_ID_EXISTING_TOKEN();
+
+        bytes[] memory data = new bytes[](7);
+        data[0] = abi.encode(uint64(100), uint32(60), uint16(9900), uint16(100));
+        data[1] = abi.encode(uint64(200), true);
+        data[2] = abi.encode(address(titu), uint64(300));
+        data[3] = abi.encode(bytes32(uint256(0xABCD)), uint64(123), uint128(5_000_000e18), uint64(456));
+        uint256[] memory thresholds = new uint256[](2);
+        thresholds[0] = 2_000_000e18;
+        thresholds[1] = 10_000_000e18;
+        uint256[] memory payouts = new uint256[](2);
+        payouts[0] = 100_000e6;
+        payouts[1] = 500_000e6;
+        data[4] = abi.encode(address(titu), address(0xCAFE), thresholds, payouts);
+        data[5] = abi.encode(uint256(50_000e18), uint64(60), uint64(86_400), uint256(100e18));
+        data[6] = abi.encode(address(0xEEEE), address(0xDDDD), uint256(10_000e18));
+
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+        p.enabledModules = ids;
+        p.moduleData = data;
+
+        vm.prank(alice);
+        factory.launchAgent(p);
+
+        assertEq(mAS.callCount(), 1);
+        assertEq(mLR.callCount(), 1);
+        assertEq(m60.callCount(), 1);
+        assertEq(mAD.callCount(), 1);
+        assertEq(mCF.callCount(), 1);
+        assertEq(mPB.callCount(), 1);
+        assertEq(mET.callCount(), 1);
+
+        assertEq(string(mAS.lastSelector()), "anti-sniper");
+        assertEq(string(mLR.lastSelector()), "launch-radar");
+        assertEq(string(m60.lastSelector()), "sixty-days");
+        assertEq(string(mAD.lastSelector()), "airdrop");
+        assertEq(string(mCF.lastSelector()), "capital-formation");
+        assertEq(string(mPB.lastSelector()), "pre-buy");
+        assertEq(string(mET.lastSelector()), "existing-token");
+    }
+
+    function test_launchAgent_module_revert_propagates() public {
+        MockConfigurableModule m = _setMockModule(factory.MODULE_ID_ANTI_SNIPER());
+        m.setShouldRevert(true);
+
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = factory.MODULE_ID_ANTI_SNIPER();
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encode(uint64(0), uint32(1), uint16(0), uint16(0));
+
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+        p.enabledModules = ids;
+        p.moduleData = data;
+
+        vm.prank(alice);
+        vm.expectRevert(MockConfigurableModule.Boom.selector);
+        factory.launchAgent(p);
+        // Counter should not advance on revert.
+        assertEq(factory.agentCount(), 0);
+    }
+
+    function test_launchAgent_unknown_module_revert() public {
+        bytes32 weirdId = keccak256("never-registered");
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = weirdId;
+        bytes[] memory data = new bytes[](1);
+        data[0] = bytes("");
+
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+        p.enabledModules = ids;
+        p.moduleData = data;
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(LaunchpadFactory.UnknownModule.selector, weirdId));
+        factory.launchAgent(p);
+    }
+
+    function test_launchAgent_duplicate_module_revert() public {
+        _setMockModule(factory.MODULE_ID_ANTI_SNIPER());
+
+        bytes32 id = factory.MODULE_ID_ANTI_SNIPER();
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = id;
+        ids[1] = id;
+        bytes[] memory data = new bytes[](2);
+        data[0] = abi.encode(uint64(0), uint32(1), uint16(0), uint16(0));
+        data[1] = abi.encode(uint64(0), uint32(1), uint16(0), uint16(0));
+
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+        p.enabledModules = ids;
+        p.moduleData = data;
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(LaunchpadFactory.DuplicateModule.selector, id));
+        factory.launchAgent(p);
+    }
+
+    function test_launchAgent_length_mismatch_revert() public {
+        _setMockModule(factory.MODULE_ID_ANTI_SNIPER());
+
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = factory.MODULE_ID_ANTI_SNIPER();
+        bytes[] memory data = new bytes[](2);
+        data[0] = bytes("");
+        data[1] = bytes("");
+
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+        p.enabledModules = ids;
+        p.moduleData = data;
+
+        vm.prank(alice);
+        vm.expectRevert(LaunchpadFactory.LengthMismatch.selector);
+        factory.launchAgent(p);
+    }
+
+    // ---------------------------------------------------------------------
+    // launchAgent — input validation
+    // ---------------------------------------------------------------------
+
+    function test_launchAgent_revert_empty_name() public {
+        LaunchpadFactory.LaunchParams memory p = _bareParams("", "AGA");
+        vm.prank(alice);
+        vm.expectRevert(LaunchpadFactory.EmptyName.selector);
+        factory.launchAgent(p);
+    }
+
+    function test_launchAgent_revert_empty_symbol() public {
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "");
+        vm.prank(alice);
+        vm.expectRevert(LaunchpadFactory.EmptySymbol.selector);
+        factory.launchAgent(p);
+    }
+
+    function test_launchAgent_revert_name_too_long() public {
+        // 65 bytes — exceeds MAX_NAME_LEN (64).
+        bytes memory longName = new bytes(65);
+        for (uint256 i = 0; i < 65; ++i) {
+            longName[i] = "a";
+        }
+        LaunchpadFactory.LaunchParams memory p = _bareParams(string(longName), "AGA");
+        vm.prank(alice);
+        vm.expectRevert(LaunchpadFactory.NameTooLong.selector);
+        factory.launchAgent(p);
+    }
+
+    function test_launchAgent_accepts_max_name_len() public {
+        bytes memory n = new bytes(64);
+        for (uint256 i = 0; i < 64; ++i) {
+            n[i] = "a";
+        }
+        LaunchpadFactory.LaunchParams memory p = _bareParams(string(n), "AGA");
+        vm.prank(alice);
+        (,, uint256 id) = factory.launchAgent(p);
+        assertEq(id, 1);
+    }
+
+    function test_launchAgent_revert_symbol_too_long() public {
+        bytes memory s = new bytes(17);
+        for (uint256 i = 0; i < 17; ++i) {
+            s[i] = "x";
+        }
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", string(s));
+        vm.prank(alice);
+        vm.expectRevert(LaunchpadFactory.SymbolTooLong.selector);
+        factory.launchAgent(p);
+    }
+
+    function test_launchAgent_accepts_max_symbol_len() public {
+        bytes memory s = new bytes(16);
+        for (uint256 i = 0; i < 16; ++i) {
+            s[i] = "x";
+        }
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", string(s));
+        vm.prank(alice);
+        (,, uint256 id) = factory.launchAgent(p);
+        assertEq(id, 1);
+    }
+
+    // ---------------------------------------------------------------------
+    // launchAgent — reentrancy
+    // ---------------------------------------------------------------------
+
+    function test_launchAgent_reentrancy_blocked() public {
+        // Bind the mock and arm it to call launchAgent inside its configure.
+        MockConfigurableModule m = _setMockModule(factory.MODULE_ID_ANTI_SNIPER());
+        m.armReentry(address(factory));
+
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = factory.MODULE_ID_ANTI_SNIPER();
+        bytes[] memory data = new bytes[](1);
+        data[0] = abi.encode(uint64(0), uint32(1), uint16(0), uint16(0));
+
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+        p.enabledModules = ids;
+        p.moduleData = data;
+
+        // OZ ReentrancyGuard reverts with ReentrancyGuardReentrantCall().
+        vm.prank(alice);
+        vm.expectRevert(); // tolerate either OZ selector or wrapper
+        factory.launchAgent(p);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    function test_getAgent_revert_zero() public {
+        vm.expectRevert(abi.encodeWithSelector(LaunchpadFactory.UnknownAgent.selector, uint256(0)));
+        factory.getAgent(0);
+    }
+
+    function test_getAgent_revert_out_of_range() public {
+        vm.expectRevert(abi.encodeWithSelector(LaunchpadFactory.UnknownAgent.selector, uint256(99)));
+        factory.getAgent(99);
+    }
+
+    function test_agentCount_starts_zero() public view {
+        assertEq(factory.agentCount(), 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // launchAgent — propagation of inner reverts
+    // ---------------------------------------------------------------------
+
+    function test_launchAgent_revert_when_factory_not_graduator_owner() public {
+        // Re-deploy a graduator NOT owned by the factory and a new factory
+        // pointing at it. Launch should revert at registerLPLock.
+        Graduator orphan = new Graduator(IUniswapV2Router02(address(router)), owner);
+        LaunchpadFactory f2 = new LaunchpadFactory(
+            address(titu),
+            treasury,
+            address(agentTokenImpl),
+            address(bondingCurveImpl),
+            feeRouter,
+            address(orphan),
+            address(uniFactory),
+            address(router),
+            owner
+        );
+
+        LaunchpadFactory.LaunchParams memory p = _bareParams("Agent A", "AGA");
+        vm.prank(alice);
+        // OZ Ownable reverts with OwnableUnauthorizedAccount(address).
+        vm.expectRevert();
+        f2.launchAgent(p);
+    }
+}


### PR DESCRIPTION
## Summary
- New `LaunchpadFactory.sol` — single launch entry point. Clones AgentToken via EIP-1167, deploys a fresh BondingCurve, pre-creates the V2 pair, deploys the per-agent LPLock, wires the graduator, and dispatches `configure(...)` into every enabled module via typed interfaces.
- Module registry keyed by `keccak256(name)`; owner-gated `setModule`. Seven canonical module ids covered: AntiSniper, LaunchRadar, SixtyDays, Airdrop, CapitalFormation, PreBuy, ExistingToken.
- Per-module typed interfaces under `interfaces/I<Module>Module.sol`.

## Why
Single audited launch path is needed for M2 E2E parity — every per-agent ERC-20 carries identical bytecode and the launch flow is atomic, gas-bounded, and idempotent on re-entry attempts.

## Test plan
- [x] `forge fmt --check`
- [x] `forge test --match-path test/unit/LaunchpadFactory.t.sol` (36 tests, all green)
- [x] full `forge test` green (437 tests)
- [x] coverage ≥ 95% on factory (99.12%)
- [x] `slither` — 0 medium+ findings (only LOW/info: calls-loop, reentrancy-benign, timestamp on LPLock)

Closes #29