### PR TITLE
phase(M3/job-factory): acp v2 contracts e2e on base sepolia

### DIFF
--- a/contracts/evm/src/acp/AgentRegistry.sol
+++ b/contracts/evm/src/acp/AgentRegistry.sol
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+/// @title AgentRegistry
+/// @notice Composite identity registry for ACP v2 agents.  Each agent maps a controller
+///         address to an off-chain metadata URI and a packed capability bitmask.  The
+///         registry also accumulates on-chain reputation scores posted by authorised
+///         scorers, with EIP-712 nonce-based replay protection.
+/// @dev    Role model
+///         - DEFAULT_ADMIN_ROLE : can grant / revoke other roles, pause / unpause.
+///         - SCORER_ROLE        : authorised to call `postScore`.
+///         - PAUSER_ROLE        : can pause the registry.
+///         Two-step controller transfer: propose → accept prevents fat-finger takeovers.
+contract AgentRegistry is AccessControl, Pausable {
+    // ─────────────────────────────────────────────────────────────
+    // Roles
+    // ─────────────────────────────────────────────────────────────
+
+    bytes32 public constant SCORER_ROLE = keccak256("SCORER_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    struct AgentInfo {
+        /// @notice Current controller address that manages the agent identity.
+        address controller;
+        /// @notice IPFS / HTTPS URI pointing to AgentMetadata JSON.
+        string metadataURI;
+        /// @notice Packed bitmask of agent capabilities (consumer-defined).
+        uint256 capabilities;
+        /// @notice Cumulative reputation score (sum of all accepted `postScore` calls).
+        int256 reputationScore;
+        /// @notice Block timestamp of first registration.
+        uint48 registeredAt;
+        /// @notice Whether this agent is currently active (controller may deactivate).
+        bool active;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Storage
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Sequential counter, used as agent ID.
+    uint256 private _nextId;
+
+    /// @notice agentId => AgentInfo
+    mapping(uint256 => AgentInfo) private _agents;
+
+    /// @notice controller address => agentId list (an address may control multiple agents)
+    mapping(address => uint256[]) private _controllerAgents;
+
+    /// @notice pending two-step transfer: agentId => proposed new controller
+    mapping(uint256 => address) private _pendingController;
+
+    /// @notice EIP-712 replay protection: agentId => nonce (incremented after each `postScore`)
+    mapping(uint256 => uint256) public scorerNonce;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a new agent identity is registered.
+    event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities);
+
+    /// @notice Emitted when an agent's metadata URI is updated.
+    event MetadataUpdated(uint256 indexed agentId, string metadataURI);
+
+    /// @notice Emitted when capabilities bitmask is changed.
+    event CapabilitiesUpdated(uint256 indexed agentId, uint256 capabilities);
+
+    /// @notice Emitted when an agent is activated or deactivated.
+    event ActiveStatusChanged(uint256 indexed agentId, bool active);
+
+    /// @notice Emitted when a controller transfer is initiated.
+    event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed);
+
+    /// @notice Emitted when a controller transfer is accepted by the proposed address.
+    event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController);
+
+    /// @notice Emitted when a controller transfer proposal is cancelled.
+    event ControllerTransferCancelled(uint256 indexed agentId);
+
+    /// @notice Emitted when a reputation score is posted for an agent.
+    event ScorePosted(uint256 indexed agentId, address indexed scorer, int256 delta, int256 newTotal, uint256 nonce);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error NotController(uint256 agentId, address caller);
+    error AgentNotFound(uint256 agentId);
+    error AgentInactive(uint256 agentId);
+    error EmptyMetadataURI();
+    error NoPendingTransfer(uint256 agentId);
+    error NotProposedController(uint256 agentId, address caller);
+    error InvalidNonce(uint256 agentId, uint256 expected, uint256 provided);
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    /// @param admin Address granted DEFAULT_ADMIN_ROLE on deployment.
+    constructor(address admin) {
+        if (admin == address(0)) revert ZeroAddress();
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(PAUSER_ROLE, admin);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Registration
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Register a new agent identity.
+    /// @param  controller   Address that will control this agent (cannot be zero).
+    /// @param  metadataURI  Non-empty URI pointing to off-chain agent metadata.
+    /// @param  capabilities Packed bitmask of declared capabilities (consumer-defined).
+    /// @return agentId      Sequential ID assigned to this agent.
+    function register(address controller, string calldata metadataURI, uint256 capabilities)
+        external
+        whenNotPaused
+        returns (uint256 agentId)
+    {
+        if (controller == address(0)) revert ZeroAddress();
+        if (bytes(metadataURI).length == 0) revert EmptyMetadataURI();
+
+        agentId = _nextId++;
+        _agents[agentId] = AgentInfo({
+            controller: controller,
+            metadataURI: metadataURI,
+            capabilities: capabilities,
+            reputationScore: 0,
+            registeredAt: uint48(block.timestamp),
+            active: true
+        });
+        _controllerAgents[controller].push(agentId);
+
+        emit AgentRegistered(agentId, controller, metadataURI, capabilities);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Agent Management (controller-only)
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Update the metadata URI of an agent.
+    /// @param agentId     ID of the agent to update.
+    /// @param metadataURI New non-empty URI.
+    function setMetadata(uint256 agentId, string calldata metadataURI) external whenNotPaused {
+        _assertController(agentId);
+        if (bytes(metadataURI).length == 0) revert EmptyMetadataURI();
+        _agents[agentId].metadataURI = metadataURI;
+        emit MetadataUpdated(agentId, metadataURI);
+    }
+
+    /// @notice Update the capabilities bitmask of an agent.
+    /// @param agentId      ID of the agent to update.
+    /// @param capabilities New capabilities bitmask.
+    function setCapabilities(uint256 agentId, uint256 capabilities) external whenNotPaused {
+        _assertController(agentId);
+        _agents[agentId].capabilities = capabilities;
+        emit CapabilitiesUpdated(agentId, capabilities);
+    }
+
+    /// @notice Activate or deactivate an agent.
+    /// @param agentId ID of the agent.
+    /// @param active  Desired active status.
+    function setActive(uint256 agentId, bool active) external whenNotPaused {
+        _assertController(agentId);
+        _agents[agentId].active = active;
+        emit ActiveStatusChanged(agentId, active);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Two-step controller transfer
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Propose a new controller address for agentId.
+    ///         The proposed address must call `acceptControllerTransfer` to complete.
+    /// @param agentId  ID of the agent.
+    /// @param proposed New controller candidate (cannot be zero).
+    function proposeControllerTransfer(uint256 agentId, address proposed) external whenNotPaused {
+        _assertController(agentId);
+        if (proposed == address(0)) revert ZeroAddress();
+        _pendingController[agentId] = proposed;
+        emit ControllerTransferProposed(agentId, proposed);
+    }
+
+    /// @notice Accept a pending controller transfer initiated by the current controller.
+    /// @param agentId ID of the agent.
+    function acceptControllerTransfer(uint256 agentId) external whenNotPaused {
+        address proposed = _pendingController[agentId];
+        if (proposed == address(0)) revert NoPendingTransfer(agentId);
+        if (proposed != msg.sender) revert NotProposedController(agentId, msg.sender);
+
+        address old = _agents[agentId].controller;
+        _agents[agentId].controller = proposed;
+        delete _pendingController[agentId];
+        _controllerAgents[proposed].push(agentId);
+
+        emit ControllerTransferAccepted(agentId, old, proposed);
+    }
+
+    /// @notice Cancel a pending controller transfer (callable by current controller only).
+    /// @param agentId ID of the agent.
+    function cancelControllerTransfer(uint256 agentId) external {
+        _assertController(agentId);
+        if (_pendingController[agentId] == address(0)) revert NoPendingTransfer(agentId);
+        delete _pendingController[agentId];
+        emit ControllerTransferCancelled(agentId);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Reputation accumulation (SCORER_ROLE)
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Post a signed reputation delta for an agent.
+    ///         Callers must hold SCORER_ROLE. The nonce must equal the current value
+    ///         in `scorerNonce[agentId]` to prevent replay.
+    /// @param agentId ID of the agent receiving the score.
+    /// @param delta   Signed delta to add to the cumulative score (may be negative).
+    /// @param nonce   Must equal `scorerNonce[agentId]`; incremented after acceptance.
+    function postScore(uint256 agentId, int256 delta, uint256 nonce)
+        external
+        whenNotPaused
+        onlyRole(SCORER_ROLE)
+    {
+        AgentInfo storage info = _agents[agentId];
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (info.registeredAt == 0) revert AgentNotFound(agentId);
+        if (!info.active) revert AgentInactive(agentId);
+
+        uint256 expected = scorerNonce[agentId];
+        if (nonce != expected) revert InvalidNonce(agentId, expected, nonce);
+
+        scorerNonce[agentId] = expected + 1;
+        info.reputationScore += delta;
+
+        emit ScorePosted(agentId, msg.sender, delta, info.reputationScore, nonce);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Pause
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Pause the registry (blocks registrations, updates, and score posts).
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /// @notice Unpause the registry.
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Return the full AgentInfo struct for a given agentId.
+    /// @param agentId ID of the agent.
+    /// @return info   The stored AgentInfo (reverts if never registered).
+    function getAgent(uint256 agentId) external view returns (AgentInfo memory info) {
+        info = _agents[agentId];
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (info.registeredAt == 0) revert AgentNotFound(agentId);
+    }
+
+    /// @notice Return all agentIds controlled by a given address.
+    /// @param controller The controller address to query.
+    /// @return ids       Array of agentIds.  May contain deactivated agents.
+    function agentsByController(address controller) external view returns (uint256[] memory ids) {
+        ids = _controllerAgents[controller];
+    }
+
+    /// @notice Total number of agents ever registered (including inactive ones).
+    /// @return count The count.
+    function totalAgents() external view returns (uint256 count) {
+        count = _nextId;
+    }
+
+    /// @notice Return the pending proposed controller for agentId (zero if none).
+    /// @param agentId ID of the agent.
+    /// @return proposed The pending controller address, or address(0) if none.
+    function pendingController(uint256 agentId) external view returns (address proposed) {
+        proposed = _pendingController[agentId];
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Internal helpers
+    // ─────────────────────────────────────────────────────────────
+
+    function _assertController(uint256 agentId) internal view {
+        AgentInfo storage info = _agents[agentId];
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (info.registeredAt == 0) revert AgentNotFound(agentId);
+        if (info.controller != msg.sender) revert NotController(agentId, msg.sender);
+    }
+}

--- a/contracts/evm/src/acp/AgentRegistry.sol
+++ b/contracts/evm/src/acp/AgentRegistry.sol
@@ -65,7 +65,9 @@ contract AgentRegistry is AccessControl, Pausable {
     // ─────────────────────────────────────────────────────────────
 
     /// @notice Emitted when a new agent identity is registered.
-    event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities);
+    event AgentRegistered(
+        uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities
+    );
 
     /// @notice Emitted when an agent's metadata URI is updated.
     event MetadataUpdated(uint256 indexed agentId, string metadataURI);
@@ -80,7 +82,9 @@ contract AgentRegistry is AccessControl, Pausable {
     event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed);
 
     /// @notice Emitted when a controller transfer is accepted by the proposed address.
-    event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController);
+    event ControllerTransferAccepted(
+        uint256 indexed agentId, address indexed oldController, address indexed newController
+    );
 
     /// @notice Emitted when a controller transfer proposal is cancelled.
     event ControllerTransferCancelled(uint256 indexed agentId);
@@ -224,11 +228,7 @@ contract AgentRegistry is AccessControl, Pausable {
     /// @param agentId ID of the agent receiving the score.
     /// @param delta   Signed delta to add to the cumulative score (may be negative).
     /// @param nonce   Must equal `scorerNonce[agentId]`; incremented after acceptance.
-    function postScore(uint256 agentId, int256 delta, uint256 nonce)
-        external
-        whenNotPaused
-        onlyRole(SCORER_ROLE)
-    {
+    function postScore(uint256 agentId, int256 delta, uint256 nonce) external whenNotPaused onlyRole(SCORER_ROLE) {
         AgentInfo storage info = _agents[agentId];
         // slither-disable-next-line incorrect-equality,timestamp
         if (info.registeredAt == 0) revert AgentNotFound(agentId);

--- a/contracts/evm/src/acp/IJob.sol
+++ b/contracts/evm/src/acp/IJob.sol
@@ -10,18 +10,18 @@ interface IJob {
 
     /// @notice Ordered job lifecycle phases.
     enum Phase {
-        Open,       // 0 — awaiting agent acceptance
-        Active,     // 1 — agent accepted; work in progress
-        Review,     // 2 — result submitted; in evaluator / principal review
-        Completed,  // 3 — payment released
-        Cancelled,  // 4 — cancelled before completion (by principal before acceptance, or by dispute resolution)
-        Disputed    // 5 — dispute raised; awaiting arbitration
+        Open, // 0 — awaiting agent acceptance
+        Active, // 1 — agent accepted; work in progress
+        Review, // 2 — result submitted; in evaluator / principal review
+        Completed, // 3 — payment released
+        Cancelled, // 4 — cancelled before completion (by principal before acceptance, or by dispute resolution)
+        Disputed // 5 — dispute raised; awaiting arbitration
     }
 
     /// @notice Job type: whether an external evaluator is required before release.
     enum JobType {
-        Direct,     // No evaluator — principal releases on result submission after grace period
-        Evaluated   // Evaluator role is required to approve / reject before release
+        Direct, // No evaluator — principal releases on result submission after grace period
+        Evaluated // Evaluator role is required to approve / reject before release
     }
 
     // ─────────────────────────────────────────────────────────────

--- a/contracts/evm/src/acp/IJob.sol
+++ b/contracts/evm/src/acp/IJob.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title IJob
+/// @notice Interface for the ACP v2 Job state machine.
+interface IJob {
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Ordered job lifecycle phases.
+    enum Phase {
+        Open,       // 0 — awaiting agent acceptance
+        Active,     // 1 — agent accepted; work in progress
+        Review,     // 2 — result submitted; in evaluator / principal review
+        Completed,  // 3 — payment released
+        Cancelled,  // 4 — cancelled before completion (by principal before acceptance, or by dispute resolution)
+        Disputed    // 5 — dispute raised; awaiting arbitration
+    }
+
+    /// @notice Job type: whether an external evaluator is required before release.
+    enum JobType {
+        Direct,     // No evaluator — principal releases on result submission after grace period
+        Evaluated   // Evaluator role is required to approve / reject before release
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    event JobInitialised(
+        uint256 indexed jobId,
+        address indexed principal,
+        uint256 indexed agentId,
+        JobType jobType,
+        uint256 budget,
+        address token,
+        uint64 deadline
+    );
+
+    event AgentAccepted(uint256 indexed jobId, address indexed agent, uint256 indexed agentId);
+
+    event ResultSubmitted(uint256 indexed jobId, address indexed agent, string resultURI);
+
+    event JobCompleted(uint256 indexed jobId, address indexed releasedBy, uint256 amount);
+
+    event JobCancelled(uint256 indexed jobId, address indexed cancelledBy, string reason);
+
+    event DisputeRaised(uint256 indexed jobId, address indexed raisedBy);
+
+    event DisputeResolved(uint256 indexed jobId, address indexed resolver, bool agentFavoured);
+
+    event EvaluatorAssigned(uint256 indexed jobId, address indexed evaluator);
+
+    event ResultApproved(uint256 indexed jobId, address indexed evaluator);
+
+    event ResultRejected(uint256 indexed jobId, address indexed evaluator, string reason);
+
+    // ─────────────────────────────────────────────────────────────
+    // State transitions (phase function signatures)
+    // ─────────────────────────────────────────────────────────────
+
+    function accept(uint256 agentId) external;
+    function submitResult(string calldata resultURI) external;
+    function approveResult() external;
+    function rejectResult(string calldata reason) external;
+    function release() external;
+    function cancel(string calldata reason) external;
+    function raiseDispute() external;
+    function resolveDispute(bool agentFavoured) external;
+    function expireJob() external;
+}

--- a/contracts/evm/src/acp/Job.sol
+++ b/contracts/evm/src/acp/Job.sol
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IJob} from "./IJob.sol";
+import {AgentRegistry} from "./AgentRegistry.sol";
+
+/// @title Job
+/// @notice ACP v2 Job — EIP-1167-clonable state machine for agent work agreements.
+/// @dev    Designed to be deployed as a minimal proxy by JobFactory; `initialize`
+///         replaces the constructor.  All privileged state transitions gate on role
+///         (principal, agent, evaluator, arbiter) and the current Phase.
+///
+///         Phase graph (allowed transitions):
+///           Open      → Active     (agent accepts)
+///           Open      → Cancelled  (principal cancels; budget refunded)
+///           Open      → Cancelled  (expiry triggers expireJob)
+///           Active    → Review     (agent submits result)
+///           Active    → Disputed   (principal raises dispute)
+///           Active    → Cancelled  (expiry triggers expireJob)
+///           Review    → Completed  (principal/evaluator approves; escrow released)
+///           Review    → Active     (evaluator rejects; agent may resubmit)
+///           Review    → Disputed   (principal or agent raises dispute)
+///           Completed → —          (terminal)
+///           Cancelled → —          (terminal)
+///           Disputed  → Completed  (arbiter resolves agent-favoured; escrow released)
+///           Disputed  → Cancelled  (arbiter resolves principal-favoured; budget refunded)
+///
+///         CEI order is enforced throughout; ReentrancyGuard on all token transfers.
+contract Job is IJob, ReentrancyGuard, Initializable {
+    using SafeERC20 for IERC20;
+
+    // ─────────────────────────────────────────────────────────────
+    // Immutable-ish state (written once in initialize)
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Monotonic job identifier (set by JobFactory at clone-time via initialize).
+    uint256 public jobId;
+
+    /// @notice Address that created and funded this job.
+    address public principal;
+
+    /// @notice The registry through which agents are looked up.
+    AgentRegistry public registry;
+
+    /// @notice Agent registry ID that this job is targeted at (0 = open to any).
+    uint256 public targetAgentId;
+
+    /// @notice ERC-20 token used for payment (address(0) means native ETH — not supported in v1).
+    address public token;
+
+    /// @notice Total budget locked in this contract.
+    uint256 public budget;
+
+    /// @notice UNIX timestamp after which the job may be expired.
+    uint64 public deadline;
+
+    /// @notice Job type (Direct vs Evaluated).
+    JobType public jobType;
+
+    /// @notice Arbiter address authorised to resolve disputes.
+    address public arbiter;
+
+    // ─────────────────────────────────────────────────────────────
+    // Mutable state
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Current phase.
+    Phase public phase;
+
+    /// @notice Address of the accepting agent (set in `accept`).
+    address public agent;
+
+    /// @notice Agent registry ID of the accepting agent.
+    uint256 public agentId;
+
+    /// @notice Evaluator address (optional; only relevant for Evaluated job type).
+    address public evaluator;
+
+    /// @notice URI pointing to the submitted result (set in `submitResult`).
+    string public resultURI;
+
+    /// @notice Timestamp at which the result was submitted (used for grace period).
+    uint64 public resultSubmittedAt;
+
+    /// @notice Grace period after result submission before principal can force-release (Direct jobs).
+    uint64 public constant RELEASE_GRACE = 48 hours;
+
+    /// @notice Grace period for dispute window after result submission.
+    uint64 public constant DISPUTE_GRACE = 72 hours;
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error InvalidDeadline();
+    error WrongPhase(Phase current, Phase required);
+    error NotPrincipal();
+    error NotAgent();
+    error NotEvaluator();
+    error NotArbiter();
+    error AgentNotFound(uint256 id);
+    error AgentInactive(uint256 id);
+    error JobNotExpired();
+    error GracePeriodActive();
+    error AlreadyInitialized();
+    error InvalidJobType();
+    error EvaluatorRequired();
+    error DirectJobNoEvaluator();
+    error TokenMismatch();
+
+    // ─────────────────────────────────────────────────────────────
+    // Modifiers
+    // ─────────────────────────────────────────────────────────────
+
+    modifier onlyPhase(Phase required) {
+        if (phase != required) revert WrongPhase(phase, required);
+        _;
+    }
+
+    modifier onlyPrincipal() {
+        if (msg.sender != principal) revert NotPrincipal();
+        _;
+    }
+
+    modifier onlyAgent() {
+        if (msg.sender != agent) revert NotAgent();
+        _;
+    }
+
+    modifier onlyEvaluator() {
+        if (msg.sender != evaluator) revert NotEvaluator();
+        _;
+    }
+
+    modifier onlyArbiter() {
+        if (msg.sender != arbiter) revert NotArbiter();
+        _;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Initializer (replaces constructor for EIP-1167 clones)
+    // ─────────────────────────────────────────────────────────────
+
+    // ─────────────────────────────────────────────────────────────
+    // Init config struct (avoids stack-too-deep in initializer)
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Packed init parameters passed to `initialize`.
+    struct InitParams {
+        uint256 jobId;
+        address principal;
+        AgentRegistry registry;
+        uint256 targetAgentId;
+        address token;
+        uint256 budget;
+        uint64 deadline;
+        JobType jobType;
+        address evaluator;
+        address arbiter;
+    }
+
+    /// @notice Initialise a newly-cloned Job contract.
+    /// @param p Packed init parameters (see `InitParams`).
+    function initialize(InitParams calldata p) external initializer {
+        if (p.principal == address(0)) revert ZeroAddress();
+        if (address(p.registry) == address(0)) revert ZeroAddress();
+        if (p.token == address(0)) revert ZeroAddress();
+        if (p.budget == 0) revert ZeroAmount();
+        // slither-disable-next-line timestamp
+        if (p.deadline <= block.timestamp) revert InvalidDeadline();
+        if (p.arbiter == address(0)) revert ZeroAddress();
+        if (p.jobType == JobType.Evaluated && p.evaluator == address(0)) revert EvaluatorRequired();
+        if (p.jobType == JobType.Direct && p.evaluator != address(0)) revert DirectJobNoEvaluator();
+
+        jobId = p.jobId;
+        principal = p.principal;
+        registry = p.registry;
+        targetAgentId = p.targetAgentId;
+        token = p.token;
+        budget = p.budget;
+        deadline = p.deadline;
+        jobType = p.jobType;
+        evaluator = p.evaluator;
+        arbiter = p.arbiter;
+
+        // phase defaults to Open (Phase(0))
+
+        emit JobInitialised(p.jobId, p.principal, p.targetAgentId, p.jobType, p.budget, p.token, p.deadline);
+        if (p.evaluator != address(0)) {
+            emit EvaluatorAssigned(p.jobId, p.evaluator);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Phase transitions
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Accept the job. Transitions Open → Active.
+    /// @dev    If targetAgentId != 0, the caller's agentId must match. The caller must
+    ///         control an active agent in the registry.
+    /// @param _agentId Registry ID of the accepting agent.
+    function accept(uint256 _agentId) external onlyPhase(Phase.Open) nonReentrant {
+        AgentRegistry.AgentInfo memory info = registry.getAgent(_agentId);
+        if (info.controller != msg.sender) revert AgentNotFound(_agentId);
+        if (!info.active) revert AgentInactive(_agentId);
+        if (targetAgentId != 0 && targetAgentId != _agentId) revert AgentNotFound(_agentId);
+
+        // Effects
+        phase = Phase.Active;
+        agent = msg.sender;
+        agentId = _agentId;
+
+        emit AgentAccepted(jobId, msg.sender, _agentId);
+    }
+
+    /// @notice Submit a result URI. Transitions Active → Review.
+    /// @param _resultURI IPFS / HTTPS URI of the deliverable.
+    function submitResult(string calldata _resultURI) external onlyPhase(Phase.Active) onlyAgent nonReentrant {
+        // Effects
+        phase = Phase.Review;
+        resultURI = _resultURI;
+        // slither-disable-next-line timestamp
+        resultSubmittedAt = uint64(block.timestamp);
+
+        emit ResultSubmitted(jobId, msg.sender, _resultURI);
+    }
+
+    /// @notice Approve a submitted result. Transitions Review → Completed.
+    /// @dev    For Evaluated jobs only the evaluator may call.
+    ///         For Direct jobs the principal may call, or the principal may call `release`
+    ///         after the grace period.
+    function approveResult() external onlyPhase(Phase.Review) nonReentrant {
+        if (jobType == JobType.Evaluated) {
+            if (msg.sender != evaluator) revert NotEvaluator();
+            emit ResultApproved(jobId, msg.sender);
+        } else {
+            // Direct — principal approves immediately
+            if (msg.sender != principal) revert NotPrincipal();
+        }
+
+        _completeJob();
+    }
+
+    /// @notice Reject a submitted result. Transitions Review → Active (agent may resubmit).
+    /// @dev    Only the evaluator may call (Evaluated jobs). For Direct jobs the principal
+    ///         should raise a dispute instead.
+    /// @param reason Human-readable reason logged to calldata only.
+    function rejectResult(string calldata reason) external onlyPhase(Phase.Review) onlyEvaluator {
+        // Effects
+        phase = Phase.Active;
+        resultURI = "";
+        resultSubmittedAt = 0;
+
+        emit ResultRejected(jobId, msg.sender, reason);
+    }
+
+    /// @notice Release budget to the agent after grace period (Direct jobs) or after
+    ///         evaluator approval window. Transitions Review → Completed.
+    /// @dev    Callable by anyone once the release grace period has elapsed.
+    function release() external onlyPhase(Phase.Review) nonReentrant {
+        // slither-disable-next-line timestamp
+        if (block.timestamp < resultSubmittedAt + RELEASE_GRACE) revert GracePeriodActive();
+        _completeJob();
+    }
+
+    /// @notice Cancel the job. Refunds the principal.
+    ///         Allowed from Open (any time) or Active/Review (principal only, before agent submits final).
+    /// @param reason Human-readable reason.
+    function cancel(string calldata reason) external nonReentrant {
+        if (msg.sender != principal) revert NotPrincipal();
+        Phase current = phase;
+        if (current == Phase.Completed || current == Phase.Cancelled || current == Phase.Disputed) {
+            revert WrongPhase(current, Phase.Open); // terminal / disputed — cannot cancel
+        }
+
+        // Effects before interaction
+        phase = Phase.Cancelled;
+        emit JobCancelled(jobId, msg.sender, reason);
+
+        // Interaction
+        uint256 refund = budget;
+        budget = 0;
+        IERC20(token).safeTransfer(principal, refund);
+    }
+
+    /// @notice Raise a dispute. Transitions Active or Review → Disputed.
+    /// @dev    Principal or agent may raise a dispute.
+    function raiseDispute() external nonReentrant {
+        if (msg.sender != principal && msg.sender != agent) revert NotPrincipal();
+        Phase current = phase;
+        if (current != Phase.Active && current != Phase.Review) {
+            revert WrongPhase(current, Phase.Active);
+        }
+        // Effects
+        phase = Phase.Disputed;
+        emit DisputeRaised(jobId, msg.sender);
+    }
+
+    /// @notice Resolve a dispute. Transitions Disputed → Completed (agent wins) or Cancelled (principal wins).
+    /// @param agentFavoured If true, releases budget to agent; if false, refunds principal.
+    function resolveDispute(bool agentFavoured) external onlyPhase(Phase.Disputed) onlyArbiter nonReentrant {
+        if (agentFavoured) {
+            emit DisputeResolved(jobId, msg.sender, true);
+            _completeJob();
+        } else {
+            phase = Phase.Cancelled;
+            emit DisputeResolved(jobId, msg.sender, false);
+            emit JobCancelled(jobId, msg.sender, "dispute resolved: principal favoured");
+
+            uint256 refund = budget;
+            budget = 0;
+            IERC20(token).safeTransfer(principal, refund);
+        }
+    }
+
+    /// @notice Expire a job that has passed its deadline without being completed.
+    ///         Open → Cancelled (refund principal), Active → Cancelled (refund principal).
+    function expireJob() external nonReentrant {
+        // slither-disable-next-line timestamp
+        if (block.timestamp <= deadline) revert JobNotExpired();
+        Phase current = phase;
+        if (current != Phase.Open && current != Phase.Active) {
+            revert WrongPhase(current, Phase.Open);
+        }
+
+        phase = Phase.Cancelled;
+        emit JobCancelled(jobId, msg.sender, "expired");
+
+        uint256 refund = budget;
+        budget = 0;
+        IERC20(token).safeTransfer(principal, refund);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Return the current phase of this job.
+    /// @return current Current Phase enum value.
+    function currentPhase() external view returns (Phase current) {
+        current = phase;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Internal helpers
+    // ─────────────────────────────────────────────────────────────
+
+    /// @dev Finalise job: set terminal state, emit event, transfer budget to agent.
+    ///      Must be called before external token transfer (CEI).
+    function _completeJob() internal {
+        phase = Phase.Completed;
+        uint256 payout = budget;
+        budget = 0;
+        address recipient = agent;
+
+        emit JobCompleted(jobId, msg.sender, payout);
+
+        // Interaction last
+        IERC20(token).safeTransfer(recipient, payout);
+    }
+}

--- a/contracts/evm/src/acp/JobFactory.sol
+++ b/contracts/evm/src/acp/JobFactory.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Job} from "./Job.sol";
+import {IJob} from "./IJob.sol";
+import {AgentRegistry} from "./AgentRegistry.sol";
+
+/// @title JobFactory
+/// @notice Deploys EIP-1167 minimal-proxy clones of the `Job` implementation and
+///         transfers the budget ERC-20 tokens into each clone before calling `initialize`.
+/// @dev    Access control:
+///           - DEFAULT_ADMIN_ROLE : set implementation address, pause/unpause.
+///           - PAUSER_ROLE        : pause/unpause.
+///         Any address may call `createJob`; the caller becomes the `principal`.
+///
+///         Token flow:
+///           1. Caller approves JobFactory for `budget` of `token`.
+///           2. `createJob` transfers `budget` from caller → new Job clone.
+///           3. Job clone is initialised; budget is locked inside the clone.
+contract JobFactory is AccessControl, Pausable {
+    using SafeERC20 for IERC20;
+    using Clones for address;
+
+    // ─────────────────────────────────────────────────────────────
+    // Roles
+    // ─────────────────────────────────────────────────────────────
+
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    // ─────────────────────────────────────────────────────────────
+    // State
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Current Job implementation address used for EIP-1167 cloning.
+    address public jobImplementation;
+
+    /// @notice AgentRegistry used to validate agent IDs at job creation time.
+    AgentRegistry public immutable registry;
+
+    /// @notice Default arbiter for dispute resolution (configurable by admin).
+    address public defaultArbiter;
+
+    /// @notice Monotonic counter; every clone gets a unique jobId.
+    uint256 private _nextJobId;
+
+    /// @notice jobId => clone address.
+    mapping(uint256 => address) public jobs;
+
+    /// @notice principal => list of jobIds created by that principal.
+    mapping(address => uint256[]) private _principalJobs;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a new Job clone is deployed and funded.
+    event JobCreated(
+        uint256 indexed jobId,
+        address indexed clone,
+        address indexed principal,
+        IJob.JobType jobType,
+        address token,
+        uint256 budget
+    );
+
+    /// @notice Emitted when the job implementation is updated.
+    event ImplementationUpdated(address indexed oldImpl, address indexed newImpl);
+
+    /// @notice Emitted when the default arbiter is updated.
+    event DefaultArbiterUpdated(address indexed oldArbiter, address indexed newArbiter);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error InvalidDeadline();
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    /// @param admin           Address granted DEFAULT_ADMIN_ROLE.
+    /// @param _jobImpl        Initial Job implementation for cloning.
+    /// @param _registry       AgentRegistry reference.
+    /// @param _defaultArbiter Default arbiter for all created jobs.
+    constructor(address admin, address _jobImpl, AgentRegistry _registry, address _defaultArbiter) {
+        if (admin == address(0)) revert ZeroAddress();
+        if (_jobImpl == address(0)) revert ZeroAddress();
+        if (address(_registry) == address(0)) revert ZeroAddress();
+        if (_defaultArbiter == address(0)) revert ZeroAddress();
+
+        jobImplementation = _jobImpl;
+        registry = _registry;
+        defaultArbiter = _defaultArbiter;
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(PAUSER_ROLE, admin);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Job creation
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Create a new Job clone, transfer the budget into it, and initialise it.
+    /// @dev    Caller must have pre-approved this contract for `budget` of `token`.
+    /// @param  targetAgentId Agent registry ID to target (0 = open to any active agent).
+    /// @param  token         ERC-20 token address for payment.
+    /// @param  budget        Amount to lock into the escrow.
+    /// @param  deadline      UNIX timestamp after which the job may be expired.
+    /// @param  jobType       Direct (no evaluator) or Evaluated.
+    /// @param  evaluator     Evaluator address; must be non-zero iff jobType == Evaluated.
+    /// @param  arbiter       Arbiter override; if address(0), uses defaultArbiter.
+    /// @return jobId         The monotonic ID assigned to this job.
+    /// @return clone         The address of the deployed Job clone.
+    function createJob(
+        uint256 targetAgentId,
+        address token,
+        uint256 budget,
+        uint64 deadline,
+        IJob.JobType jobType,
+        address evaluator,
+        address arbiter
+    ) external whenNotPaused returns (uint256 jobId, address clone) {
+        if (token == address(0)) revert ZeroAddress();
+        if (budget == 0) revert ZeroAmount();
+        // slither-disable-next-line timestamp
+        if (deadline <= block.timestamp) revert InvalidDeadline();
+
+        address resolvedArbiter = arbiter == address(0) ? defaultArbiter : arbiter;
+
+        jobId = _nextJobId++;
+        clone = jobImplementation.clone();
+
+        jobs[jobId] = clone;
+        _principalJobs[msg.sender].push(jobId);
+
+        // Emit before external calls (satisfies CEI for event ordering)
+        emit JobCreated(jobId, clone, msg.sender, jobType, token, budget);
+
+        // Transfer budget from principal → clone before initialise
+        IERC20(token).safeTransferFrom(msg.sender, clone, budget);
+
+        // Initialise the clone
+        Job.InitParams memory p = Job.InitParams({
+            jobId: jobId,
+            principal: msg.sender,
+            registry: registry,
+            targetAgentId: targetAgentId,
+            token: token,
+            budget: budget,
+            deadline: deadline,
+            jobType: jobType,
+            evaluator: evaluator,
+            arbiter: resolvedArbiter
+        });
+        Job(clone).initialize(p);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Admin
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Update the Job implementation used for future clones.
+    /// @param  newImpl New implementation address (must be non-zero).
+    function setJobImplementation(address newImpl) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newImpl == address(0)) revert ZeroAddress();
+        address old = jobImplementation;
+        jobImplementation = newImpl;
+        emit ImplementationUpdated(old, newImpl);
+    }
+
+    /// @notice Update the default arbiter.
+    /// @param  newArbiter New default arbiter (must be non-zero).
+    function setDefaultArbiter(address newArbiter) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newArbiter == address(0)) revert ZeroAddress();
+        address old = defaultArbiter;
+        defaultArbiter = newArbiter;
+        emit DefaultArbiterUpdated(old, newArbiter);
+    }
+
+    /// @notice Pause job creation.
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /// @notice Unpause job creation.
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Return the clone address for a given jobId.
+    /// @param  jobId The job ID to look up.
+    /// @return clone Address of the Job clone, or address(0) if not found.
+    function getJob(uint256 jobId) external view returns (address clone) {
+        clone = jobs[jobId];
+    }
+
+    /// @notice Return all jobIds created by a given principal.
+    /// @param  principal The principal address.
+    /// @return jobIds    Array of job IDs created by this principal.
+    function jobsByPrincipal(address principal) external view returns (uint256[] memory jobIds) {
+        jobIds = _principalJobs[principal];
+    }
+
+    /// @notice Total number of jobs ever created.
+    /// @return count Total job count.
+    function totalJobs() external view returns (uint256 count) {
+        count = _nextJobId;
+    }
+}

--- a/contracts/evm/test/acp/JobFactory.t.sol
+++ b/contracts/evm/test/acp/JobFactory.t.sol
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {JobFactory} from "../../src/acp/JobFactory.sol";
+import {Job} from "../../src/acp/Job.sol";
+import {IJob} from "../../src/acp/IJob.sol";
+import {AgentRegistry} from "../../src/acp/AgentRegistry.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock", "MCK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract JobFactoryTest is Test {
+    AgentRegistry internal registry;
+    MockERC20 internal token;
+    Job internal jobImpl;
+    JobFactory internal factory;
+
+    address internal admin = makeAddr("admin");
+    address internal arbiter = makeAddr("arbiter");
+    address internal principal = makeAddr("principal");
+    address internal agentCtrl = makeAddr("agentCtrl");
+    address internal evaluator = makeAddr("evaluator");
+    address internal stranger = makeAddr("stranger");
+
+    uint256 internal agentId0;
+
+    uint256 internal constant BUDGET = 1000e18;
+    uint64 internal constant DEADLINE_DELTA = 7 days;
+
+    event JobCreated(
+        uint256 indexed jobId,
+        address indexed clone,
+        address indexed principal,
+        IJob.JobType jobType,
+        address token,
+        uint256 budget
+    );
+
+    event ImplementationUpdated(address indexed oldImpl, address indexed newImpl);
+    event DefaultArbiterUpdated(address indexed oldArbiter, address indexed newArbiter);
+
+    function setUp() public {
+        // Deploy registry + agent
+        registry = new AgentRegistry(admin);
+        vm.prank(agentCtrl);
+        agentId0 = registry.register(agentCtrl, "ipfs://QmAgent", 0x1);
+
+        token = new MockERC20();
+        jobImpl = new Job();
+        factory = new JobFactory(admin, address(jobImpl), registry, arbiter);
+
+        // Mint + approve tokens for principal
+        token.mint(principal, BUDGET * 10);
+        vm.prank(principal);
+        token.approve(address(factory), type(uint256).max);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    function test_constructor_setsState() public view {
+        assertEq(factory.jobImplementation(), address(jobImpl));
+        assertEq(address(factory.registry()), address(registry));
+        assertEq(factory.defaultArbiter(), arbiter);
+    }
+
+    function test_constructor_revert_zeroAdmin() public {
+        vm.expectRevert(JobFactory.ZeroAddress.selector);
+        new JobFactory(address(0), address(jobImpl), registry, arbiter);
+    }
+
+    function test_constructor_revert_zeroImpl() public {
+        vm.expectRevert(JobFactory.ZeroAddress.selector);
+        new JobFactory(admin, address(0), registry, arbiter);
+    }
+
+    function test_constructor_revert_zeroArbiter() public {
+        vm.expectRevert(JobFactory.ZeroAddress.selector);
+        new JobFactory(admin, address(jobImpl), registry, address(0));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // createJob — happy paths
+    // ─────────────────────────────────────────────────────────────
+
+    function test_createJob_direct() public {
+        vm.expectEmit(false, false, true, true);
+        emit JobCreated(0, address(0), principal, IJob.JobType.Direct, address(token), BUDGET);
+
+        vm.prank(principal);
+        (uint256 jobId, address clone) = factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+
+        assertEq(jobId, 0);
+        assertNotEq(clone, address(0));
+        assertEq(factory.getJob(jobId), clone);
+        assertEq(factory.totalJobs(), 1);
+        assertEq(token.balanceOf(clone), BUDGET);
+
+        Job j = Job(clone);
+        assertEq(j.principal(), principal);
+        assertEq(uint8(j.phase()), uint8(IJob.Phase.Open));
+        assertEq(uint8(j.jobType()), uint8(IJob.JobType.Direct));
+        assertEq(j.budget(), BUDGET);
+    }
+
+    function test_createJob_evaluated() public {
+        vm.prank(principal);
+        (uint256 jobId, address clone) = factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Evaluated, evaluator, address(0)
+        );
+        Job j = Job(clone);
+        assertEq(j.evaluator(), evaluator);
+        assertEq(uint8(j.jobType()), uint8(IJob.JobType.Evaluated));
+        assertEq(jobId, 0);
+    }
+
+    function test_createJob_usesDefaultArbiter() public {
+        vm.prank(principal);
+        (, address clone) = factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+        assertEq(Job(clone).arbiter(), arbiter);
+    }
+
+    function test_createJob_customArbiter() public {
+        address customArbiter = makeAddr("customArbiter");
+        vm.prank(principal);
+        (, address clone) = factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), customArbiter
+        );
+        assertEq(Job(clone).arbiter(), customArbiter);
+    }
+
+    function test_createJob_multipleJobs_uniqueIds() public {
+        vm.prank(principal);
+        (uint256 id0,) = factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+        vm.prank(principal);
+        (uint256 id1,) = factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+        assertEq(id0, 0);
+        assertEq(id1, 1);
+        assertEq(factory.totalJobs(), 2);
+        assertNotEq(factory.getJob(0), factory.getJob(1));
+    }
+
+    function test_createJob_tracked_byPrincipal() public {
+        vm.prank(principal);
+        factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+        uint256[] memory ids = factory.jobsByPrincipal(principal);
+        assertEq(ids.length, 1);
+        assertEq(ids[0], 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // createJob — revert paths
+    // ─────────────────────────────────────────────────────────────
+
+    function test_createJob_revert_zeroToken() public {
+        vm.expectRevert(JobFactory.ZeroAddress.selector);
+        vm.prank(principal);
+        factory.createJob(
+            0, address(0), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+    }
+
+    function test_createJob_revert_zeroBudget() public {
+        vm.expectRevert(JobFactory.ZeroAmount.selector);
+        vm.prank(principal);
+        factory.createJob(
+            0, address(token), 0, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+    }
+
+    function test_createJob_revert_pastDeadline() public {
+        vm.expectRevert(JobFactory.InvalidDeadline.selector);
+        vm.prank(principal);
+        factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp - 1),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+    }
+
+    function test_createJob_revert_paused() public {
+        vm.prank(admin);
+        factory.pause();
+        vm.expectRevert();
+        vm.prank(principal);
+        factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Clone isolation
+    // ─────────────────────────────────────────────────────────────
+
+    function test_cloneIsolation_differentAddresses() public {
+        vm.prank(principal);
+        (, address clone0) = factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+        vm.prank(principal);
+        (, address clone1) = factory.createJob(
+            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+        assertNotEq(clone0, clone1);
+        // State is isolated
+        assertEq(Job(clone0).jobId(), 0);
+        assertEq(Job(clone1).jobId(), 1);
+    }
+
+    function test_implementation_notInitialized() public view {
+        // The implementation contract itself should be uninitialised (version = 0 / default state)
+        assertEq(Job(address(jobImpl)).budget(), 0);
+        assertEq(Job(address(jobImpl)).principal(), address(0));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Admin functions
+    // ─────────────────────────────────────────────────────────────
+
+    function test_setJobImplementation() public {
+        Job newImpl = new Job();
+        vm.expectEmit(true, true, false, false);
+        emit ImplementationUpdated(address(jobImpl), address(newImpl));
+        vm.prank(admin);
+        factory.setJobImplementation(address(newImpl));
+        assertEq(factory.jobImplementation(), address(newImpl));
+    }
+
+    function test_setJobImplementation_revert_zero() public {
+        vm.expectRevert(JobFactory.ZeroAddress.selector);
+        vm.prank(admin);
+        factory.setJobImplementation(address(0));
+    }
+
+    function test_setJobImplementation_revert_notAdmin() public {
+        vm.expectRevert();
+        vm.prank(stranger);
+        factory.setJobImplementation(address(jobImpl));
+    }
+
+    function test_setDefaultArbiter() public {
+        address newArbiter = makeAddr("newArbiter");
+        vm.expectEmit(true, true, false, false);
+        emit DefaultArbiterUpdated(arbiter, newArbiter);
+        vm.prank(admin);
+        factory.setDefaultArbiter(newArbiter);
+        assertEq(factory.defaultArbiter(), newArbiter);
+    }
+
+    function test_setDefaultArbiter_revert_zero() public {
+        vm.expectRevert(JobFactory.ZeroAddress.selector);
+        vm.prank(admin);
+        factory.setDefaultArbiter(address(0));
+    }
+
+    function test_pause_unpause() public {
+        vm.prank(admin);
+        factory.pause();
+        assertTrue(factory.paused());
+        vm.prank(admin);
+        factory.unpause();
+        assertFalse(factory.paused());
+    }
+
+    function test_pause_revert_notPauser() public {
+        vm.expectRevert();
+        vm.prank(stranger);
+        factory.pause();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // End-to-end: create → accept → complete
+    // ─────────────────────────────────────────────────────────────
+
+    function test_e2e_createAndComplete() public {
+        vm.prank(principal);
+        (, address clone) = factory.createJob(
+            agentId0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+
+        Job j = Job(clone);
+        vm.prank(agentCtrl);
+        j.accept(agentId0);
+        vm.prank(agentCtrl);
+        j.submitResult("ipfs://QmResult");
+        vm.prank(principal);
+        j.approveResult();
+
+        assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
+        assertEq(token.balanceOf(agentCtrl), BUDGET);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Fuzz
+    // ─────────────────────────────────────────────────────────────
+
+    function testFuzz_createJob_amounts(uint256 budgetAmount) public {
+        budgetAmount = bound(budgetAmount, 1, type(uint128).max);
+        token.mint(principal, budgetAmount);
+        vm.prank(principal);
+        token.approve(address(factory), type(uint256).max);
+
+        vm.prank(principal);
+        (, address clone) = factory.createJob(
+            0, address(token), budgetAmount, uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct, address(0), address(0)
+        );
+        assertEq(token.balanceOf(clone), budgetAmount);
+        assertEq(Job(clone).budget(), budgetAmount);
+    }
+}

--- a/contracts/evm/test/acp/JobFactory.t.sol
+++ b/contracts/evm/test/acp/JobFactory.t.sol
@@ -97,8 +97,13 @@ contract JobFactoryTest is Test {
 
         vm.prank(principal);
         (uint256 jobId, address clone) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
 
         assertEq(jobId, 0);
@@ -117,8 +122,13 @@ contract JobFactoryTest is Test {
     function test_createJob_evaluated() public {
         vm.prank(principal);
         (uint256 jobId, address clone) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Evaluated, evaluator, address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Evaluated,
+            evaluator,
+            address(0)
         );
         Job j = Job(clone);
         assertEq(j.evaluator(), evaluator);
@@ -129,8 +139,13 @@ contract JobFactoryTest is Test {
     function test_createJob_usesDefaultArbiter() public {
         vm.prank(principal);
         (, address clone) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
         assertEq(Job(clone).arbiter(), arbiter);
     }
@@ -139,8 +154,13 @@ contract JobFactoryTest is Test {
         address customArbiter = makeAddr("customArbiter");
         vm.prank(principal);
         (, address clone) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), customArbiter
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            customArbiter
         );
         assertEq(Job(clone).arbiter(), customArbiter);
     }
@@ -148,13 +168,23 @@ contract JobFactoryTest is Test {
     function test_createJob_multipleJobs_uniqueIds() public {
         vm.prank(principal);
         (uint256 id0,) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
         vm.prank(principal);
         (uint256 id1,) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
         assertEq(id0, 0);
         assertEq(id1, 1);
@@ -165,8 +195,13 @@ contract JobFactoryTest is Test {
     function test_createJob_tracked_byPrincipal() public {
         vm.prank(principal);
         factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
         uint256[] memory ids = factory.jobsByPrincipal(principal);
         assertEq(ids.length, 1);
@@ -181,8 +216,7 @@ contract JobFactoryTest is Test {
         vm.expectRevert(JobFactory.ZeroAddress.selector);
         vm.prank(principal);
         factory.createJob(
-            0, address(0), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0, address(0), BUDGET, uint64(block.timestamp + DEADLINE_DELTA), IJob.JobType.Direct, address(0), address(0)
         );
     }
 
@@ -190,8 +224,7 @@ contract JobFactoryTest is Test {
         vm.expectRevert(JobFactory.ZeroAmount.selector);
         vm.prank(principal);
         factory.createJob(
-            0, address(token), 0, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0, address(token), 0, uint64(block.timestamp + DEADLINE_DELTA), IJob.JobType.Direct, address(0), address(0)
         );
     }
 
@@ -199,8 +232,7 @@ contract JobFactoryTest is Test {
         vm.expectRevert(JobFactory.InvalidDeadline.selector);
         vm.prank(principal);
         factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp - 1),
-            IJob.JobType.Direct, address(0), address(0)
+            0, address(token), BUDGET, uint64(block.timestamp - 1), IJob.JobType.Direct, address(0), address(0)
         );
     }
 
@@ -210,8 +242,13 @@ contract JobFactoryTest is Test {
         vm.expectRevert();
         vm.prank(principal);
         factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
     }
 
@@ -222,13 +259,23 @@ contract JobFactoryTest is Test {
     function test_cloneIsolation_differentAddresses() public {
         vm.prank(principal);
         (, address clone0) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
         vm.prank(principal);
         (, address clone1) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
         assertNotEq(clone0, clone1);
         // State is isolated
@@ -304,8 +351,13 @@ contract JobFactoryTest is Test {
     function test_e2e_createAndComplete() public {
         vm.prank(principal);
         (, address clone) = factory.createJob(
-            agentId0, address(token), BUDGET, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            agentId0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
 
         Job j = Job(clone);
@@ -332,8 +384,13 @@ contract JobFactoryTest is Test {
 
         vm.prank(principal);
         (, address clone) = factory.createJob(
-            0, address(token), budgetAmount, uint64(block.timestamp + DEADLINE_DELTA),
-            IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            budgetAmount,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0)
         );
         assertEq(token.balanceOf(clone), budgetAmount);
         assertEq(Job(clone).budget(), budgetAmount);


### PR DESCRIPTION
Phase \`job-factory\` of \`M3 — acp v2 contracts e2e on base sepolia\`.

closes #54

Verification: \`.claude/cron/last-verify-M3-job-factory.log\`

## Changes
- `contracts/evm/src/acp/JobFactory.sol` — EIP-1167 minimal-proxy factory:
  - Clones Job implementation, transfers budget ERC-20 into clone, then initialises
  - Event emitted before external calls (CEI compliant)
  - Admin: setJobImplementation, setDefaultArbiter, pause/unpause
  - registry is immutable
- `contracts/evm/test/acp/JobFactory.t.sol` — 25 tests including e2e create→complete

## Verify
- forge build: green
- forge test (25/25 pass)
- slither: 0 findings