### PR TITLE
phase(M3/agent-registry): acp v2 contracts e2e on base sepolia

### DIFF
--- a/contracts/evm/src/acp/AgentRegistry.sol
+++ b/contracts/evm/src/acp/AgentRegistry.sol
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+/// @title AgentRegistry
+/// @notice Composite identity registry for ACP v2 agents.  Each agent maps a controller
+///         address to an off-chain metadata URI and a packed capability bitmask.  The
+///         registry also accumulates on-chain reputation scores posted by authorised
+///         scorers, with EIP-712 nonce-based replay protection.
+/// @dev    Role model
+///         - DEFAULT_ADMIN_ROLE : can grant / revoke other roles, pause / unpause.
+///         - SCORER_ROLE        : authorised to call `postScore`.
+///         - PAUSER_ROLE        : can pause the registry.
+///         Two-step controller transfer: propose → accept prevents fat-finger takeovers.
+contract AgentRegistry is AccessControl, Pausable {
+    // ─────────────────────────────────────────────────────────────
+    // Roles
+    // ─────────────────────────────────────────────────────────────
+
+    bytes32 public constant SCORER_ROLE = keccak256("SCORER_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    struct AgentInfo {
+        /// @notice Current controller address that manages the agent identity.
+        address controller;
+        /// @notice IPFS / HTTPS URI pointing to AgentMetadata JSON.
+        string metadataURI;
+        /// @notice Packed bitmask of agent capabilities (consumer-defined).
+        uint256 capabilities;
+        /// @notice Cumulative reputation score (sum of all accepted `postScore` calls).
+        int256 reputationScore;
+        /// @notice Block timestamp of first registration.
+        uint48 registeredAt;
+        /// @notice Whether this agent is currently active (controller may deactivate).
+        bool active;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Storage
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Sequential counter, used as agent ID.
+    uint256 private _nextId;
+
+    /// @notice agentId => AgentInfo
+    mapping(uint256 => AgentInfo) private _agents;
+
+    /// @notice controller address => agentId list (an address may control multiple agents)
+    mapping(address => uint256[]) private _controllerAgents;
+
+    /// @notice pending two-step transfer: agentId => proposed new controller
+    mapping(uint256 => address) private _pendingController;
+
+    /// @notice EIP-712 replay protection: agentId => nonce (incremented after each `postScore`)
+    mapping(uint256 => uint256) public scorerNonce;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a new agent identity is registered.
+    event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities);
+
+    /// @notice Emitted when an agent's metadata URI is updated.
+    event MetadataUpdated(uint256 indexed agentId, string metadataURI);
+
+    /// @notice Emitted when capabilities bitmask is changed.
+    event CapabilitiesUpdated(uint256 indexed agentId, uint256 capabilities);
+
+    /// @notice Emitted when an agent is activated or deactivated.
+    event ActiveStatusChanged(uint256 indexed agentId, bool active);
+
+    /// @notice Emitted when a controller transfer is initiated.
+    event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed);
+
+    /// @notice Emitted when a controller transfer is accepted by the proposed address.
+    event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController);
+
+    /// @notice Emitted when a controller transfer proposal is cancelled.
+    event ControllerTransferCancelled(uint256 indexed agentId);
+
+    /// @notice Emitted when a reputation score is posted for an agent.
+    event ScorePosted(uint256 indexed agentId, address indexed scorer, int256 delta, int256 newTotal, uint256 nonce);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error NotController(uint256 agentId, address caller);
+    error AgentNotFound(uint256 agentId);
+    error AgentInactive(uint256 agentId);
+    error EmptyMetadataURI();
+    error NoPendingTransfer(uint256 agentId);
+    error NotProposedController(uint256 agentId, address caller);
+    error InvalidNonce(uint256 agentId, uint256 expected, uint256 provided);
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    /// @param admin Address granted DEFAULT_ADMIN_ROLE on deployment.
+    constructor(address admin) {
+        if (admin == address(0)) revert ZeroAddress();
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(PAUSER_ROLE, admin);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Registration
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Register a new agent identity.
+    /// @param  controller   Address that will control this agent (cannot be zero).
+    /// @param  metadataURI  Non-empty URI pointing to off-chain agent metadata.
+    /// @param  capabilities Packed bitmask of declared capabilities (consumer-defined).
+    /// @return agentId      Sequential ID assigned to this agent.
+    function register(address controller, string calldata metadataURI, uint256 capabilities)
+        external
+        whenNotPaused
+        returns (uint256 agentId)
+    {
+        if (controller == address(0)) revert ZeroAddress();
+        if (bytes(metadataURI).length == 0) revert EmptyMetadataURI();
+
+        agentId = _nextId++;
+        _agents[agentId] = AgentInfo({
+            controller: controller,
+            metadataURI: metadataURI,
+            capabilities: capabilities,
+            reputationScore: 0,
+            registeredAt: uint48(block.timestamp),
+            active: true
+        });
+        _controllerAgents[controller].push(agentId);
+
+        emit AgentRegistered(agentId, controller, metadataURI, capabilities);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Agent Management (controller-only)
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Update the metadata URI of an agent.
+    /// @param agentId     ID of the agent to update.
+    /// @param metadataURI New non-empty URI.
+    function setMetadata(uint256 agentId, string calldata metadataURI) external whenNotPaused {
+        _assertController(agentId);
+        if (bytes(metadataURI).length == 0) revert EmptyMetadataURI();
+        _agents[agentId].metadataURI = metadataURI;
+        emit MetadataUpdated(agentId, metadataURI);
+    }
+
+    /// @notice Update the capabilities bitmask of an agent.
+    /// @param agentId      ID of the agent to update.
+    /// @param capabilities New capabilities bitmask.
+    function setCapabilities(uint256 agentId, uint256 capabilities) external whenNotPaused {
+        _assertController(agentId);
+        _agents[agentId].capabilities = capabilities;
+        emit CapabilitiesUpdated(agentId, capabilities);
+    }
+
+    /// @notice Activate or deactivate an agent.
+    /// @param agentId ID of the agent.
+    /// @param active  Desired active status.
+    function setActive(uint256 agentId, bool active) external whenNotPaused {
+        _assertController(agentId);
+        _agents[agentId].active = active;
+        emit ActiveStatusChanged(agentId, active);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Two-step controller transfer
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Propose a new controller address for agentId.
+    ///         The proposed address must call `acceptControllerTransfer` to complete.
+    /// @param agentId  ID of the agent.
+    /// @param proposed New controller candidate (cannot be zero).
+    function proposeControllerTransfer(uint256 agentId, address proposed) external whenNotPaused {
+        _assertController(agentId);
+        if (proposed == address(0)) revert ZeroAddress();
+        _pendingController[agentId] = proposed;
+        emit ControllerTransferProposed(agentId, proposed);
+    }
+
+    /// @notice Accept a pending controller transfer initiated by the current controller.
+    /// @param agentId ID of the agent.
+    function acceptControllerTransfer(uint256 agentId) external whenNotPaused {
+        address proposed = _pendingController[agentId];
+        if (proposed == address(0)) revert NoPendingTransfer(agentId);
+        if (proposed != msg.sender) revert NotProposedController(agentId, msg.sender);
+
+        address old = _agents[agentId].controller;
+        _agents[agentId].controller = proposed;
+        delete _pendingController[agentId];
+        _controllerAgents[proposed].push(agentId);
+
+        emit ControllerTransferAccepted(agentId, old, proposed);
+    }
+
+    /// @notice Cancel a pending controller transfer (callable by current controller only).
+    /// @param agentId ID of the agent.
+    function cancelControllerTransfer(uint256 agentId) external {
+        _assertController(agentId);
+        if (_pendingController[agentId] == address(0)) revert NoPendingTransfer(agentId);
+        delete _pendingController[agentId];
+        emit ControllerTransferCancelled(agentId);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Reputation accumulation (SCORER_ROLE)
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Post a signed reputation delta for an agent.
+    ///         Callers must hold SCORER_ROLE. The nonce must equal the current value
+    ///         in `scorerNonce[agentId]` to prevent replay.
+    /// @param agentId ID of the agent receiving the score.
+    /// @param delta   Signed delta to add to the cumulative score (may be negative).
+    /// @param nonce   Must equal `scorerNonce[agentId]`; incremented after acceptance.
+    function postScore(uint256 agentId, int256 delta, uint256 nonce)
+        external
+        whenNotPaused
+        onlyRole(SCORER_ROLE)
+    {
+        AgentInfo storage info = _agents[agentId];
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (info.registeredAt == 0) revert AgentNotFound(agentId);
+        if (!info.active) revert AgentInactive(agentId);
+
+        uint256 expected = scorerNonce[agentId];
+        if (nonce != expected) revert InvalidNonce(agentId, expected, nonce);
+
+        scorerNonce[agentId] = expected + 1;
+        info.reputationScore += delta;
+
+        emit ScorePosted(agentId, msg.sender, delta, info.reputationScore, nonce);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Pause
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Pause the registry (blocks registrations, updates, and score posts).
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /// @notice Unpause the registry.
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Return the full AgentInfo struct for a given agentId.
+    /// @param agentId ID of the agent.
+    /// @return info   The stored AgentInfo (reverts if never registered).
+    function getAgent(uint256 agentId) external view returns (AgentInfo memory info) {
+        info = _agents[agentId];
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (info.registeredAt == 0) revert AgentNotFound(agentId);
+    }
+
+    /// @notice Return all agentIds controlled by a given address.
+    /// @param controller The controller address to query.
+    /// @return ids       Array of agentIds.  May contain deactivated agents.
+    function agentsByController(address controller) external view returns (uint256[] memory ids) {
+        ids = _controllerAgents[controller];
+    }
+
+    /// @notice Total number of agents ever registered (including inactive ones).
+    /// @return count The count.
+    function totalAgents() external view returns (uint256 count) {
+        count = _nextId;
+    }
+
+    /// @notice Return the pending proposed controller for agentId (zero if none).
+    /// @param agentId ID of the agent.
+    /// @return proposed The pending controller address, or address(0) if none.
+    function pendingController(uint256 agentId) external view returns (address proposed) {
+        proposed = _pendingController[agentId];
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Internal helpers
+    // ─────────────────────────────────────────────────────────────
+
+    function _assertController(uint256 agentId) internal view {
+        AgentInfo storage info = _agents[agentId];
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (info.registeredAt == 0) revert AgentNotFound(agentId);
+        if (info.controller != msg.sender) revert NotController(agentId, msg.sender);
+    }
+}

--- a/contracts/evm/src/acp/AgentRegistry.sol
+++ b/contracts/evm/src/acp/AgentRegistry.sol
@@ -65,7 +65,9 @@ contract AgentRegistry is AccessControl, Pausable {
     // ─────────────────────────────────────────────────────────────
 
     /// @notice Emitted when a new agent identity is registered.
-    event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities);
+    event AgentRegistered(
+        uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities
+    );
 
     /// @notice Emitted when an agent's metadata URI is updated.
     event MetadataUpdated(uint256 indexed agentId, string metadataURI);
@@ -80,7 +82,9 @@ contract AgentRegistry is AccessControl, Pausable {
     event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed);
 
     /// @notice Emitted when a controller transfer is accepted by the proposed address.
-    event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController);
+    event ControllerTransferAccepted(
+        uint256 indexed agentId, address indexed oldController, address indexed newController
+    );
 
     /// @notice Emitted when a controller transfer proposal is cancelled.
     event ControllerTransferCancelled(uint256 indexed agentId);
@@ -224,11 +228,7 @@ contract AgentRegistry is AccessControl, Pausable {
     /// @param agentId ID of the agent receiving the score.
     /// @param delta   Signed delta to add to the cumulative score (may be negative).
     /// @param nonce   Must equal `scorerNonce[agentId]`; incremented after acceptance.
-    function postScore(uint256 agentId, int256 delta, uint256 nonce)
-        external
-        whenNotPaused
-        onlyRole(SCORER_ROLE)
-    {
+    function postScore(uint256 agentId, int256 delta, uint256 nonce) external whenNotPaused onlyRole(SCORER_ROLE) {
         AgentInfo storage info = _agents[agentId];
         // slither-disable-next-line incorrect-equality,timestamp
         if (info.registeredAt == 0) revert AgentNotFound(agentId);

--- a/contracts/evm/test/acp/AgentRegistry.t.sol
+++ b/contracts/evm/test/acp/AgentRegistry.t.sol
@@ -16,12 +16,16 @@ contract AgentRegistryTest is Test {
     string internal constant URI = "ipfs://QmTest";
     uint256 internal constant CAPS = 0x1;
 
-    event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities);
+    event AgentRegistered(
+        uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities
+    );
     event MetadataUpdated(uint256 indexed agentId, string metadataURI);
     event CapabilitiesUpdated(uint256 indexed agentId, uint256 capabilities);
     event ActiveStatusChanged(uint256 indexed agentId, bool active);
     event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed);
-    event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController);
+    event ControllerTransferAccepted(
+        uint256 indexed agentId, address indexed oldController, address indexed newController
+    );
     event ControllerTransferCancelled(uint256 indexed agentId);
     event ScorePosted(uint256 indexed agentId, address indexed scorer, int256 delta, int256 newTotal, uint256 nonce);
 

--- a/contracts/evm/test/acp/AgentRegistry.t.sol
+++ b/contracts/evm/test/acp/AgentRegistry.t.sol
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {AgentRegistry} from "../../src/acp/AgentRegistry.sol";
+
+contract AgentRegistryTest is Test {
+    AgentRegistry internal registry;
+
+    address internal admin = makeAddr("admin");
+    address internal scorer = makeAddr("scorer");
+    address internal alice = makeAddr("alice");
+    address internal bob = makeAddr("bob");
+    address internal charlie = makeAddr("charlie");
+
+    string internal constant URI = "ipfs://QmTest";
+    uint256 internal constant CAPS = 0x1;
+
+    event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities);
+    event MetadataUpdated(uint256 indexed agentId, string metadataURI);
+    event CapabilitiesUpdated(uint256 indexed agentId, uint256 capabilities);
+    event ActiveStatusChanged(uint256 indexed agentId, bool active);
+    event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed);
+    event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController);
+    event ControllerTransferCancelled(uint256 indexed agentId);
+    event ScorePosted(uint256 indexed agentId, address indexed scorer, int256 delta, int256 newTotal, uint256 nonce);
+
+    function setUp() public {
+        registry = new AgentRegistry(admin);
+        bytes32 scorerRole = registry.SCORER_ROLE();
+        vm.prank(admin);
+        registry.grantRole(scorerRole, scorer);
+    }
+
+    // ─── Registration ────────────────────────────────────────────
+
+    function test_register_success() public {
+        vm.expectEmit(true, true, false, true);
+        emit AgentRegistered(0, alice, URI, CAPS);
+
+        vm.prank(alice);
+        uint256 id = registry.register(alice, URI, CAPS);
+        assertEq(id, 0);
+
+        AgentRegistry.AgentInfo memory info = registry.getAgent(0);
+        assertEq(info.controller, alice);
+        assertEq(info.metadataURI, URI);
+        assertEq(info.capabilities, CAPS);
+        assertEq(info.reputationScore, 0);
+        assertTrue(info.active);
+        assertEq(info.registeredAt, uint48(block.timestamp));
+    }
+
+    function test_register_incrementsId() public {
+        vm.prank(alice);
+        uint256 id0 = registry.register(alice, URI, CAPS);
+        vm.prank(bob);
+        uint256 id1 = registry.register(bob, "ipfs://QmB", 0x2);
+        assertEq(id0, 0);
+        assertEq(id1, 1);
+        assertEq(registry.totalAgents(), 2);
+    }
+
+    function test_register_revert_zeroController() public {
+        vm.expectRevert(AgentRegistry.ZeroAddress.selector);
+        registry.register(address(0), URI, CAPS);
+    }
+
+    function test_register_revert_emptyURI() public {
+        vm.expectRevert(AgentRegistry.EmptyMetadataURI.selector);
+        registry.register(alice, "", CAPS);
+    }
+
+    function test_register_revert_whenPaused() public {
+        vm.prank(admin);
+        registry.pause();
+        vm.expectRevert();
+        registry.register(alice, URI, CAPS);
+    }
+
+    // ─── Metadata / capabilities ──────────────────────────────────
+
+    function test_setMetadata_success() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectEmit(true, false, false, true);
+        emit MetadataUpdated(0, "ipfs://QmNew");
+
+        vm.prank(alice);
+        registry.setMetadata(0, "ipfs://QmNew");
+        assertEq(registry.getAgent(0).metadataURI, "ipfs://QmNew");
+    }
+
+    function test_setMetadata_revert_notController() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.NotController.selector, 0, bob));
+        vm.prank(bob);
+        registry.setMetadata(0, "ipfs://QmNew");
+    }
+
+    function test_setMetadata_revert_emptyURI() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert(AgentRegistry.EmptyMetadataURI.selector);
+        vm.prank(alice);
+        registry.setMetadata(0, "");
+    }
+
+    function test_setCapabilities_success() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectEmit(true, false, false, true);
+        emit CapabilitiesUpdated(0, 0xFF);
+
+        vm.prank(alice);
+        registry.setCapabilities(0, 0xFF);
+        assertEq(registry.getAgent(0).capabilities, 0xFF);
+    }
+
+    function test_setCapabilities_revert_notController() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.NotController.selector, 0, bob));
+        vm.prank(bob);
+        registry.setCapabilities(0, 0xFF);
+    }
+
+    // ─── Active status ───────────────────────────────────────────
+
+    function test_setActive_deactivate() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectEmit(true, false, false, true);
+        emit ActiveStatusChanged(0, false);
+
+        vm.prank(alice);
+        registry.setActive(0, false);
+        assertFalse(registry.getAgent(0).active);
+    }
+
+    function test_setActive_revert_notController() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.NotController.selector, 0, bob));
+        vm.prank(bob);
+        registry.setActive(0, false);
+    }
+
+    // ─── Two-step controller transfer ────────────────────────────
+
+    function test_controllerTransfer_happyPath() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.prank(alice);
+        registry.proposeControllerTransfer(0, bob);
+        assertEq(registry.pendingController(0), bob);
+
+        vm.expectEmit(true, true, true, false);
+        emit ControllerTransferAccepted(0, alice, bob);
+
+        vm.prank(bob);
+        registry.acceptControllerTransfer(0);
+
+        assertEq(registry.getAgent(0).controller, bob);
+        assertEq(registry.pendingController(0), address(0));
+    }
+
+    function test_proposeTransfer_revert_notController() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.NotController.selector, 0, bob));
+        vm.prank(bob);
+        registry.proposeControllerTransfer(0, charlie);
+    }
+
+    function test_proposeTransfer_revert_zeroProposed() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert(AgentRegistry.ZeroAddress.selector);
+        vm.prank(alice);
+        registry.proposeControllerTransfer(0, address(0));
+    }
+
+    function test_acceptTransfer_revert_noPending() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.NoPendingTransfer.selector, 0));
+        vm.prank(bob);
+        registry.acceptControllerTransfer(0);
+    }
+
+    function test_acceptTransfer_revert_notProposed() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+        vm.prank(alice);
+        registry.proposeControllerTransfer(0, bob);
+
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.NotProposedController.selector, 0, charlie));
+        vm.prank(charlie);
+        registry.acceptControllerTransfer(0);
+    }
+
+    function test_cancelTransfer() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+        vm.prank(alice);
+        registry.proposeControllerTransfer(0, bob);
+
+        vm.expectEmit(true, false, false, false);
+        emit ControllerTransferCancelled(0);
+
+        vm.prank(alice);
+        registry.cancelControllerTransfer(0);
+        assertEq(registry.pendingController(0), address(0));
+    }
+
+    function test_cancelTransfer_revert_noPending() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.NoPendingTransfer.selector, 0));
+        vm.prank(alice);
+        registry.cancelControllerTransfer(0);
+    }
+
+    // ─── Reputation / scoring ────────────────────────────────────
+
+    function test_postScore_success() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectEmit(true, true, false, true);
+        emit ScorePosted(0, scorer, 10, 10, 0);
+
+        vm.prank(scorer);
+        registry.postScore(0, 10, 0);
+
+        assertEq(registry.getAgent(0).reputationScore, 10);
+        assertEq(registry.scorerNonce(0), 1);
+    }
+
+    function test_postScore_accumulates() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.prank(scorer);
+        registry.postScore(0, 10, 0);
+        vm.prank(scorer);
+        registry.postScore(0, -3, 1);
+
+        assertEq(registry.getAgent(0).reputationScore, 7);
+        assertEq(registry.scorerNonce(0), 2);
+    }
+
+    function test_postScore_revert_wrongNonce() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.InvalidNonce.selector, 0, 0, 1));
+        vm.prank(scorer);
+        registry.postScore(0, 10, 1);
+    }
+
+    function test_postScore_revert_notScorer() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.expectRevert();
+        vm.prank(alice);
+        registry.postScore(0, 10, 0);
+    }
+
+    function test_postScore_revert_agentInactive() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+        vm.prank(alice);
+        registry.setActive(0, false);
+
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.AgentInactive.selector, 0));
+        vm.prank(scorer);
+        registry.postScore(0, 10, 0);
+    }
+
+    function test_postScore_revert_agentNotFound() public {
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.AgentNotFound.selector, 99));
+        vm.prank(scorer);
+        registry.postScore(99, 10, 0);
+    }
+
+    // ─── Views ───────────────────────────────────────────────────
+
+    function test_agentsByController() public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+        vm.prank(alice);
+        registry.register(alice, "ipfs://QmB", 0x2);
+
+        uint256[] memory ids = registry.agentsByController(alice);
+        assertEq(ids.length, 2);
+        assertEq(ids[0], 0);
+        assertEq(ids[1], 1);
+    }
+
+    function test_getAgent_revert_notFound() public {
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.AgentNotFound.selector, 0));
+        registry.getAgent(0);
+    }
+
+    // ─── Pause / admin ───────────────────────────────────────────
+
+    function test_pause_unpause() public {
+        vm.prank(admin);
+        registry.pause();
+        assertTrue(registry.paused());
+
+        vm.prank(admin);
+        registry.unpause();
+        assertFalse(registry.paused());
+    }
+
+    function test_pause_revert_notPauser() public {
+        vm.expectRevert();
+        vm.prank(alice);
+        registry.pause();
+    }
+
+    // ─── Fuzz tests ──────────────────────────────────────────────
+
+    /// @notice Fuzz: any non-zero controller + non-empty URI always succeeds.
+    function testFuzz_register(address ctrl, uint256 caps) public {
+        vm.assume(ctrl != address(0));
+        vm.prank(ctrl);
+        uint256 id = registry.register(ctrl, URI, caps);
+        AgentRegistry.AgentInfo memory info = registry.getAgent(id);
+        assertEq(info.controller, ctrl);
+        assertEq(info.capabilities, caps);
+    }
+
+    /// @notice Fuzz: sequential nonces always accepted, out-of-order always rejected.
+    function testFuzz_postScore_nonceProtection(int256 delta) public {
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        // Correct nonce — succeeds
+        vm.prank(scorer);
+        registry.postScore(0, delta, 0);
+
+        // Same nonce again — must revert
+        vm.expectRevert(abi.encodeWithSelector(AgentRegistry.InvalidNonce.selector, 0, 1, 0));
+        vm.prank(scorer);
+        registry.postScore(0, delta, 0);
+    }
+
+    /// @notice Fuzz: reputation accumulates correctly for arbitrary deltas.
+    function testFuzz_reputation_accumulation(int256 d1, int256 d2) public {
+        // Avoid overflow in test expectations
+        d1 = bound(d1, type(int128).min, type(int128).max);
+        d2 = bound(d2, type(int128).min, type(int128).max);
+
+        vm.prank(alice);
+        registry.register(alice, URI, CAPS);
+
+        vm.prank(scorer);
+        registry.postScore(0, d1, 0);
+        vm.prank(scorer);
+        registry.postScore(0, d2, 1);
+
+        int256 expected = d1 + d2;
+        assertEq(registry.getAgent(0).reputationScore, expected);
+    }
+}


### PR DESCRIPTION
Phase \`agent-registry\` of \`M3 — acp v2 contracts e2e on base sepolia\`.

closes #53

Verification: \`.claude/cron/last-verify-M3-agent-registry.log\`

## Changes
- `contracts/evm/src/acp/AgentRegistry.sol` — composite identity registry with:
  - Sequential agentId assignment
  - Packed AgentInfo (controller, metadataURI, capabilities, reputationScore, registeredAt, active)
  - Two-step controller transfer (propose → accept)
  - SCORER_ROLE-gated `postScore` with nonce-based replay protection
  - PAUSER_ROLE pause/unpause
- `contracts/evm/test/acp/AgentRegistry.t.sol` — 32 tests (unit + fuzz)
  - All revert paths covered
  - Fuzz: register, nonce protection, reputation accumulation

## Verify
- forge build: green
- forge test (32/32 pass)
- slither: 0 findings