### PR TITLE
feat(web): playwright e2e for launch-trade-graduate flow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -25,18 +25,45 @@ jobs:
     uses: ./.github/workflows/security.yml
     secrets: inherit
 
+  # Smoke E2E: launch → trade → graduate against local anvil.
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: foundry-rs/foundry-toolchain@v1
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.6.2"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm dlx playwright install chromium --with-deps
+      - run: forge build
+        working-directory: contracts/evm
+      - run: pnpm --filter @titular/web e2e
+        env:
+          CI: "true"
+          CONTRACTS_DIR: ${{ github.workspace }}/contracts/evm
+
   status:
     name: all checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [lint, test, security]
+    needs: [lint, test, security, e2e]
     if: always()
     steps:
       - name: summarise
         run: |
           if [[ "${{ needs.lint.result }}" == "success" && \
                 "${{ needs.test.result }}" == "success" && \
-                "${{ needs.security.result }}" == "success" ]]; then
+                "${{ needs.security.result }}" == "success" && \
+                "${{ needs.e2e.result }}" == "success" ]]; then
             echo "All checks passed."
           else
             echo "One or more checks failed."

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,22 @@
+title = "titular gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Well-known Anvil deterministic dev keys (account 0-9). Public, deterministic, non-secret — derived from the standard Foundry test mnemonic."
+regexes = [
+  '''0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80''',
+  '''0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d''',
+  '''0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cde8b9b6''',
+  '''0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6''',
+  '''0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a''',
+  '''0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba''',
+  '''0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e''',
+  '''0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356''',
+  '''0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97''',
+  '''0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dfd80a39bf''',
+]
+paths = [
+  '''apps/web/e2e/fixtures/.*''',
+]

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -178,11 +178,22 @@ function deployMockUniswap(rpcUrl: string): {
   uniswapRouter: string;
 } {
   // foundry >=1.5.1 requires --broadcast to actually send the tx (without it
-  // forge create only simulates). After broadcast the receipt line
-  // "Deployed to: 0x..." appears on stdout. Capture stdout+stderr together
-  // via shell 2>&1 so the regex works regardless of which fd foundry uses.
-  function forgeCreate(args: string): string {
-    return execSync(`forge create ${args} --broadcast 2>&1`, {
+  // forge create only simulates). --broadcast must appear before --constructor-args
+  // because --constructor-args is variadic and consumes all subsequent tokens.
+  // Capture stdout+stderr together (2>&1) so "Deployed to:" is always visible.
+  function forgeCreateRun(contract: string, extraArgs = ""): string {
+    const cmd = [
+      "forge create",
+      contract,
+      `--rpc-url ${rpcUrl}`,
+      `--private-key ${DEPLOYER_PRIVATE_KEY}`,
+      "--broadcast",
+      extraArgs,
+      "2>&1",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    return execSync(cmd, {
       cwd: CONTRACTS_DIR,
       shell: true,
       stdio: "pipe",
@@ -196,14 +207,13 @@ function deployMockUniswap(rpcUrl: string): {
   }
 
   const factoryAddr = extractAddress(
-    forgeCreate(
-      `test/mocks/MockUniswapV2Factory.sol:MockUniswapV2Factory --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY}`
-    )
+    forgeCreateRun("test/mocks/MockUniswapV2Factory.sol:MockUniswapV2Factory")
   );
 
   const routerAddr = extractAddress(
-    forgeCreate(
-      `test/mocks/MockUniswapV2Router.sol:MockUniswapV2Router --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --constructor-args ${factoryAddr}`
+    forgeCreateRun(
+      "test/mocks/MockUniswapV2Router.sol:MockUniswapV2Router",
+      `--constructor-args ${factoryAddr}`
     )
   );
 

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -19,6 +19,42 @@ import fs from "node:fs";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
+/**
+ * Poll http://127.0.0.1:<port> with eth_blockNumber until the JSON-RPC
+ * socket is accepting connections. Throws if the node is not ready within
+ * the allotted attempts.
+ *
+ * @param rpcUrl  - full URL, e.g. "http://127.0.0.1:8545"
+ * @param retries - number of attempts (default 60)
+ * @param delayMs - milliseconds between attempts (default 50)
+ */
+async function waitForRpc(rpcUrl: string, retries = 60, delayMs = 50): Promise<void> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const res = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "eth_blockNumber",
+          params: [],
+          id: 1,
+        }),
+      });
+      if (res.ok) {
+        const body = (await res.json()) as { result?: string };
+        if (body.result !== undefined) return;
+      }
+    } catch {
+      // connection refused — anvil not up yet
+    }
+    await sleep(delayMs);
+  }
+  throw new Error(
+    `[anvil] RPC at ${rpcUrl} did not respond after ${retries * delayMs} ms. Check that anvil is installed and the port is available.`
+  );
+}
+
 export const ANVIL_MNEMONIC = "test test test test test test test test test test test junk";
 export const DEPLOYER_PRIVATE_KEY =
   "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -55,20 +91,10 @@ export async function startAnvil(): Promise<string> {
     console.error("[anvil] failed to start:", err.message);
   });
 
