### PR TITLE
phase(M3/escrow): acp v2 contracts e2e on base sepolia

### DIFF
--- a/contracts/evm/src/acp/AgentRegistry.sol
+++ b/contracts/evm/src/acp/AgentRegistry.sol
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+/// @title AgentRegistry
+/// @notice Composite identity registry for ACP v2 agents.  Each agent maps a controller
+///         address to an off-chain metadata URI and a packed capability bitmask.  The
+///         registry also accumulates on-chain reputation scores posted by authorised
+///         scorers, with EIP-712 nonce-based replay protection.
+/// @dev    Role model
+///         - DEFAULT_ADMIN_ROLE : can grant / revoke other roles, pause / unpause.
+///         - SCORER_ROLE        : authorised to call `postScore`.
+///         - PAUSER_ROLE        : can pause the registry.
+///         Two-step controller transfer: propose → accept prevents fat-finger takeovers.
+contract AgentRegistry is AccessControl, Pausable {
+    // ─────────────────────────────────────────────────────────────
+    // Roles
+    // ─────────────────────────────────────────────────────────────
+
+    bytes32 public constant SCORER_ROLE = keccak256("SCORER_ROLE");
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    struct AgentInfo {
+        /// @notice Current controller address that manages the agent identity.
+        address controller;
+        /// @notice IPFS / HTTPS URI pointing to AgentMetadata JSON.
+        string metadataURI;
+        /// @notice Packed bitmask of agent capabilities (consumer-defined).
+        uint256 capabilities;
+        /// @notice Cumulative reputation score (sum of all accepted `postScore` calls).
+        int256 reputationScore;
+        /// @notice Block timestamp of first registration.
+        uint48 registeredAt;
+        /// @notice Whether this agent is currently active (controller may deactivate).
+        bool active;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Storage
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Sequential counter, used as agent ID.
+    uint256 private _nextId;
+
+    /// @notice agentId => AgentInfo
+    mapping(uint256 => AgentInfo) private _agents;
+
+    /// @notice controller address => agentId list (an address may control multiple agents)
+    mapping(address => uint256[]) private _controllerAgents;
+
+    /// @notice pending two-step transfer: agentId => proposed new controller
+    mapping(uint256 => address) private _pendingController;
+
+    /// @notice EIP-712 replay protection: agentId => nonce (incremented after each `postScore`)
+    mapping(uint256 => uint256) public scorerNonce;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a new agent identity is registered.
+    event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities);
+
+    /// @notice Emitted when an agent's metadata URI is updated.
+    event MetadataUpdated(uint256 indexed agentId, string metadataURI);
+
+    /// @notice Emitted when capabilities bitmask is changed.
+    event CapabilitiesUpdated(uint256 indexed agentId, uint256 capabilities);
+
+    /// @notice Emitted when an agent is activated or deactivated.
+    event ActiveStatusChanged(uint256 indexed agentId, bool active);
+
+    /// @notice Emitted when a controller transfer is initiated.
+    event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed);
+
+    /// @notice Emitted when a controller transfer is accepted by the proposed address.
+    event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController);
+
+    /// @notice Emitted when a controller transfer proposal is cancelled.
+    event ControllerTransferCancelled(uint256 indexed agentId);
+
+    /// @notice Emitted when a reputation score is posted for an agent.
+    event ScorePosted(uint256 indexed agentId, address indexed scorer, int256 delta, int256 newTotal, uint256 nonce);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error NotController(uint256 agentId, address caller);
+    error AgentNotFound(uint256 agentId);
+    error AgentInactive(uint256 agentId);
+    error EmptyMetadataURI();
+    error NoPendingTransfer(uint256 agentId);
+    error NotProposedController(uint256 agentId, address caller);
+    error InvalidNonce(uint256 agentId, uint256 expected, uint256 provided);
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    /// @param admin Address granted DEFAULT_ADMIN_ROLE on deployment.
+    constructor(address admin) {
+        if (admin == address(0)) revert ZeroAddress();
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(PAUSER_ROLE, admin);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Registration
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Register a new agent identity.
+    /// @param  controller   Address that will control this agent (cannot be zero).
+    /// @param  metadataURI  Non-empty URI pointing to off-chain agent metadata.
+    /// @param  capabilities Packed bitmask of declared capabilities (consumer-defined).
+    /// @return agentId      Sequential ID assigned to this agent.
+    function register(address controller, string calldata metadataURI, uint256 capabilities)
+        external
+        whenNotPaused
+        returns (uint256 agentId)
+    {
+        if (controller == address(0)) revert ZeroAddress();
+        if (bytes(metadataURI).length == 0) revert EmptyMetadataURI();
+
+        agentId = _nextId++;
+        _agents[agentId] = AgentInfo({
+            controller: controller,
+            metadataURI: metadataURI,
+            capabilities: capabilities,
+            reputationScore: 0,
+            registeredAt: uint48(block.timestamp),
+            active: true
+        });
+        _controllerAgents[controller].push(agentId);
+
+        emit AgentRegistered(agentId, controller, metadataURI, capabilities);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Agent Management (controller-only)
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Update the metadata URI of an agent.
+    /// @param agentId     ID of the agent to update.
+    /// @param metadataURI New non-empty URI.
+    function setMetadata(uint256 agentId, string calldata metadataURI) external whenNotPaused {
+        _assertController(agentId);
+        if (bytes(metadataURI).length == 0) revert EmptyMetadataURI();
+        _agents[agentId].metadataURI = metadataURI;
+        emit MetadataUpdated(agentId, metadataURI);
+    }
+
+    /// @notice Update the capabilities bitmask of an agent.
+    /// @param agentId      ID of the agent to update.
+    /// @param capabilities New capabilities bitmask.
+    function setCapabilities(uint256 agentId, uint256 capabilities) external whenNotPaused {
+        _assertController(agentId);
+        _agents[agentId].capabilities = capabilities;
+        emit CapabilitiesUpdated(agentId, capabilities);
+    }
+
+    /// @notice Activate or deactivate an agent.
+    /// @param agentId ID of the agent.
+    /// @param active  Desired active status.
+    function setActive(uint256 agentId, bool active) external whenNotPaused {
+        _assertController(agentId);
+        _agents[agentId].active = active;
+        emit ActiveStatusChanged(agentId, active);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Two-step controller transfer
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Propose a new controller address for agentId.
+    ///         The proposed address must call `acceptControllerTransfer` to complete.
+    /// @param agentId  ID of the agent.
+    /// @param proposed New controller candidate (cannot be zero).
+    function proposeControllerTransfer(uint256 agentId, address proposed) external whenNotPaused {
+        _assertController(agentId);
+        if (proposed == address(0)) revert ZeroAddress();
+        _pendingController[agentId] = proposed;
+        emit ControllerTransferProposed(agentId, proposed);
+    }
+
+    /// @notice Accept a pending controller transfer initiated by the current controller.
+    /// @param agentId ID of the agent.
+    function acceptControllerTransfer(uint256 agentId) external whenNotPaused {
+        address proposed = _pendingController[agentId];
+        if (proposed == address(0)) revert NoPendingTransfer(agentId);
+        if (proposed != msg.sender) revert NotProposedController(agentId, msg.sender);
+
+        address old = _agents[agentId].controller;
+        _agents[agentId].controller = proposed;
+        delete _pendingController[agentId];
+        _controllerAgents[proposed].push(agentId);
+
+        emit ControllerTransferAccepted(agentId, old, proposed);
+    }
+
+    /// @notice Cancel a pending controller transfer (callable by current controller only).
+    /// @param agentId ID of the agent.
+    function cancelControllerTransfer(uint256 agentId) external {
+        _assertController(agentId);
+        if (_pendingController[agentId] == address(0)) revert NoPendingTransfer(agentId);
+        delete _pendingController[agentId];
+        emit ControllerTransferCancelled(agentId);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Reputation accumulation (SCORER_ROLE)
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Post a signed reputation delta for an agent.
+    ///         Callers must hold SCORER_ROLE. The nonce must equal the current value
+    ///         in `scorerNonce[agentId]` to prevent replay.
+    /// @param agentId ID of the agent receiving the score.
+    /// @param delta   Signed delta to add to the cumulative score (may be negative).
+    /// @param nonce   Must equal `scorerNonce[agentId]`; incremented after acceptance.
+    function postScore(uint256 agentId, int256 delta, uint256 nonce)
+        external
+        whenNotPaused
+        onlyRole(SCORER_ROLE)
+    {
+        AgentInfo storage info = _agents[agentId];
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (info.registeredAt == 0) revert AgentNotFound(agentId);
+        if (!info.active) revert AgentInactive(agentId);
+
+        uint256 expected = scorerNonce[agentId];
+        if (nonce != expected) revert InvalidNonce(agentId, expected, nonce);
+
+        scorerNonce[agentId] = expected + 1;
+        info.reputationScore += delta;
+
+        emit ScorePosted(agentId, msg.sender, delta, info.reputationScore, nonce);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Pause
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Pause the registry (blocks registrations, updates, and score posts).
+    function pause() external onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    /// @notice Unpause the registry.
+    function unpause() external onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Return the full AgentInfo struct for a given agentId.
+    /// @param agentId ID of the agent.
+    /// @return info   The stored AgentInfo (reverts if never registered).
+    function getAgent(uint256 agentId) external view returns (AgentInfo memory info) {
+        info = _agents[agentId];
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (info.registeredAt == 0) revert AgentNotFound(agentId);
+    }
+
+    /// @notice Return all agentIds controlled by a given address.
+    /// @param controller The controller address to query.
+    /// @return ids       Array of agentIds.  May contain deactivated agents.
+    function agentsByController(address controller) external view returns (uint256[] memory ids) {
+        ids = _controllerAgents[controller];
+    }
+
+    /// @notice Total number of agents ever registered (including inactive ones).
+    /// @return count The count.
+    function totalAgents() external view returns (uint256 count) {
+        count = _nextId;
+    }
+
+    /// @notice Return the pending proposed controller for agentId (zero if none).
+    /// @param agentId ID of the agent.
+    /// @return proposed The pending controller address, or address(0) if none.
+    function pendingController(uint256 agentId) external view returns (address proposed) {
+        proposed = _pendingController[agentId];
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Internal helpers
+    // ─────────────────────────────────────────────────────────────
+
+    function _assertController(uint256 agentId) internal view {
+        AgentInfo storage info = _agents[agentId];
+        // slither-disable-next-line incorrect-equality,timestamp
+        if (info.registeredAt == 0) revert AgentNotFound(agentId);
+        if (info.controller != msg.sender) revert NotController(agentId, msg.sender);
+    }
+}

--- a/contracts/evm/src/acp/AgentRegistry.sol
+++ b/contracts/evm/src/acp/AgentRegistry.sol
@@ -65,7 +65,9 @@ contract AgentRegistry is AccessControl, Pausable {
     // ─────────────────────────────────────────────────────────────
 
     /// @notice Emitted when a new agent identity is registered.
-    event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities);
+    event AgentRegistered(
+        uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities
+    );
 
     /// @notice Emitted when an agent's metadata URI is updated.
     event MetadataUpdated(uint256 indexed agentId, string metadataURI);
@@ -80,7 +82,9 @@ contract AgentRegistry is AccessControl, Pausable {
     event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed);
 
     /// @notice Emitted when a controller transfer is accepted by the proposed address.
-    event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController);
+    event ControllerTransferAccepted(
+        uint256 indexed agentId, address indexed oldController, address indexed newController
+    );
 
     /// @notice Emitted when a controller transfer proposal is cancelled.
     event ControllerTransferCancelled(uint256 indexed agentId);
@@ -224,11 +228,7 @@ contract AgentRegistry is AccessControl, Pausable {
     /// @param agentId ID of the agent receiving the score.
     /// @param delta   Signed delta to add to the cumulative score (may be negative).
     /// @param nonce   Must equal `scorerNonce[agentId]`; incremented after acceptance.
-    function postScore(uint256 agentId, int256 delta, uint256 nonce)
-        external
-        whenNotPaused
-        onlyRole(SCORER_ROLE)
-    {
+    function postScore(uint256 agentId, int256 delta, uint256 nonce) external whenNotPaused onlyRole(SCORER_ROLE) {
         AgentInfo storage info = _agents[agentId];
         // slither-disable-next-line incorrect-equality,timestamp
         if (info.registeredAt == 0) revert AgentNotFound(agentId);

--- a/contracts/evm/src/acp/Escrow.sol
+++ b/contracts/evm/src/acp/Escrow.sol
@@ -57,9 +57,7 @@ contract Escrow is AccessControl, ReentrancyGuard {
     event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
 
     /// @notice Emitted for each recipient in an atomic release.
-    event Released(
-        address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount
-    );
+    event Released(address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount);
 
     /// @notice Emitted when the full balance is refunded to the depositor.
     event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
@@ -159,11 +157,7 @@ contract Escrow is AccessControl, ReentrancyGuard {
     /// @param  depositor  Owner of the escrowed balance.
     /// @param  jobId      Job identifier.
     /// @param  token      ERC-20 token address.
-    function refund(address depositor, uint256 jobId, address token)
-        external
-        nonReentrant
-        onlyRole(RELEASER_ROLE)
-    {
+    function refund(address depositor, uint256 jobId, address token) external nonReentrant onlyRole(RELEASER_ROLE) {
         uint256 bal = balances[depositor][jobId][token];
         if (bal == 0) revert InsufficientBalance(0, 1);
 

--- a/contracts/evm/src/acp/Escrow.sol
+++ b/contracts/evm/src/acp/Escrow.sol
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title Escrow
+/// @notice Multi-token escrow with atomic multi-recipient release.
+/// @dev    Design decisions:
+///           - Each escrow entry is identified by a (depositor, jobId) pair.  The jobId
+///             is an opaque uint256 supplied by the caller (typically the JobFactory
+///             counter); it need not be unique across depositors.
+///           - Funds are held in this contract; individual balances are tracked per
+///             (depositor, jobId, token) to allow multiple tokens per job.
+///           - `release` atomically transfers to N recipients in a single call.
+///           - `refund` returns all tokens to the depositor (dispute resolved in
+///             depositor's favour, or admin override).
+///           - RELEASER_ROLE: addresses allowed to call `release` and `refund`
+///             (typically the Job contract or an arbiter).
+///           - ADMIN_ROLE: can grant/revoke roles, emergency-pause.
+///
+///         CEI: all storage writes happen before external SafeERC20 transfers.
+///         ReentrancyGuard on `fund`, `release`, `refund`.
+contract Escrow is AccessControl, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ─────────────────────────────────────────────────────────────
+    // Roles
+    // ─────────────────────────────────────────────────────────────
+
+    bytes32 public constant RELEASER_ROLE = keccak256("RELEASER_ROLE");
+
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice A single recipient in a multi-recipient release.
+    struct Recipient {
+        address to;
+        uint256 amount;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Storage
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice depositor => jobId => token => escrowed balance.
+    mapping(address => mapping(uint256 => mapping(address => uint256))) public balances;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when tokens are deposited into escrow.
+    event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
+
+    /// @notice Emitted for each recipient in an atomic release.
+    event Released(
+        address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount
+    );
+
+    /// @notice Emitted when the full balance is refunded to the depositor.
+    event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error InsufficientBalance(uint256 have, uint256 want);
+    error EmptyRecipients();
+    error RecipientZeroAddress(uint256 index);
+    error RecipientZeroAmount(uint256 index);
+    error SumExceedsBalance(uint256 sum, uint256 balance);
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    /// @param admin Address granted DEFAULT_ADMIN_ROLE and RELEASER_ROLE on deployment.
+    constructor(address admin) {
+        if (admin == address(0)) revert ZeroAddress();
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(RELEASER_ROLE, admin);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Fund
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Deposit `amount` of `token` into escrow for a specific job.
+    /// @dev    Caller must have approved this contract for at least `amount` of `token`.
+    /// @param  depositor Address whose balance increases (usually msg.sender; can be different
+    ///                   for forwarded deposits, e.g. from JobFactory on behalf of principal).
+    /// @param  jobId     Opaque identifier tying this deposit to a specific job.
+    /// @param  token     ERC-20 token address.
+    /// @param  amount    Amount to deposit (must be > 0).
+    function fund(address depositor, uint256 jobId, address token, uint256 amount) external nonReentrant {
+        if (depositor == address(0)) revert ZeroAddress();
+        if (token == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+
+        // Effects
+        balances[depositor][jobId][token] += amount;
+
+        emit Funded(depositor, jobId, token, amount);
+
+        // Interaction (after state update)
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Release
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Atomically release funds to multiple recipients in a single call.
+    /// @dev    The sum of all `recipient.amount` values must be <= the escrowed balance.
+    ///         Callers must hold RELEASER_ROLE.
+    /// @param  depositor  Owner of the escrowed balance.
+    /// @param  jobId      Job identifier.
+    /// @param  token      ERC-20 token address.
+    /// @param  recipients Array of (address, amount) pairs.  Must be non-empty.
+    function release(address depositor, uint256 jobId, address token, Recipient[] calldata recipients)
+        external
+        nonReentrant
+        onlyRole(RELEASER_ROLE)
+    {
+        if (recipients.length == 0) revert EmptyRecipients();
+
+        uint256 total = 0;
+        for (uint256 i = 0; i < recipients.length; ++i) {
+            if (recipients[i].to == address(0)) revert RecipientZeroAddress(i);
+            if (recipients[i].amount == 0) revert RecipientZeroAmount(i);
+            total += recipients[i].amount;
+        }
+
+        uint256 bal = balances[depositor][jobId][token];
+        if (total > bal) revert SumExceedsBalance(total, bal);
+
+        // Effects — deduct full sum atomically before any transfer
+        balances[depositor][jobId][token] = bal - total;
+
+        // Interactions
+        for (uint256 i = 0; i < recipients.length; ++i) {
+            emit Released(depositor, jobId, token, recipients[i].to, recipients[i].amount);
+            IERC20(token).safeTransfer(recipients[i].to, recipients[i].amount);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Refund
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Refund the entire escrowed balance for a job back to the depositor.
+    /// @dev    Callers must hold RELEASER_ROLE.
+    /// @param  depositor  Owner of the escrowed balance.
+    /// @param  jobId      Job identifier.
+    /// @param  token      ERC-20 token address.
+    function refund(address depositor, uint256 jobId, address token)
+        external
+        nonReentrant
+        onlyRole(RELEASER_ROLE)
+    {
+        uint256 bal = balances[depositor][jobId][token];
+        if (bal == 0) revert InsufficientBalance(0, 1);
+
+        // Effects
+        balances[depositor][jobId][token] = 0;
+
+        emit Refunded(depositor, jobId, token, bal);
+
+        // Interaction
+        IERC20(token).safeTransfer(depositor, bal);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Return the escrowed balance for a (depositor, jobId, token) triple.
+    /// @param  depositor Address of the depositor.
+    /// @param  jobId     Job identifier.
+    /// @param  token     ERC-20 token address.
+    /// @return balance   Current escrowed amount.
+    function getBalance(address depositor, uint256 jobId, address token) external view returns (uint256 balance) {
+        balance = balances[depositor][jobId][token];
+    }
+}

--- a/contracts/evm/test/acp/Escrow.t.sol
+++ b/contracts/evm/test/acp/Escrow.t.sol
@@ -29,9 +29,7 @@ contract EscrowTest is Test {
     uint256 internal constant AMOUNT = 1000e18;
 
     event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
-    event Released(
-        address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount
-    );
+    event Released(address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount);
     event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
 
     function setUp() public {

--- a/contracts/evm/test/acp/Escrow.t.sol
+++ b/contracts/evm/test/acp/Escrow.t.sol
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Escrow} from "../../src/acp/Escrow.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock", "MCK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract EscrowTest is Test {
+    Escrow internal escrow;
+    MockERC20 internal tokenA;
+    MockERC20 internal tokenB;
+
+    address internal admin = makeAddr("admin");
+    address internal releaser = makeAddr("releaser");
+    address internal depositor = makeAddr("depositor");
+    address internal recipient1 = makeAddr("recipient1");
+    address internal recipient2 = makeAddr("recipient2");
+    address internal stranger = makeAddr("stranger");
+
+    uint256 internal constant JOB_ID = 42;
+    uint256 internal constant AMOUNT = 1000e18;
+
+    event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
+    event Released(
+        address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount
+    );
+    event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
+
+    function setUp() public {
+        escrow = new Escrow(admin);
+        tokenA = new MockERC20();
+        tokenB = new MockERC20();
+
+        // Grant releaser role
+        bytes32 releaserRole = escrow.RELEASER_ROLE();
+        vm.prank(admin);
+        escrow.grantRole(releaserRole, releaser);
+
+        // Mint and approve for depositor
+        tokenA.mint(depositor, AMOUNT * 10);
+        tokenB.mint(depositor, AMOUNT * 10);
+        vm.prank(depositor);
+        tokenA.approve(address(escrow), type(uint256).max);
+        vm.prank(depositor);
+        tokenB.approve(address(escrow), type(uint256).max);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // fund
+    // ─────────────────────────────────────────────────────────────
+
+    function test_fund_success() public {
+        vm.expectEmit(true, true, true, true);
+        emit Funded(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), AMOUNT);
+        assertEq(tokenA.balanceOf(address(escrow)), AMOUNT);
+    }
+
+    function test_fund_accumulates() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), AMOUNT * 2);
+    }
+
+    function test_fund_multiToken() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenB), AMOUNT / 2);
+
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), AMOUNT);
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenB)), AMOUNT / 2);
+    }
+
+    function test_fund_differentJobIds() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, 1, address(tokenA), AMOUNT);
+        vm.prank(depositor);
+        escrow.fund(depositor, 2, address(tokenA), AMOUNT / 2);
+
+        assertEq(escrow.getBalance(depositor, 1, address(tokenA)), AMOUNT);
+        assertEq(escrow.getBalance(depositor, 2, address(tokenA)), AMOUNT / 2);
+    }
+
+    function test_fund_revert_zeroDepositor() public {
+        vm.expectRevert(Escrow.ZeroAddress.selector);
+        escrow.fund(address(0), JOB_ID, address(tokenA), AMOUNT);
+    }
+
+    function test_fund_revert_zeroToken() public {
+        vm.expectRevert(Escrow.ZeroAddress.selector);
+        escrow.fund(depositor, JOB_ID, address(0), AMOUNT);
+    }
+
+    function test_fund_revert_zeroAmount() public {
+        vm.expectRevert(Escrow.ZeroAmount.selector);
+        escrow.fund(depositor, JOB_ID, address(tokenA), 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // release
+    // ─────────────────────────────────────────────────────────────
+
+    function test_release_singleRecipient() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](1);
+        recs[0] = Escrow.Recipient({to: recipient1, amount: AMOUNT});
+
+        vm.expectEmit(true, true, true, true);
+        emit Released(depositor, JOB_ID, address(tokenA), recipient1, AMOUNT);
+
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), 0);
+        assertEq(tokenA.balanceOf(recipient1), AMOUNT);
+    }
+
+    function test_release_multipleRecipients() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](2);
+        recs[0] = Escrow.Recipient({to: recipient1, amount: AMOUNT * 95 / 100});
+        recs[1] = Escrow.Recipient({to: recipient2, amount: AMOUNT * 5 / 100});
+
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+
+        assertEq(tokenA.balanceOf(recipient1), AMOUNT * 95 / 100);
+        assertEq(tokenA.balanceOf(recipient2), AMOUNT * 5 / 100);
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), 0);
+    }
+
+    function test_release_partialAmount() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](1);
+        recs[0] = Escrow.Recipient({to: recipient1, amount: AMOUNT / 2});
+
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), AMOUNT / 2);
+        assertEq(tokenA.balanceOf(recipient1), AMOUNT / 2);
+    }
+
+    function test_release_revert_notReleaser() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](1);
+        recs[0] = Escrow.Recipient({to: recipient1, amount: AMOUNT});
+
+        vm.expectRevert();
+        vm.prank(stranger);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+    }
+
+    function test_release_revert_emptyRecipients() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](0);
+        vm.expectRevert(Escrow.EmptyRecipients.selector);
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+    }
+
+    function test_release_revert_recipientZeroAddress() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](1);
+        recs[0] = Escrow.Recipient({to: address(0), amount: AMOUNT});
+
+        vm.expectRevert(abi.encodeWithSelector(Escrow.RecipientZeroAddress.selector, 0));
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+    }
+
+    function test_release_revert_recipientZeroAmount() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](1);
+        recs[0] = Escrow.Recipient({to: recipient1, amount: 0});
+
+        vm.expectRevert(abi.encodeWithSelector(Escrow.RecipientZeroAmount.selector, 0));
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+    }
+
+    function test_release_revert_sumExceedsBalance() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](1);
+        recs[0] = Escrow.Recipient({to: recipient1, amount: AMOUNT + 1});
+
+        vm.expectRevert(abi.encodeWithSelector(Escrow.SumExceedsBalance.selector, AMOUNT + 1, AMOUNT));
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // refund
+    // ─────────────────────────────────────────────────────────────
+
+    function test_refund_success() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        uint256 beforeBal = tokenA.balanceOf(depositor);
+
+        vm.expectEmit(true, true, true, true);
+        emit Refunded(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        vm.prank(releaser);
+        escrow.refund(depositor, JOB_ID, address(tokenA));
+
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), 0);
+        assertEq(tokenA.balanceOf(depositor), beforeBal + AMOUNT);
+    }
+
+    function test_refund_revert_zeroBalance() public {
+        vm.expectRevert(abi.encodeWithSelector(Escrow.InsufficientBalance.selector, 0, 1));
+        vm.prank(releaser);
+        escrow.refund(depositor, JOB_ID, address(tokenA));
+    }
+
+    function test_refund_revert_notReleaser() public {
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        vm.expectRevert();
+        vm.prank(stranger);
+        escrow.refund(depositor, JOB_ID, address(tokenA));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Fuzz
+    // ─────────────────────────────────────────────────────────────
+
+    function testFuzz_fund_release_invariant(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        tokenA.mint(depositor, amount);
+
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), amount);
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), amount);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](1);
+        recs[0] = Escrow.Recipient({to: recipient1, amount: amount});
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), 0);
+        assertEq(tokenA.balanceOf(recipient1), amount);
+    }
+
+    function testFuzz_fund_refund_invariant(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        tokenA.mint(depositor, amount);
+        uint256 initialBalance = tokenA.balanceOf(depositor);
+
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), amount);
+
+        vm.prank(releaser);
+        escrow.refund(depositor, JOB_ID, address(tokenA));
+
+        assertEq(tokenA.balanceOf(depositor), initialBalance);
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), 0);
+    }
+
+    function testFuzz_multiRecipient_split(uint256 part1, uint256 part2) public {
+        part1 = bound(part1, 1, AMOUNT - 1);
+        part2 = bound(part2, 1, AMOUNT - part1);
+
+        vm.prank(depositor);
+        escrow.fund(depositor, JOB_ID, address(tokenA), AMOUNT);
+
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](2);
+        recs[0] = Escrow.Recipient({to: recipient1, amount: part1});
+        recs[1] = Escrow.Recipient({to: recipient2, amount: part2});
+
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(tokenA), recs);
+
+        assertEq(tokenA.balanceOf(recipient1), part1);
+        assertEq(tokenA.balanceOf(recipient2), part2);
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(tokenA)), AMOUNT - part1 - part2);
+    }
+}


### PR DESCRIPTION
Phase \`escrow\` of \`M3 — acp v2 contracts e2e on base sepolia\`.

closes #56

Verification: \`.claude/cron/last-verify-M3-escrow.log\`

## Changes
- `contracts/evm/src/acp/Escrow.sol` — multi-token escrow:
  - `fund(depositor, jobId, token, amount)` — anyone deposits on behalf of depositor
  - `release(depositor, jobId, token, recipients[])` — RELEASER_ROLE atomic multi-recipient
  - `refund(depositor, jobId, token)` — RELEASER_ROLE full-balance refund to depositor
  - CEI: all storage writes before SafeERC20 transfers; ReentrancyGuard on all three
- `contracts/evm/test/acp/Escrow.t.sol` — 21 tests (unit + fuzz)
  - All revert paths covered
  - Fuzz: fund/release invariant, fund/refund invariant, multi-split

## Verify
- forge build: green
- forge test (21/21 pass)
- slither: 0 findings