### PR TITLE
feat(indexer): event handlers for launch trade graduate

### DIFF
--- a/services/indexer-go/internal/handlers/handlers.go
+++ b/services/indexer-go/internal/handlers/handlers.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	contractabi "github.com/0xDevNinja/titular/services/indexer-go/internal/abi"
+)
+
+// zeroAddr is used when constructing filterers for offline log parsing.
+// The address is irrelevant because Parse methods only call UnpackLog,
+// which does not require an RPC backend.
+var zeroAddr = common.Address{}
+
+// HandleAgentLaunched decodes a LaunchpadFactory AgentLaunched log and
+// persists an agent record via store. It is idempotent: duplicate logs
+// (same txHash + logIndex) are silently skipped.
+func HandleAgentLaunched(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleAgentLaunched: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewLaunchpadFactoryFilterer(zeroAddr, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleAgentLaunched: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseAgentLaunched(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleAgentLaunched: parse: %w", err)
+	}
+
+	rec := AgentRecord{
+		AgentID:  ev.AgentId,
+		Token:    ev.Token,
+		Curve:    ev.Curve,
+		Creator:  ev.Creator,
+		LpLock:   ev.LpLock,
+		Pair:     ev.Pair,
+		Modules:  ev.Modules,
+		BlockNum: log.BlockNumber,
+		TxHash:   log.TxHash,
+		LogIndex: log.Index,
+	}
+
+	if err := store.UpsertAgent(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleAgentLaunched: upsert: %w", err)
+	}
+
+	return nil
+}
+
+// HandleBought decodes a BondingCurve Bought log and persists a trade record.
+// It is idempotent: duplicate logs are silently skipped.
+func HandleBought(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleBought: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewBondingCurveFilterer(zeroAddr, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleBought: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseBought(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleBought: parse: %w", err)
+	}
+
+	rec := TradeRecord{
+		Direction: "buy",
+		Trader:    ev.Buyer,
+		Curve:     log.Address,
+		QuoteIn:   ev.QuoteIn,
+		AgentOut:  ev.AgentOut,
+		Fee:       ev.Fee,
+		BlockNum:  log.BlockNumber,
+		TxHash:    log.TxHash,
+		LogIndex:  log.Index,
+	}
+
+	if err := store.InsertTrade(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleBought: insert: %w", err)
+	}
+
+	return nil
+}
+
+// HandleSold decodes a BondingCurve Sold log and persists a trade record.
+// It is idempotent: duplicate logs are silently skipped.
+func HandleSold(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleSold: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewBondingCurveFilterer(zeroAddr, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleSold: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseSold(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleSold: parse: %w", err)
+	}
+
+	rec := TradeRecord{
+		Direction: "sell",
+		Trader:    ev.Seller,
+		Curve:     log.Address,
+		AgentIn:   ev.AgentIn,
+		QuoteOut:  ev.QuoteOut,
+		Fee:       ev.Fee,
+		BlockNum:  log.BlockNumber,
+		TxHash:    log.TxHash,
+		LogIndex:  log.Index,
+	}
+
+	if err := store.InsertTrade(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleSold: insert: %w", err)
+	}
+
+	return nil
+}
+
+// HandleGraduated decodes a Graduator Graduated log, marks the associated
+// agent as graduated, and persists the Uniswap V2 pair address.
+// The event is emitted by the Graduator contract, which includes both the
+// curve address and the pair address as indexed fields.
+// It is idempotent: duplicate logs are silently skipped.
+func HandleGraduated(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleGraduated: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewGraduatorFilterer(zeroAddr, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleGraduated: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseGraduated(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleGraduated: parse: %w", err)
+	}
+
+	rec := GraduationRecord{
+		Curve:    ev.Curve,
+		Pair:     ev.Pair,
+		BlockNum: log.BlockNumber,
+		TxHash:   log.TxHash,
+		LogIndex: log.Index,
+	}
+
+	if err := store.MarkGraduated(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleGraduated: mark: %w", err)
+	}
+
+	return nil
+}

--- a/services/indexer-go/internal/handlers/handlers_test.go
+++ b/services/indexer-go/internal/handlers/handlers_test.go
@@ -1,0 +1,542 @@
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	contractabi "github.com/0xDevNinja/titular/services/indexer-go/internal/abi"
+	"github.com/0xDevNinja/titular/services/indexer-go/internal/handlers"
+)
+
+// ----------------------------------------------------------------------------
+// In-memory Store implementation used by all tests
+// ----------------------------------------------------------------------------
+
+type memStore struct {
+	mu          sync.Mutex
+	processed   map[string]bool // key: txHash+logIndex
+	agents      []handlers.AgentRecord
+	trades      []handlers.TradeRecord
+	graduations []handlers.GraduationRecord
+}
+
+func newMemStore() *memStore {
+	return &memStore{processed: make(map[string]bool)}
+}
+
+func logKey(txHash common.Hash, idx uint) string {
+	return txHash.Hex() + ":" + string(rune(idx))
+}
+
+func (s *memStore) IsLogProcessed(_ context.Context, txHash common.Hash, logIndex uint) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.processed[logKey(txHash, logIndex)], nil
+}
+
+func (s *memStore) UpsertAgent(_ context.Context, rec handlers.AgentRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.agents = append(s.agents, rec)
+	return nil
+}
+
+func (s *memStore) InsertTrade(_ context.Context, rec handlers.TradeRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.trades = append(s.trades, rec)
+	return nil
+}
+
+func (s *memStore) MarkGraduated(_ context.Context, rec handlers.GraduationRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.graduations = append(s.graduations, rec)
+	return nil
+}
+
+// ----------------------------------------------------------------------------
+// ABI helpers — parse event signatures once and reuse across tests
+// ----------------------------------------------------------------------------
+
+func mustGetABI(t *testing.T, meta *bind.MetaData) abi.ABI {
+	t.Helper()
+	parsed, err := meta.GetAbi()
+	if err != nil {
+		t.Fatalf("GetAbi: %v", err)
+	}
+	return *parsed
+}
+
+// encodeData packs non-indexed fields using the ABI encoder. fieldNames must
+// match the non-indexed parameters in declaration order.
+func encodeData(t *testing.T, parsed abi.ABI, eventName string, values ...interface{}) []byte {
+	t.Helper()
+	ev, ok := parsed.Events[eventName]
+	if !ok {
+		t.Fatalf("event %q not in ABI", eventName)
+	}
+
+	var args abi.Arguments
+	for _, a := range ev.Inputs {
+		if !a.Indexed {
+			args = append(args, a)
+		}
+	}
+
+	data, err := args.Pack(values...)
+	if err != nil {
+		t.Fatalf("pack %q: %v", eventName, err)
+	}
+	return data
+}
+
+// addrTopic converts an Ethereum address to a log topic (left-padded to 32 bytes).
+func addrTopic(addr common.Address) common.Hash {
+	return common.BytesToHash(addr.Bytes())
+}
+
+// uint256Topic converts a *big.Int to a log topic.
+func uint256Topic(n *big.Int) common.Hash {
+	return common.BigToHash(n)
+}
+
+// fixedTxHash returns a deterministic tx hash for a given seed.
+func fixedTxHash(seed byte) common.Hash {
+	var h common.Hash
+	h[31] = seed
+	return h
+}
+
+// errStore is a Store that always returns an error from IsLogProcessed.
+type errStore struct{}
+
+func (e *errStore) IsLogProcessed(_ context.Context, _ common.Hash, _ uint) (bool, error) {
+	return false, fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) UpsertAgent(_ context.Context, _ handlers.AgentRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) InsertTrade(_ context.Context, _ handlers.TradeRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) MarkGraduated(_ context.Context, _ handlers.GraduationRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+// ----------------------------------------------------------------------------
+// Error-path tests: store errors and malformed log data
+// ----------------------------------------------------------------------------
+
+// TestHandlers_StoreError verifies that a store error is propagated correctly
+// from each handler (covering the IsLogProcessed error branch).
+func TestHandlers_StoreError(t *testing.T) {
+	ctx := context.Background()
+	es := &errStore{}
+
+	// Any non-empty log — the store will fail before parse is reached.
+	emptyLog := types.Log{TxHash: fixedTxHash(0xAA), Index: 99}
+
+	if err := handlers.HandleAgentLaunched(ctx, emptyLog, es); err == nil {
+		t.Error("HandleAgentLaunched: expected error from store, got nil")
+	}
+	if err := handlers.HandleBought(ctx, emptyLog, es); err == nil {
+		t.Error("HandleBought: expected error from store, got nil")
+	}
+	if err := handlers.HandleSold(ctx, emptyLog, es); err == nil {
+		t.Error("HandleSold: expected error from store, got nil")
+	}
+	if err := handlers.HandleGraduated(ctx, emptyLog, es); err == nil {
+		t.Error("HandleGraduated: expected error from store, got nil")
+	}
+}
+
+// TestHandlers_ParseError verifies that malformed log data (empty topics + data)
+// causes a parse error that is wrapped and returned.
+func TestHandlers_ParseError(t *testing.T) {
+	ctx := context.Background()
+
+	// Log with wrong topic count / no data — will fail ABI unpack.
+	badLog := types.Log{
+		TxHash: fixedTxHash(0xBB),
+		Index:  88,
+		Topics: []common.Hash{}, // no topics → parse will fail
+		Data:   []byte{0xBA, 0xAD},
+	}
+
+	table := []struct {
+		name    string
+		handler func(context.Context, types.Log, handlers.Store) error
+	}{
+		{"AgentLaunched", handlers.HandleAgentLaunched},
+		{"Bought", handlers.HandleBought},
+		{"Sold", handlers.HandleSold},
+		{"Graduated", handlers.HandleGraduated},
+	}
+
+	for _, tc := range table {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			store := newMemStore()
+			err := tc.handler(ctx, badLog, store)
+			if err == nil {
+				t.Errorf("%s: expected parse error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TestHandleAgentLaunched
+// ----------------------------------------------------------------------------
+
+func TestHandleAgentLaunched(t *testing.T) {
+	factoryABI := mustGetABI(t, contractabi.LaunchpadFactoryMetaData)
+	eventID := factoryABI.Events["AgentLaunched"].ID
+
+	agentID := big.NewInt(1)
+	token := common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	curve := common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
+	creator := common.HexToAddress("0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC")
+	lpLock := common.HexToAddress("0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD")
+	pair := common.HexToAddress("0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE")
+	modules := [][32]byte{}
+
+	data := encodeData(t, factoryABI, "AgentLaunched", creator, lpLock, pair, modules)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		BlockNumber: 42,
+		TxHash:      fixedTxHash(0x01),
+		Index:       0,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(agentID),
+			addrTopic(token),
+			addrTopic(curve),
+		},
+		Data: data,
+	}
+
+	table := []struct {
+		name      string
+		duplicate bool
+	}{
+		{name: "first call persists record", duplicate: false},
+		{name: "duplicate call is skipped", duplicate: true},
+	}
+
+	store := newMemStore()
+	ctx := context.Background()
+
+	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(store.agents)
+			if err := handlers.HandleAgentLaunched(ctx, log, store); err != nil {
+				t.Fatalf("HandleAgentLaunched: %v", err)
+			}
+			after := len(store.agents)
+
+			if tc.duplicate {
+				if after != before {
+					t.Errorf("duplicate: expected no new agent, got %d new", after-before)
+				}
+				return
+			}
+
+			if after != before+1 {
+				t.Fatalf("expected 1 new agent, got %d", after-before)
+			}
+
+			got := store.agents[before]
+			if got.AgentID.Cmp(agentID) != 0 {
+				t.Errorf("AgentID: got %s, want %s", got.AgentID, agentID)
+			}
+			if got.Token != token {
+				t.Errorf("Token: got %s, want %s", got.Token, token)
+			}
+			if got.Curve != curve {
+				t.Errorf("Curve: got %s, want %s", got.Curve, curve)
+			}
+			if got.Creator != creator {
+				t.Errorf("Creator: got %s, want %s", got.Creator, creator)
+			}
+			if got.LpLock != lpLock {
+				t.Errorf("LpLock: got %s, want %s", got.LpLock, lpLock)
+			}
+			if got.Pair != pair {
+				t.Errorf("Pair: got %s, want %s", got.Pair, pair)
+			}
+			if got.BlockNum != 42 {
+				t.Errorf("BlockNum: got %d, want 42", got.BlockNum)
+			}
+			if got.TxHash != log.TxHash {
+				t.Errorf("TxHash mismatch")
+			}
+			if got.LogIndex != log.Index {
+				t.Errorf("LogIndex: got %d, want %d", got.LogIndex, log.Index)
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TestHandleBought
+// ----------------------------------------------------------------------------
+
+func TestHandleBought(t *testing.T) {
+	curveABI := mustGetABI(t, contractabi.BondingCurveMetaData)
+	eventID := curveABI.Events["Bought"].ID
+
+	buyer := common.HexToAddress("0x1100000000000000000000000000000000000001")
+	quoteIn := big.NewInt(1_000_000)
+	agentOut := big.NewInt(500_000)
+	fee := big.NewInt(3_000)
+	curveAddr := common.HexToAddress("0x2200000000000000000000000000000000000002")
+
+	data := encodeData(t, curveABI, "Bought", quoteIn, agentOut, fee)
+
+	log := types.Log{
+		Address:     curveAddr,
+		BlockNumber: 100,
+		TxHash:      fixedTxHash(0x02),
+		Index:       1,
+		Topics: []common.Hash{
+			eventID,
+			addrTopic(buyer),
+		},
+		Data: data,
+	}
+
+	table := []struct {
+		name      string
+		duplicate bool
+	}{
+		{name: "first call persists trade", duplicate: false},
+		{name: "duplicate call is skipped", duplicate: true},
+	}
+
+	store := newMemStore()
+	ctx := context.Background()
+
+	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(store.trades)
+			if err := handlers.HandleBought(ctx, log, store); err != nil {
+				t.Fatalf("HandleBought: %v", err)
+			}
+			after := len(store.trades)
+
+			if tc.duplicate {
+				if after != before {
+					t.Errorf("duplicate: expected no new trade, got %d new", after-before)
+				}
+				return
+			}
+
+			if after != before+1 {
+				t.Fatalf("expected 1 new trade, got %d", after-before)
+			}
+
+			got := store.trades[before]
+			if got.Direction != "buy" {
+				t.Errorf("Direction: got %q, want %q", got.Direction, "buy")
+			}
+			if got.Trader != buyer {
+				t.Errorf("Trader: got %s, want %s", got.Trader, buyer)
+			}
+			if got.Curve != curveAddr {
+				t.Errorf("Curve: got %s, want %s", got.Curve, curveAddr)
+			}
+			if got.QuoteIn.Cmp(quoteIn) != 0 {
+				t.Errorf("QuoteIn: got %s, want %s", got.QuoteIn, quoteIn)
+			}
+			if got.AgentOut.Cmp(agentOut) != 0 {
+				t.Errorf("AgentOut: got %s, want %s", got.AgentOut, agentOut)
+			}
+			if got.Fee.Cmp(fee) != 0 {
+				t.Errorf("Fee: got %s, want %s", got.Fee, fee)
+			}
+			if got.BlockNum != 100 {
+				t.Errorf("BlockNum: got %d, want 100", got.BlockNum)
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TestHandleSold
+// ----------------------------------------------------------------------------
+
+func TestHandleSold(t *testing.T) {
+	curveABI := mustGetABI(t, contractabi.BondingCurveMetaData)
+	eventID := curveABI.Events["Sold"].ID
+
+	seller := common.HexToAddress("0x3300000000000000000000000000000000000003")
+	agentIn := big.NewInt(250_000)
+	quoteOut := big.NewInt(490_000)
+	fee := big.NewInt(1_500)
+	curveAddr := common.HexToAddress("0x4400000000000000000000000000000000000004")
+
+	data := encodeData(t, curveABI, "Sold", agentIn, quoteOut, fee)
+
+	log := types.Log{
+		Address:     curveAddr,
+		BlockNumber: 200,
+		TxHash:      fixedTxHash(0x03),
+		Index:       2,
+		Topics: []common.Hash{
+			eventID,
+			addrTopic(seller),
+		},
+		Data: data,
+	}
+
+	table := []struct {
+		name      string
+		duplicate bool
+	}{
+		{name: "first call persists trade", duplicate: false},
+		{name: "duplicate call is skipped", duplicate: true},
+	}
+
+	store := newMemStore()
+	ctx := context.Background()
+
+	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(store.trades)
+			if err := handlers.HandleSold(ctx, log, store); err != nil {
+				t.Fatalf("HandleSold: %v", err)
+			}
+			after := len(store.trades)
+
+			if tc.duplicate {
+				if after != before {
+					t.Errorf("duplicate: expected no new trade, got %d new", after-before)
+				}
+				return
+			}
+
+			if after != before+1 {
+				t.Fatalf("expected 1 new trade, got %d", after-before)
+			}
+
+			got := store.trades[before]
+			if got.Direction != "sell" {
+				t.Errorf("Direction: got %q, want %q", got.Direction, "sell")
+			}
+			if got.Trader != seller {
+				t.Errorf("Trader: got %s, want %s", got.Trader, seller)
+			}
+			if got.Curve != curveAddr {
+				t.Errorf("Curve: got %s, want %s", got.Curve, curveAddr)
+			}
+			if got.AgentIn.Cmp(agentIn) != 0 {
+				t.Errorf("AgentIn: got %s, want %s", got.AgentIn, agentIn)
+			}
+			if got.QuoteOut.Cmp(quoteOut) != 0 {
+				t.Errorf("QuoteOut: got %s, want %s", got.QuoteOut, quoteOut)
+			}
+			if got.Fee.Cmp(fee) != 0 {
+				t.Errorf("Fee: got %s, want %s", got.Fee, fee)
+			}
+			if got.BlockNum != 200 {
+				t.Errorf("BlockNum: got %d, want 200", got.BlockNum)
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// TestHandleGraduated
+// ----------------------------------------------------------------------------
+
+func TestHandleGraduated(t *testing.T) {
+	graduatorABI := mustGetABI(t, contractabi.GraduatorMetaData)
+	eventID := graduatorABI.Events["Graduated"].ID
+
+	curve := common.HexToAddress("0x5500000000000000000000000000000000000005")
+	pair := common.HexToAddress("0x6600000000000000000000000000000000000006")
+	liquidity := big.NewInt(1_000_000_000)
+	quoteAmount := big.NewInt(500_000_000)
+	agentAmount := big.NewInt(200_000_000)
+
+	data := encodeData(t, graduatorABI, "Graduated", liquidity, quoteAmount, agentAmount)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0x7777777777777777777777777777777777777777"),
+		BlockNumber: 300,
+		TxHash:      fixedTxHash(0x04),
+		Index:       3,
+		Topics: []common.Hash{
+			eventID,
+			addrTopic(curve),
+			addrTopic(pair),
+		},
+		Data: data,
+	}
+
+	table := []struct {
+		name      string
+		duplicate bool
+	}{
+		{name: "first call marks graduated", duplicate: false},
+		{name: "duplicate call is skipped", duplicate: true},
+	}
+
+	store := newMemStore()
+	ctx := context.Background()
+
+	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(store.graduations)
+			if err := handlers.HandleGraduated(ctx, log, store); err != nil {
+				t.Fatalf("HandleGraduated: %v", err)
+			}
+			after := len(store.graduations)
+
+			if tc.duplicate {
+				if after != before {
+					t.Errorf("duplicate: expected no new graduation, got %d new", after-before)
+				}
+				return
+			}
+
+			if after != before+1 {
+				t.Fatalf("expected 1 new graduation, got %d", after-before)
+			}
+
+			got := store.graduations[before]
+			if got.Curve != curve {
+				t.Errorf("Curve: got %s, want %s", got.Curve, curve)
+			}
+			if got.Pair != pair {
+				t.Errorf("Pair: got %s, want %s", got.Pair, pair)
+			}
+			if got.BlockNum != 300 {
+				t.Errorf("BlockNum: got %d, want 300", got.BlockNum)
+			}
+			if got.TxHash != log.TxHash {
+				t.Errorf("TxHash mismatch")
+			}
+			if got.LogIndex != log.Index {
+				t.Errorf("LogIndex: got %d, want %d", got.LogIndex, log.Index)
+			}
+		})
+	}
+}

--- a/services/indexer-go/internal/handlers/store.go
+++ b/services/indexer-go/internal/handlers/store.go
@@ -1,0 +1,74 @@
+// Package handlers decodes on-chain events and persists them via a Store.
+//
+// Each handler is idempotent: a duplicate (txHash, logIndex) pair is silently
+// skipped. Block numbers are stored so callers can detect and rewind reorgs
+// without assuming logs arrive in monotonic order.
+package handlers
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// AgentRecord holds the fields extracted from an AgentLaunched event.
+type AgentRecord struct {
+	AgentID  *big.Int
+	Token    common.Address
+	Curve    common.Address
+	Creator  common.Address
+	LpLock   common.Address
+	Pair     common.Address
+	Modules  [][32]byte
+	BlockNum uint64
+	TxHash   common.Hash
+	LogIndex uint
+}
+
+// TradeRecord holds the fields from a Bought or Sold event.
+// Direction is "buy" or "sell".
+type TradeRecord struct {
+	Direction string
+	Trader    common.Address
+	// Curve contract that emitted the event — used to look up the agent.
+	Curve    common.Address
+	QuoteIn  *big.Int // non-nil for buy; nil for sell
+	AgentOut *big.Int // non-nil for buy; nil for sell
+	AgentIn  *big.Int // non-nil for sell; nil for buy
+	QuoteOut *big.Int // non-nil for sell; nil for buy
+	Fee      *big.Int
+	BlockNum uint64
+	TxHash   common.Hash
+	LogIndex uint
+}
+
+// GraduationRecord holds the fields from a Graduator.Graduated event.
+type GraduationRecord struct {
+	Curve    common.Address
+	Pair     common.Address
+	BlockNum uint64
+	TxHash   common.Hash
+	LogIndex uint
+}
+
+// Store is the persistence interface used by all handlers.
+// Implementations must be safe for concurrent use.
+type Store interface {
+	// IsLogProcessed returns true when a log identified by (txHash, logIndex)
+	// has already been persisted. It is called before every write to enforce
+	// idempotency.
+	IsLogProcessed(ctx context.Context, txHash common.Hash, logIndex uint) (bool, error)
+
+	// UpsertAgent inserts or updates an agent record. On conflict the existing
+	// row is left unchanged (insert-if-not-exists semantics).
+	UpsertAgent(ctx context.Context, rec AgentRecord) error
+
+	// InsertTrade persists a single trade. The (txHash, logIndex) uniqueness
+	// is enforced by the caller via IsLogProcessed before this is called.
+	InsertTrade(ctx context.Context, rec TradeRecord) error
+
+	// MarkGraduated marks an agent as graduated and stores the Uniswap V2
+	// pair address. Identified by curve address.
+	MarkGraduated(ctx context.Context, rec GraduationRecord) error
+}


### PR DESCRIPTION
## Summary

- Add `services/indexer-go/internal/handlers/` with four event handlers: `HandleAgentLaunched`, `HandleBought`, `HandleSold`, `HandleGraduated`
- Each handler decodes on-chain logs via abigen `ParseXxx` methods and persists records through a `Store` interface
- `Store` interface (4 methods) keeps handlers testable in isolation — no real DB dependency in this PR

## Why

Indexer needs typed event decoding to turn raw `types.Log` entries into structured records. Handlers are idempotent on `(txHash, logIndex)` and store block numbers to support reorg rewind without assuming monotonic delivery.

## Test plan

- [x] Table-driven tests: one success + one duplicate-skip sub-test per handler
- [x] Error path tests: store error propagation, malformed log data parse errors
- [x] `go test -race ./...` green, 86.7% coverage on handlers package (>85% gate)
- [x] `go vet ./...` clean
- [x] `govulncheck ./...` — 0 vulnerabilities in called code
- [ ] CI green

Closes #47