-  // Poll until the node is ready (max 15 s).
-  const deadline = Date.now() + 15_000;
-  while (Date.now() < deadline) {
-    try {
-      const res = execSync(
-        `curl -sf -X POST ${rpcUrl} -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'`,
-        { stdio: "pipe" }
-      );
-      const body = JSON.parse(res.toString());
-      if (body.result) break;
-    } catch {
-      await sleep(200);
-    }
-  }
+  // Wait until the JSON-RPC socket is live before returning.
+  // waitForRpc polls eth_blockNumber (50 ms × 60 = 3 s max) and throws if
+  // anvil never comes up, preventing forge script from hitting ECONNREFUSED.
+  await waitForRpc(rpcUrl);
 
   return rpcUrl;
 }

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -177,30 +177,35 @@ function deployMockUniswap(rpcUrl: string): {
   uniswapFactory: string;
   uniswapRouter: string;
 } {
-  // Parse the deployed address from `forge create` text output.
-  // The --json flag changed its schema across foundry versions (pre-1.5 had
-  // `deployedTo`, 1.5.1 outputs a transaction object with no address field).
-  // Parsing the human-readable "Deployed to: 0x..." line is stable across all
-  // foundry versions.
+  // foundry >=1.5.1 requires --broadcast to actually send the tx (without it
+  // forge create only simulates). After broadcast the receipt line
+  // "Deployed to: 0x..." appears on stdout. Capture stdout+stderr together
+  // via shell 2>&1 so the regex works regardless of which fd foundry uses.
+  function forgeCreate(args: string): string {
+    return execSync(`forge create ${args} --broadcast 2>&1`, {
+      cwd: CONTRACTS_DIR,
+      shell: true,
+      stdio: "pipe",
+    }).toString();
+  }
+
   function extractAddress(output: string): string {
     const match = output.match(/Deployed to:\s*(0x[0-9a-fA-F]{40})/);
     if (!match) throw new Error(`forge create output missing "Deployed to:" line:\n${output}`);
     return match[1];
   }
 
-  const factoryOut = execSync(
-    `forge create test/mocks/MockUniswapV2Factory.sol:MockUniswapV2Factory --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY}`,
-    { cwd: CONTRACTS_DIR, stdio: "pipe" }
-  ).toString();
+  const factoryAddr = extractAddress(
+    forgeCreate(
+      `test/mocks/MockUniswapV2Factory.sol:MockUniswapV2Factory --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY}`
+    )
+  );
 
-  const factoryAddr = extractAddress(factoryOut);
-
-  const routerOut = execSync(
-    `forge create test/mocks/MockUniswapV2Router.sol:MockUniswapV2Router --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --constructor-args ${factoryAddr}`,
-    { cwd: CONTRACTS_DIR, stdio: "pipe" }
-  ).toString();
-
-  const routerAddr = extractAddress(routerOut);
+  const routerAddr = extractAddress(
+    forgeCreate(
+      `test/mocks/MockUniswapV2Router.sol:MockUniswapV2Router --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --constructor-args ${factoryAddr}`
+    )
+  );
 
   return { uniswapFactory: factoryAddr, uniswapRouter: routerAddr };
 }

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -177,19 +177,28 @@ function deployMockUniswap(rpcUrl: string): {
   uniswapFactory: string;
   uniswapRouter: string;
 } {
+  // `forge create --json` used `deployedTo` in foundry <1.5 and `address` in
+  // foundry >=1.5.1. Accept both to stay compatible across toolchain versions.
+  function extractAddress(json: string): string {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    const addr = (parsed.address ?? parsed.deployedTo) as string | undefined;
+    if (!addr) throw new Error(`forge create JSON missing address field: ${json}`);
+    return addr;
+  }
+
   const factoryOut = execSync(
     `forge create test/mocks/MockUniswapV2Factory.sol:MockUniswapV2Factory --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --json`,
     { cwd: CONTRACTS_DIR, stdio: "pipe" }
   ).toString();
 
-  const factoryAddr: string = JSON.parse(factoryOut).deployedTo;
+  const factoryAddr = extractAddress(factoryOut);
 
   const routerOut = execSync(
     `forge create test/mocks/MockUniswapV2Router.sol:MockUniswapV2Router --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --constructor-args ${factoryAddr} --json`,
     { cwd: CONTRACTS_DIR, stdio: "pipe" }
   ).toString();
 
-  const routerAddr: string = JSON.parse(routerOut).deployedTo;
+  const routerAddr = extractAddress(routerOut);
 
   return { uniswapFactory: factoryAddr, uniswapRouter: routerAddr };
 }

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -177,24 +177,26 @@ function deployMockUniswap(rpcUrl: string): {
   uniswapFactory: string;
   uniswapRouter: string;
 } {
-  // `forge create --json` used `deployedTo` in foundry <1.5 and `address` in
-  // foundry >=1.5.1. Accept both to stay compatible across toolchain versions.
-  function extractAddress(json: string): string {
-    const parsed = JSON.parse(json) as Record<string, unknown>;
-    const addr = (parsed.address ?? parsed.deployedTo) as string | undefined;
-    if (!addr) throw new Error(`forge create JSON missing address field: ${json}`);
-    return addr;
+  // Parse the deployed address from `forge create` text output.
+  // The --json flag changed its schema across foundry versions (pre-1.5 had
+  // `deployedTo`, 1.5.1 outputs a transaction object with no address field).
+  // Parsing the human-readable "Deployed to: 0x..." line is stable across all
+  // foundry versions.
+  function extractAddress(output: string): string {
+    const match = output.match(/Deployed to:\s*(0x[0-9a-fA-F]{40})/);
+    if (!match) throw new Error(`forge create output missing "Deployed to:" line:\n${output}`);
+    return match[1];
   }
 
   const factoryOut = execSync(
-    `forge create test/mocks/MockUniswapV2Factory.sol:MockUniswapV2Factory --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --json`,
+    `forge create test/mocks/MockUniswapV2Factory.sol:MockUniswapV2Factory --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY}`,
     { cwd: CONTRACTS_DIR, stdio: "pipe" }
   ).toString();
 
   const factoryAddr = extractAddress(factoryOut);
 
   const routerOut = execSync(
-    `forge create test/mocks/MockUniswapV2Router.sol:MockUniswapV2Router --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --constructor-args ${factoryAddr} --json`,
+    `forge create test/mocks/MockUniswapV2Router.sol:MockUniswapV2Router --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --constructor-args ${factoryAddr}`,
     { cwd: CONTRACTS_DIR, stdio: "pipe" }
   ).toString();
 

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -145,6 +145,16 @@ export function deployContracts(rpcUrl: string): AnvilAddresses {
     }
   );
 
+  // DeployPhase1 always writes deployments/base-sepolia.json (regardless of
+  // chainId). DeployPhase2 maps chainId 31337 -> deployments/local.json. Copy
+  // the Phase 1 artifact across so Phase 2's preflight finds it.
+  const phase1Src = path.join(deployDir, "base-sepolia.json");
+  const phase1Dst = path.join(deployDir, "local.json");
+  if (!fs.existsSync(phase1Src)) {
+    throw new Error(`Phase 1 deployment file not found at ${phase1Src}`);
+  }
+  fs.copyFileSync(phase1Src, phase1Dst);
+
   // Deploy mock Uniswap V2 infrastructure via a small inline cast call
   // sequence so Phase 2 can reference a real factory + router on anvil.
   // We use the mocks checked in under test/mocks/.
@@ -238,7 +248,7 @@ export interface AnvilAddresses {
  */
 function parseDeploymentJson(deployDir: string): AnvilAddresses {
   // DeployPhase2 writes <chainId>.json; anvil chain id is 31337.
-  const candidates = ["31337.json", "base-sepolia.json"];
+  const candidates = ["local.json", "31337.json", "base-sepolia.json"];
   let raw: string | undefined;
   for (const name of candidates) {
     const p = path.join(deployDir, name);

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -1,0 +1,228 @@
+/**
+ * Anvil fixture: spawns a local EVM node, deploys Phase1 + Phase2 contracts,
+ * and returns wired addresses + a funded signer mnemonic for tests.
+ *
+ * The fixture is used as a Playwright global setup step so the contracts are
+ * deployed once per test run (not per test).
+ *
+ * Required env:
+ *   ANVIL_PORT       — defaults to 8545
+ *   CONTRACTS_DIR    — path to contracts/evm (default resolved from cwd)
+ *
+ * Outputs (written to process.env so Playwright workers can read them):
+ *   ANVIL_RPC_URL, TITU_ADDR, TREASURY_ADDR, FACTORY_ADDR, GRADUATOR_ADDR,
+ *   DEPLOYER_MNEMONIC, ANVIL_CHAIN_ID
+ */
+
+import { type ChildProcess, execSync, spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+export const ANVIL_MNEMONIC = "test test test test test test test test test test test junk";
+export const DEPLOYER_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+export const DEPLOYER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+const ANVIL_PORT = Number(process.env.ANVIL_PORT ?? "8545");
+const CONTRACTS_DIR =
+  process.env.CONTRACTS_DIR ?? path.resolve(path.join(process.cwd(), "../../contracts/evm"));
+
+let anvilProcess: ChildProcess | null = null;
+
+/**
+ * Start anvil and wait until it is accepting connections.
+ */
+export async function startAnvil(): Promise<string> {
+  const rpcUrl = `http://127.0.0.1:${ANVIL_PORT}`;
+
+  anvilProcess = spawn(
+    "anvil",
+    [
+      "--port",
+      String(ANVIL_PORT),
+      "--mnemonic",
+      ANVIL_MNEMONIC,
+      "--chain-id",
+      "31337",
+      "--block-time",
+      "0",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] }
+  );
+
+  anvilProcess.on("error", (err) => {
+    console.error("[anvil] failed to start:", err.message);
+  });
+
+  // Poll until the node is ready (max 15 s).
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = execSync(
+        `curl -sf -X POST ${rpcUrl} -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'`,
+        { stdio: "pipe" }
+      );
+      const body = JSON.parse(res.toString());
+      if (body.result) break;
+    } catch {
+      await sleep(200);
+    }
+  }
+
+  return rpcUrl;
+}
+
+/**
+ * Deploy Phase1 + Phase2 contracts against the running anvil node.
+ * Returns the deployed contract addresses extracted from the broadcast
+ * artifacts written by forge.
+ */
+export function deployContracts(rpcUrl: string): AnvilAddresses {
+  const deployDir = path.join(CONTRACTS_DIR, "deployments");
+
+  // Phase 1 — TITU, Treasury, VestingVault, VeTITU, FeeDistributor
+  execSync(
+    `forge script script/DeployPhase1.s.sol:DeployPhase1 --rpc-url ${rpcUrl} --broadcast --private-key ${DEPLOYER_PRIVATE_KEY} --sender ${DEPLOYER_ADDRESS}`,
+    {
+      cwd: CONTRACTS_DIR,
+      env: {
+        ...process.env,
+        DEPLOYER_PRIVATE_KEY,
+        MULTISIG: DEPLOYER_ADDRESS,
+      },
+      stdio: "pipe",
+    }
+  );
+
+  // Deploy mock Uniswap V2 infrastructure via a small inline cast call
+  // sequence so Phase 2 can reference a real factory + router on anvil.
+  // We use the mocks checked in under test/mocks/.
+  const mockAddresses = deployMockUniswap(rpcUrl);
+
+  // Phase 2 — LaunchpadFactory, Graduator, modules, etc.
+  execSync(
+    `forge script script/DeployPhase2.s.sol:DeployPhase2 --rpc-url ${rpcUrl} --broadcast --private-key ${DEPLOYER_PRIVATE_KEY} --sender ${DEPLOYER_ADDRESS}`,
+    {
+      cwd: CONTRACTS_DIR,
+      env: {
+        ...process.env,
+        DEPLOYER_PRIVATE_KEY,
+        MULTISIG: DEPLOYER_ADDRESS,
+        UNISWAP_V2_FACTORY: mockAddresses.uniswapFactory,
+        UNISWAP_V2_ROUTER: mockAddresses.uniswapRouter,
+      },
+      stdio: "pipe",
+    }
+  );
+
+  return parseDeploymentJson(deployDir);
+}
+
+/**
+ * Deploy MockUniswapV2Factory + MockUniswapV2Router using forge create
+ * (they're test-only contracts so the deploy script doesn't cover them).
+ */
+function deployMockUniswap(rpcUrl: string): {
+  uniswapFactory: string;
+  uniswapRouter: string;
+} {
+  const factoryOut = execSync(
+    `forge create test/mocks/MockUniswapV2Factory.sol:MockUniswapV2Factory --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --json`,
+    { cwd: CONTRACTS_DIR, stdio: "pipe" }
+  ).toString();
+
+  const factoryAddr: string = JSON.parse(factoryOut).deployedTo;
+
+  const routerOut = execSync(
+    `forge create test/mocks/MockUniswapV2Router.sol:MockUniswapV2Router --rpc-url ${rpcUrl} --private-key ${DEPLOYER_PRIVATE_KEY} --constructor-args ${factoryAddr} --json`,
+    { cwd: CONTRACTS_DIR, stdio: "pipe" }
+  ).toString();
+
+  const routerAddr: string = JSON.parse(routerOut).deployedTo;
+
+  return { uniswapFactory: factoryAddr, uniswapRouter: routerAddr };
+}
+
+/** Addresses surfaced by the fixture for test assertions. */
+export interface AnvilAddresses {
+  titu: string;
+  treasury: string;
+  factory: string;
+  graduator: string;
+  feeRouter: string;
+  rpcUrl: string;
+  chainId: number;
+  deployerAddress: string;
+  deployerMnemonic: string;
+}
+
+/**
+ * Parse the merged deployment JSON written by DeployPhase2.
+ */
+function parseDeploymentJson(deployDir: string): AnvilAddresses {
+  // DeployPhase2 writes <chainId>.json; anvil chain id is 31337.
+  const candidates = ["31337.json", "base-sepolia.json"];
+  let raw: string | undefined;
+  for (const name of candidates) {
+    const p = path.join(deployDir, name);
+    if (fs.existsSync(p)) {
+      raw = fs.readFileSync(p, "utf-8");
+      break;
+    }
+  }
+  if (!raw) {
+    throw new Error(
+      `Deployment JSON not found in ${deployDir}. Looked for: ${candidates.join(", ")}`
+    );
+  }
+
+  const json: DeploymentJson = JSON.parse(raw);
+
+  // Support both the merged format (phase1/phase2 keys) and legacy flat format.
+  const p1 = json.phase1?.contracts ?? json.contracts;
+  const p2 = json.phase2?.contracts;
+
+  if (!p1?.TITU || !p1?.Treasury) {
+    throw new Error("Phase1 deployment JSON missing TITU or Treasury address");
+  }
+  if (!p2?.LaunchpadFactory || !p2?.Graduator || !p2?.FeeRouter) {
+    throw new Error("Phase2 deployment JSON missing LaunchpadFactory, Graduator, or FeeRouter");
+  }
+
+  return {
+    titu: p1.TITU,
+    treasury: p1.Treasury,
+    factory: p2.LaunchpadFactory,
+    graduator: p2.Graduator,
+    feeRouter: p2.FeeRouter,
+    rpcUrl: `http://127.0.0.1:${ANVIL_PORT}`,
+    chainId: 31337,
+    deployerAddress: DEPLOYER_ADDRESS,
+    deployerMnemonic: ANVIL_MNEMONIC,
+  };
+}
+
+interface DeploymentJson {
+  chainId?: number;
+  phase1?: {
+    deployedAt?: number;
+    contracts?: Record<string, string | null>;
+  };
+  phase2?: {
+    deployedAt?: number;
+    contracts?: Record<string, string | null>;
+  };
+  // Legacy flat format (Phase1-only files).
+  contracts?: Record<string, string | null>;
+}
+
+/**
+ * Stop the anvil process started by {startAnvil}.
+ */
+export function stopAnvil(): void {
+  if (anvilProcess) {
+    anvilProcess.kill("SIGTERM");
+    anvilProcess = null;
+  }
+}

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -84,17 +84,22 @@ export async function startAnvil(): Promise<string> {
       "--block-time",
       "0",
     ],
+    // "ignore" stdin; pipe stdout/stderr so the OS pipe buffer never blocks the
+    // child process. We drain both streams to /dev/null by attaching no-op
+    // listeners — this avoids the child stalling when the 64 KB pipe fills.
     { stdio: ["ignore", "pipe", "pipe"] }
   );
+
+  anvilProcess.stdout?.resume();
+  anvilProcess.stderr?.resume();
 
   anvilProcess.on("error", (err) => {
     console.error("[anvil] failed to start:", err.message);
   });
 
-  // Wait until the JSON-RPC socket is live before returning.
-  // waitForRpc polls eth_blockNumber (50 ms × 60 = 3 s max) and throws if
-  // anvil never comes up, preventing forge script from hitting ECONNREFUSED.
-  await waitForRpc(rpcUrl);
+  // Poll until the JSON-RPC socket is accepting connections.
+  // 300 attempts × 100 ms = 30 s — enough for CI runner cold-start.
+  await waitForRpc(rpcUrl, 300, 100);
 
   return rpcUrl;
 }

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -72,8 +72,20 @@ let anvilProcess: ChildProcess | null = null;
 export async function startAnvil(): Promise<string> {
   const rpcUrl = `http://127.0.0.1:${ANVIL_PORT}`;
 
+  // Resolve the anvil binary path explicitly so spawn never relies solely on
+  // PATH resolution (which can differ between the shell step and the Node child).
+  const anvilBin = (() => {
+    try {
+      return execSync("which anvil", { stdio: "pipe" }).toString().trim();
+    } catch {
+      return "anvil"; // fall back to PATH lookup
+    }
+  })();
+
+  console.log(`[anvil] binary: ${anvilBin}`);
+
   anvilProcess = spawn(
-    "anvil",
+    anvilBin,
     [
       "--port",
       String(ANVIL_PORT),
@@ -83,18 +95,25 @@ export async function startAnvil(): Promise<string> {
       "31337",
       "--block-time",
       "0",
+      "--silent", // suppress banner noise in CI logs
     ],
-    // "ignore" stdin; pipe stdout/stderr so the OS pipe buffer never blocks the
-    // child process. We drain both streams to /dev/null by attaching no-op
-    // listeners — this avoids the child stalling when the 64 KB pipe fills.
+    // Pipe stdout/stderr so we can surface startup errors. The streams are
+    // forwarded to the parent process so CI logs show any anvil crash reason.
     { stdio: ["ignore", "pipe", "pipe"] }
   );
 
-  anvilProcess.stdout?.resume();
-  anvilProcess.stderr?.resume();
+  // Forward anvil output to the parent process so errors are visible in CI.
+  anvilProcess.stdout?.pipe(process.stdout);
+  anvilProcess.stderr?.pipe(process.stderr);
 
   anvilProcess.on("error", (err) => {
-    console.error("[anvil] failed to start:", err.message);
+    console.error("[anvil] spawn error:", err.message);
+  });
+
+  anvilProcess.on("close", (code) => {
+    if (code !== null && code !== 0) {
+      console.error(`[anvil] process exited early with code ${code}`);
+    }
   });
 
   // Poll until the JSON-RPC socket is accepting connections.

--- a/apps/web/e2e/fixtures/anvil.ts
+++ b/apps/web/e2e/fixtures/anvil.ts
@@ -93,8 +93,8 @@ export async function startAnvil(): Promise<string> {
       ANVIL_MNEMONIC,
       "--chain-id",
       "31337",
-      "--block-time",
-      "0",
+      // omit --block-time: anvil defaults to instant (on-demand) mining.
+      // foundry >=1.5.1 rejects --block-time 0 as invalid.
       "--silent", // suppress banner noise in CI logs
     ],
     // Pipe stdout/stderr so we can surface startup errors. The streams are

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -1,0 +1,29 @@
+/**
+ * Playwright global setup: starts anvil and deploys contracts once before
+ * any worker spins up. Addresses are written to process.env so every worker
+ * can read them via globalThis / env in the test files.
+ *
+ * Global teardown (`global-teardown.ts`) stops anvil after all tests finish.
+ */
+
+import { type AnvilAddresses, deployContracts, startAnvil } from "./fixtures/anvil.js";
+
+// Augment the global object so the addresses survive across workers.
+declare global {
+  var __anvilAddresses: AnvilAddresses | undefined;
+}
+
+export default async function globalSetup(): Promise<void> {
+  const rpcUrl = await startAnvil();
+  const addresses = deployContracts(rpcUrl);
+  globalThis.__anvilAddresses = addresses;
+
+  // Expose to process.env so tests that run in separate processes can read them.
+  process.env.ANVIL_RPC_URL = addresses.rpcUrl;
+  process.env.ANVIL_CHAIN_ID = String(addresses.chainId);
+  process.env.TITU_ADDR = addresses.titu;
+  process.env.TREASURY_ADDR = addresses.treasury;
+  process.env.FACTORY_ADDR = addresses.factory;
+  process.env.GRADUATOR_ADDR = addresses.graduator;
+  process.env.FEE_ROUTER_ADDR = addresses.feeRouter;
+}

--- a/apps/web/e2e/global-teardown.ts
+++ b/apps/web/e2e/global-teardown.ts
@@ -1,0 +1,5 @@
+import { stopAnvil } from "./fixtures/anvil.js";
+
+export default async function globalTeardown(): Promise<void> {
+  stopAnvil();
+}

--- a/apps/web/e2e/launchpad.spec.ts
+++ b/apps/web/e2e/launchpad.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * E2E smoke: launch → trade → graduate
+ *
+ * Covers scenario S1 from the testing strategy (smoke level):
+ *   1. Launch: complete the wizard, confirm AgentLaunched result surfaced in UI.
+ *   2. Trade: navigate to agent page, submit a buy via the trade widget.
+ *   3. Graduate: visit the graduated agent fixture page, assert the Graduated
+ *      badge and locked LP marker are visible.
+ *
+ * The current server actions return deterministic fixture stubs. The anvil node
+ * started by global-setup deploys real contracts so contract addresses are
+ * available in the environment — future iterations wire the UI to the live
+ * chain; this test will pass without modification once that wiring lands.
+ */
+
+import { type Page, expect, test } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Wait for a form step to become visible by its aria-label. */
+async function waitForStep(page: Page, label: string) {
+  await page.waitForSelector(`[aria-label="${label}"]`, { timeout: 10_000 });
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+test.describe("launchpad golden path", () => {
+  // ── 1. Launch wizard ──────────────────────────────────────────────────────
+
+  test("completes the launch wizard and shows agent launched result", async ({ page }) => {
+    await page.goto("/launchpad/create");
+    await expect(page).toHaveTitle(/Titular/i);
+
+    // Step 0 — Agent Identity
+    await waitForStep(page, "Agent identity form");
+
+    await page.fill("#name", "E2EBot");
+    await page.fill("#symbol", "E2EB");
+    await page.fill("#description", "End-to-end test agent");
+    // imageURI is pre-filled with a fixture URL; leave it as-is.
+    await page.click('button[type="submit"]:has-text("Next")');
+
+    // Step 1 — Soul
+    await waitForStep(page, "Soul configuration form");
+    // soulURI is pre-filled; go straight to Next.
+    await page.click('button[type="submit"]:has-text("Next")');
+
+    // Step 2 — Modules
+    await waitForStep(page, "Modules selection form");
+    // No modules selected for a bare launch.
+    await page.click('button[type="submit"]:has-text("Next")');
+
+    // Step 3 — Review
+    await page.waitForSelector('[aria-label="Launch review"]', {
+      timeout: 10_000,
+    });
+    await expect(page.locator('[aria-label="LaunchParams JSON preview"]')).toContainText("E2EBot");
+    await page.click('button:has-text("Launch agent")');
+
+    // Step 4 — Submit
+    await page.waitForSelector('[aria-label="Submit launch"]', {
+      timeout: 10_000,
+    });
+    await page.click('button:has-text("Confirm launch")');
+
+    // Result — the fixture stub returns a deterministic response.
+    const result = page.locator('[aria-label="Launch result"]');
+    await expect(result).toBeVisible({ timeout: 15_000 });
+    await expect(result.locator("text=Agent launched!")).toBeVisible();
+    await expect(result.locator("dt:has-text('Transaction hash') + dd code")).toContainText("0x");
+    await expect(result.locator("dt:has-text('Agent ID') + dd")).not.toBeEmpty();
+
+    // "View agent page" link is present and well-formed.
+    const viewLink = result.locator('a:has-text("View agent page")');
+    await expect(viewLink).toBeVisible();
+    const href = await viewLink.getAttribute("href");
+    expect(href).toMatch(/^\/agent\//);
+  });
+
+  // ── 2. Trade widget ───────────────────────────────────────────────────────
+
+  test("buys on the bonding curve via the trade widget", async ({ page }) => {
+    // Use the sample fixture agent (slug = "sample", not graduated).
+    await page.goto("/agent/sample");
+
+    await expect(page.locator("h1")).toContainText("AlphaBot");
+
+    // Graduation progress bar is visible (not graduated yet).
+    const progressbar = page.getByRole("progressbar");
+    await expect(progressbar).toBeVisible();
+
+    // Switch to Buy tab (already selected by default).
+    const buyTab = page.getByRole("tab", { name: "Buy" });
+    await expect(buyTab).toHaveAttribute("aria-selected", "true");
+
+    // Enter an amount.
+    const amountIn = page.locator("#amount-in");
+    await amountIn.fill("100");
+
+    // Estimated output updates (live via bondingCurve math).
+    const preview = page.locator("#amount-out-preview");
+    await expect(preview).not.toContainText("—");
+
+    // Submit the trade form.
+    const submitBtn = page.locator('button[type="submit"]');
+    await submitBtn.click();
+
+    // The fixture stub returns a trade result.
+    const tradeResult = page.locator('[aria-label="Trade result"]');
+    await expect(tradeResult).toBeVisible({ timeout: 10_000 });
+    await expect(tradeResult.locator("text=Trade submitted!")).toBeVisible();
+    await expect(tradeResult.locator("dt:has-text('Tx hash:') + dd code")).toContainText("0x");
+  });
+
+  test("sells on the bonding curve via the trade widget", async ({ page }) => {
+    await page.goto("/agent/sample");
+
+    const sellTab = page.getByRole("tab", { name: "Sell" });
+    await sellTab.click();
+    await expect(sellTab).toHaveAttribute("aria-selected", "true");
+
+    await page.locator("#amount-in").fill("1000");
+
+    const preview = page.locator("#amount-out-preview");
+    await expect(preview).not.toContainText("—");
+
+    await page.locator('button[type="submit"]').click();
+
+    const tradeResult = page.locator('[aria-label="Trade result"]');
+    await expect(tradeResult).toBeVisible({ timeout: 10_000 });
+    await expect(tradeResult.locator("text=Trade submitted!")).toBeVisible();
+  });
+
+  // ── 3. Graduation ─────────────────────────────────────────────────────────
+
+  test("graduated agent page shows Graduated badge and LP-lock marker", async ({ page }) => {
+    // The "graduated" fixture (slug = "graduated") pre-sets graduated: true.
+    await page.goto("/agent/graduated");
+
+    await expect(page.locator("h1")).toContainText("GradBot");
+
+    // Graduated badge is rendered as an <output> with aria-label.
+    const graduatedBadge = page.locator('[aria-label="Graduated agent"]');
+    await expect(graduatedBadge).toBeVisible();
+    await expect(graduatedBadge).toContainText("Graduated");
+
+    // Graduation progress bar is NOT rendered (agent already graduated).
+    await expect(page.getByRole("progressbar")).not.toBeVisible();
+
+    // Trade widget disables the submit button for graduated agents.
+    const submitBtn = page.locator('button[type="submit"]');
+    await expect(submitBtn).toBeDisabled();
+    await expect(submitBtn).toContainText("Graduated");
+
+    // Trade widget shows the Uniswap note for graduated agents.
+    const uniNote = page.locator('[role="note"]');
+    await expect(uniNote).toBeVisible();
+    await expect(uniNote).toContainText("Uniswap V2");
+
+    // TITU raised matches the graduation threshold in the stats row.
+    const tituRaised = page.locator('[aria-label="Price and market cap stats"]');
+    await expect(tituRaised).toContainText("42,000");
+  });
+
+  // ── 4. Contract addresses available from anvil fixture ───────────────────
+
+  test("anvil deployment addresses are set in environment", () => {
+    // If the global setup ran successfully, these env vars are populated.
+    // This test acts as a fast gate: if it fails, the deployment failed.
+    const factoryAddr = process.env.FACTORY_ADDR;
+    const tituAddr = process.env.TITU_ADDR;
+
+    // In CI the global setup runs for real; locally with reuseExistingServer
+    // and no anvil started, env vars may be absent — skip gracefully.
+    if (!factoryAddr || !tituAddr) {
+      test.skip();
+      return;
+    }
+
+    expect(factoryAddr).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(tituAddr).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(process.env.GRADUATOR_ADDR).toMatch(/^0x[0-9a-fA-F]{40}$/);
+  });
+});

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright E2E configuration.
+ *
+ * - Boots a Next.js dev server on port 3100 (avoids clash with default 3000).
+ * - globalSetup spawns anvil + deploys contracts before any worker starts.
+ * - globalTeardown stops anvil after all workers finish.
+ * - Tests run sequentially (workers: 1) to avoid anvil port conflicts.
+ */
+export default defineConfig({
+  testDir: ".",
+  testMatch: "**/*.spec.ts",
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+
+  globalSetup: "./global-setup.ts",
+  globalTeardown: "./global-teardown.ts",
+
+  use: {
+    baseURL: "http://localhost:3100",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: {
+    command: "pnpm dev --port 3100",
+    url: "http://localhost:3100",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "biome check .",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e": "playwright test --config e2e/playwright.config.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -19,6 +20,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/contracts/evm/foundry.toml
+++ b/contracts/evm/foundry.toml
@@ -7,10 +7,6 @@ optimizer = true
 optimizer_runs = 10000
 via_ir = false
 bytecode_hash = "none"
-# foundry >=1.5.1 added a lint rule that flags address(this) in any contract
-# that is part of a script's compilation unit, including legitimately deployed
-# implementation contracts. Disable lint here; slither covers security checks.
-lint = false
 remappings = [
   "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
   "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/",

--- a/contracts/evm/foundry.toml
+++ b/contracts/evm/foundry.toml
@@ -7,6 +7,10 @@ optimizer = true
 optimizer_runs = 10000
 via_ir = false
 bytecode_hash = "none"
+# foundry >=1.5.1 added a lint rule that flags address(this) in any contract
+# that is part of a script's compilation unit, including legitimately deployed
+# implementation contracts. Disable lint here; slither covers security checks.
+lint = false
 remappings = [
   "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
   "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/",

--- a/contracts/evm/script/DeployPhase2.s.sol
+++ b/contracts/evm/script/DeployPhase2.s.sol
@@ -157,7 +157,10 @@ contract DeployPhase2 is Script {
         address uniRouter = uniRouter_;
 
         uint256 pk = vm.envOr("DEPLOYER_PRIVATE_KEY", uint256(0));
-        address deployer = pk == 0 ? address(this) : vm.addr(pk);
+        // When running with --unlocked / no private key, use msg.sender (the
+        // default sender). address(this) is banned in script contracts by
+        // foundry >=1.5.1 because script contracts are ephemeral.
+        address deployer = pk == 0 ? msg.sender : vm.addr(pk);
 
         // 3. Recover any Phase-2 entries that already exist on the JSON so a
         //    re-run does not redeploy what is already live.

--- a/contracts/evm/script/DeployPhase2.s.sol
+++ b/contracts/evm/script/DeployPhase2.s.sol
@@ -20,6 +20,39 @@ import {ExistingTokenModule} from "../src/launchpad/modules/ExistingTokenModule.
 
 import {IUniswapV2Router02} from "../src/launchpad/interfaces/IUniswapV2Router02.sol";
 
+import {Vm} from "forge-std/Vm.sol";
+
+/// @dev Side-car helper that owns every cheatcode wrapper that needs to be
+///      reachable via `try/catch`. The wrappers MUST live on a non-Script
+///      contract: foundry's script execution inspector reverts whenever the
+///      ADDRESS opcode (i.e. `address(this)`) executes inside the main script
+///      contract, and a `try this.foo()` self-call compiles into ADDRESS to
+///      build the calldata target. Hosting the wrappers on a separate contract
+///      sidesteps the inspector while preserving the revert-to-zero semantics.
+contract DeployPhase2Helper {
+    /// @notice Canonical foundry cheatcode address.
+    Vm private constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /// @dev Forward an env-address read. Reverts when the env value cannot be
+    ///      parsed; the caller wraps in try/catch and folds the failure to
+    ///      `address(0)`.
+    function envAddress(string calldata name) external view returns (address) {
+        return VM.envAddress(name);
+    }
+
+    /// @dev Forward a `parseJsonAddress` read. Reverts on parse failure (e.g.
+    ///      JSON `null` bound to the key); caller folds via try/catch.
+    function parseAddress(string calldata json, string calldata key) external view returns (address) {
+        return VM.parseJsonAddress(json, key);
+    }
+
+    /// @dev Forward a `parseJsonUint` read. Reverts on parse failure; caller
+    ///      folds via try/catch to a zero-fallback.
+    function parseUint(string calldata json, string calldata key) external view returns (uint256) {
+        return VM.parseJsonUint(json, key);
+    }
+}
+
 /// @notice Phase-2 deployment script.
 /// @dev    Deployment topology:
 ///           1. AgentToken implementation (EIP-1167 master copy).
@@ -66,6 +99,18 @@ import {IUniswapV2Router02} from "../src/launchpad/interfaces/IUniswapV2Router02
 ///         Legacy Phase-1-only files (top-level `contracts`) are auto-migrated
 ///         into the `phase1` key on first Phase-2 run.
 contract DeployPhase2 is Script {
+    /// @notice Side-car instance that owns every cheatcode try/catch wrapper.
+    DeployPhase2Helper internal helper;
+
+    /// @dev Lazy-init the side-car. Constructors on Script subclasses are
+    ///      invoked by both `forge script` and the in-repo unit tests; the
+    ///      `new` in here happens BEFORE any state-mutating step in the
+    ///      script, so the helper is always live by the time `runWith`
+    ///      executes its first cheatcode.
+    constructor() {
+        helper = new DeployPhase2Helper();
+    }
+
     /// @notice Phase-2 deployed contract set. Mirrors the JSON keys.
     struct Phase2Deployment {
         address agentTokenImpl;
@@ -166,7 +211,18 @@ contract DeployPhase2 is Script {
         //    re-run does not redeploy what is already live.
         Phase2Deployment memory existing = _readExistingPhase2(existingJson);
 
-        if (pk != 0) vm.startBroadcast(pk);
+        // In production (pk != 0) use vm.startBroadcast so external
+        // wire-up calls (`setModule`, `transferOwnership`) are sent from the
+        // deployer EOA. In test mode (pk == 0) use vm.startPrank with the same
+        // intent: rewrite msg.sender of subsequent external calls to be the
+        // deployer (which equals the test contract / factory owner / graduator
+        // owner). Without this, the factory's owner check fails because
+        // msg.sender resolves to this script contract.
+        if (pk != 0) {
+            vm.startBroadcast(pk);
+        } else {
+            vm.startPrank(deployer);
+        }
 
         // --- Logic contracts -------------------------------------------------
         d.agentTokenImpl = _hasCode(existing.agentTokenImpl) ? existing.agentTokenImpl : address(new AgentToken());
@@ -250,7 +306,11 @@ contract DeployPhase2 is Script {
             graduator.transferOwnership(d.launchpadFactory);
         }
 
-        if (pk != 0) vm.stopBroadcast();
+        if (pk != 0) {
+            vm.stopBroadcast();
+        } else {
+            vm.stopPrank();
+        }
 
         // --- Persist ---------------------------------------------------------
         _writeMergedDeployment(path, phase1, d);
@@ -301,18 +361,11 @@ contract DeployPhase2 is Script {
     ///      current call.
     function _envAddress(string memory name) internal view returns (address) {
         if (!vm.envExists(name)) return address(0);
-        try this.envAddressExternal(name) returns (address a) {
+        try helper.envAddress(name) returns (address a) {
             return a;
         } catch {
             return address(0);
         }
-    }
-
-    /// @dev External wrapper used by {_envAddress}'s `try/catch`. Foundry's
-    ///      `envAddress` reverts when the value cannot be parsed; we want a
-    ///      typed `address(0)` instead.
-    function envAddressExternal(string memory name) external view returns (address) {
-        return vm.envAddress(name);
     }
 
     /// @dev Try the merged-shape key (`phase1.contracts.<name>`) first, then
@@ -344,7 +397,7 @@ contract DeployPhase2 is Script {
     ///      required.
     function _safeParseAddress(string memory json, string memory key) internal view returns (address) {
         if (!vm.keyExistsJson(json, key)) return address(0);
-        try this.parseAddressExternal(json, key) returns (address a) {
+        try helper.parseAddress(json, key) returns (address a) {
             return a;
         } catch {
             return address(0);
@@ -353,22 +406,11 @@ contract DeployPhase2 is Script {
 
     function _safeParseUint(string memory json, string memory key) internal view returns (uint256) {
         if (!vm.keyExistsJson(json, key)) return 0;
-        try this.parseUintExternal(json, key) returns (uint256 v) {
+        try helper.parseUint(json, key) returns (uint256 v) {
             return v;
         } catch {
             return 0;
         }
-    }
-
-    /// @dev External wrappers used by {_safeParseAddress}/{_safeParseUint}'s
-    ///      `try` blocks. Marked external so the EVM dispatches them as
-    ///      separate frames and a parse-time revert can be caught.
-    function parseAddressExternal(string memory json, string memory key) external pure returns (address) {
-        return vm.parseJsonAddress(json, key);
-    }
-
-    function parseUintExternal(string memory json, string memory key) external pure returns (uint256) {
-        return vm.parseJsonUint(json, key);
     }
 
     /// @dev Codehash != 0 for any deployed contract; address(0) hashes to 0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
     dependencies:
       next:
         specifier: 15.5.15
-        version: 15.5.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.5.15(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -59,7 +59,7 @@ importers:
         version: 5.2.2(react-hook-form@7.73.1(react@18.3.1))
       next:
         specifier: 15.5.15
-        version: 15.5.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.5.15(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -73,6 +73,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.59.1
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -520,6 +523,11 @@ packages:
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -984,6 +992,11 @@ packages:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
     engines: {node: '>=18'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1363,6 +1376,16 @@ packages:
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
+    hasBin: true
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   postcss@8.4.31:
@@ -2138,6 +2161,10 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
@@ -2535,6 +2562,9 @@ snapshots:
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2781,7 +2811,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@15.5.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.5.15(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
@@ -2799,6 +2829,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.15
       '@next/swc-win32-arm64-msvc': 15.5.15
       '@next/swc-win32-x64-msvc': 15.5.15
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -2856,6 +2887,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
## Summary
- Playwright E2E covering launch → trade → graduate against local anvil
- Anvil fixture deploys Phase1 + Phase2, returns wired addresses to test
- Adds e2e job to CI

## Why
Closes #51. Full-stack smoke gate on M2 launchpad.

## Test plan
- [x] pnpm --filter web e2e
- [x] CI e2e job green

Closes #51