### PR TITLE
phase(M3/fee-splitter): acp v2 contracts e2e on base sepolia

### DIFF
--- a/contracts/evm/src/acp/FeeSplitter.sol
+++ b/contracts/evm/src/acp/FeeSplitter.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @title FeeSplitter
+/// @notice Distributes protocol fees according to two split schedules:
+///
+///         Schedule A — "95/5" (agent job payment):
+///           - 95% → agent (primary recipient)
+///           -  3% → treasury
+///           -  2% → buyback-burner
+///           Total: 100%
+///
+///         Schedule B — "90/5/5" (platform or liquidity fee):
+///           - 90% → primary recipient
+///           -  5% → treasury
+///           -  5% → buyback-burner
+///           Total: 100%
+///
+///         Basis points (BPS) are used throughout (10 000 = 100%).
+///         Dust (remainder from integer division) stays with primary recipient.
+///
+///         CALLER_ROLE: addresses allowed to call `split` (e.g. Job contracts).
+///         DEFAULT_ADMIN_ROLE: configure treasury + buyback addresses, grant/revoke roles.
+contract FeeSplitter is AccessControl, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ─────────────────────────────────────────────────────────────
+    // Constants
+    // ─────────────────────────────────────────────────────────────
+
+    uint256 public constant BPS = 10_000;
+
+    /// @notice Schedule A: treasury share = 3%, buyback share = 2%, primary = 95%.
+    uint256 public constant SCHEDULE_A_TREASURY_BPS = 300;
+    uint256 public constant SCHEDULE_A_BUYBACK_BPS = 200;
+
+    /// @notice Schedule B: treasury share = 5%, buyback share = 5%, primary = 90%.
+    uint256 public constant SCHEDULE_B_TREASURY_BPS = 500;
+    uint256 public constant SCHEDULE_B_BUYBACK_BPS = 500;
+
+    // ─────────────────────────────────────────────────────────────
+    // Roles
+    // ─────────────────────────────────────────────────────────────
+
+    bytes32 public constant CALLER_ROLE = keccak256("CALLER_ROLE");
+
+    // ─────────────────────────────────────────────────────────────
+    // Split schedule enum
+    // ─────────────────────────────────────────────────────────────
+
+    enum Schedule {
+        A, // 95 / 3 / 2
+        B  // 90 / 5 / 5
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // State
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Treasury address receives the treasury share.
+    address public treasury;
+
+    /// @notice BuybackBurner address receives the buyback share.
+    address public buybackBurner;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a fee split is executed.
+    event FeeSplit(
+        address indexed token,
+        address indexed primary,
+        Schedule indexed schedule,
+        uint256 primaryAmount,
+        uint256 treasuryAmount,
+        uint256 buybackAmount
+    );
+
+    /// @notice Emitted when treasury address is updated.
+    event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury);
+
+    /// @notice Emitted when buyback burner address is updated.
+    event BuybackBurnerUpdated(address indexed oldBurner, address indexed newBurner);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    /// @param admin         Address granted DEFAULT_ADMIN_ROLE.
+    /// @param _treasury     Initial treasury address.
+    /// @param _buybackBurner Initial BuybackBurner address.
+    constructor(address admin, address _treasury, address _buybackBurner) {
+        if (admin == address(0)) revert ZeroAddress();
+        if (_treasury == address(0)) revert ZeroAddress();
+        if (_buybackBurner == address(0)) revert ZeroAddress();
+
+        treasury = _treasury;
+        buybackBurner = _buybackBurner;
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(CALLER_ROLE, admin);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Split
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Split `amount` of `token` according to `schedule`.
+    /// @dev    Caller must hold CALLER_ROLE.
+    ///         Caller must have pre-approved this contract for `amount` of `token`.
+    ///         The primary recipient receives any dust from integer division.
+    /// @param  token     ERC-20 token to split.
+    /// @param  amount    Total amount to split (must be > 0).
+    /// @param  primary   Primary recipient (agent or LPs) — receives the largest share.
+    /// @param  schedule  Split schedule (A or B).
+    function split(address token, uint256 amount, address primary, Schedule schedule)
+        external
+        nonReentrant
+        onlyRole(CALLER_ROLE)
+    {
+        if (token == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        if (primary == address(0)) revert ZeroAddress();
+
+        (uint256 treasuryBps, uint256 buybackBps) = _bps(schedule);
+
+        uint256 treasuryAmt = (amount * treasuryBps) / BPS;
+        uint256 buybackAmt = (amount * buybackBps) / BPS;
+        // Dust goes to primary (primary gets floor; treasury/buyback get floor)
+        uint256 primaryAmt = amount - treasuryAmt - buybackAmt;
+
+        emit FeeSplit(token, primary, schedule, primaryAmt, treasuryAmt, buybackAmt);
+
+        // Pull total from caller first
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+
+        // Then distribute — CEI order for each sub-transfer
+        IERC20(token).safeTransfer(primary, primaryAmt);
+        IERC20(token).safeTransfer(treasury, treasuryAmt);
+        IERC20(token).safeTransfer(buybackBurner, buybackAmt);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Admin
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Update the treasury address.
+    /// @param  newTreasury New treasury address (must be non-zero).
+    function setTreasury(address newTreasury) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newTreasury == address(0)) revert ZeroAddress();
+        address old = treasury;
+        treasury = newTreasury;
+        emit TreasuryUpdated(old, newTreasury);
+    }
+
+    /// @notice Update the buyback burner address.
+    /// @param  newBurner New buyback burner address (must be non-zero).
+    function setBuybackBurner(address newBurner) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newBurner == address(0)) revert ZeroAddress();
+        address old = buybackBurner;
+        buybackBurner = newBurner;
+        emit BuybackBurnerUpdated(old, newBurner);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Preview the split amounts for a given amount and schedule without transferring.
+    /// @param  amount   Total amount to split.
+    /// @param  schedule Split schedule.
+    /// @return primaryAmt  Amount going to the primary recipient.
+    /// @return treasuryAmt Amount going to treasury.
+    /// @return buybackAmt  Amount going to buyback burner.
+    function previewSplit(uint256 amount, Schedule schedule)
+        external
+        pure
+        returns (uint256 primaryAmt, uint256 treasuryAmt, uint256 buybackAmt)
+    {
+        (uint256 treasuryBps, uint256 buybackBps) = _bps(schedule);
+        treasuryAmt = (amount * treasuryBps) / BPS;
+        buybackAmt = (amount * buybackBps) / BPS;
+        primaryAmt = amount - treasuryAmt - buybackAmt;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Internal
+    // ─────────────────────────────────────────────────────────────
+
+    function _bps(Schedule schedule) internal pure returns (uint256 treasuryBps, uint256 buybackBps) {
+        if (schedule == Schedule.A) {
+            treasuryBps = SCHEDULE_A_TREASURY_BPS;
+            buybackBps = SCHEDULE_A_BUYBACK_BPS;
+        } else {
+            treasuryBps = SCHEDULE_B_TREASURY_BPS;
+            buybackBps = SCHEDULE_B_BUYBACK_BPS;
+        }
+    }
+}

--- a/contracts/evm/src/acp/FeeSplitter.sol
+++ b/contracts/evm/src/acp/FeeSplitter.sol
@@ -55,7 +55,7 @@ contract FeeSplitter is AccessControl, ReentrancyGuard {
 
     enum Schedule {
         A, // 95 / 3 / 2
-        B  // 90 / 5 / 5
+        B // 90 / 5 / 5
     }
 
     // ─────────────────────────────────────────────────────────────

--- a/contracts/evm/test/acp/FeeSplitter.t.sol
+++ b/contracts/evm/test/acp/FeeSplitter.t.sol
@@ -64,7 +64,9 @@ contract FeeSplitterTest is Test {
         uint256 expectedBuyback = 200e18;
 
         vm.expectEmit(true, true, true, true);
-        emit FeeSplit(address(token), primary, FeeSplitter.Schedule.A, expectedPrimary, expectedTreasury, expectedBuyback);
+        emit FeeSplit(
+            address(token), primary, FeeSplitter.Schedule.A, expectedPrimary, expectedTreasury, expectedBuyback
+        );
 
         vm.prank(caller);
         splitter.split(address(token), AMOUNT, primary, FeeSplitter.Schedule.A);

--- a/contracts/evm/test/acp/FeeSplitter.t.sol
+++ b/contracts/evm/test/acp/FeeSplitter.t.sol
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {FeeSplitter} from "../../src/acp/FeeSplitter.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock", "MCK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract FeeSplitterTest is Test {
+    FeeSplitter internal splitter;
+    MockERC20 internal token;
+
+    address internal admin = makeAddr("admin");
+    address internal treasury = makeAddr("treasury");
+    address internal buyback = makeAddr("buyback");
+    address internal caller = makeAddr("caller");
+    address internal primary = makeAddr("primary");
+    address internal stranger = makeAddr("stranger");
+
+    uint256 internal constant AMOUNT = 10_000e18; // 10 000 tokens for easy BPS arithmetic
+
+    event FeeSplit(
+        address indexed token,
+        address indexed primary,
+        FeeSplitter.Schedule indexed schedule,
+        uint256 primaryAmount,
+        uint256 treasuryAmount,
+        uint256 buybackAmount
+    );
+
+    event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury);
+    event BuybackBurnerUpdated(address indexed oldBurner, address indexed newBurner);
+
+    function setUp() public {
+        splitter = new FeeSplitter(admin, treasury, buyback);
+        token = new MockERC20();
+
+        // Grant caller role
+        bytes32 callerRole = splitter.CALLER_ROLE();
+        vm.prank(admin);
+        splitter.grantRole(callerRole, caller);
+
+        // Mint + approve
+        token.mint(caller, AMOUNT * 100);
+        vm.prank(caller);
+        token.approve(address(splitter), type(uint256).max);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Schedule A: 95/3/2
+    // ─────────────────────────────────────────────────────────────
+
+    function test_split_scheduleA_amounts() public {
+        // 10 000 tokens → primary=9500, treasury=300, buyback=200
+        uint256 expectedPrimary = 9500e18;
+        uint256 expectedTreasury = 300e18;
+        uint256 expectedBuyback = 200e18;
+
+        vm.expectEmit(true, true, true, true);
+        emit FeeSplit(address(token), primary, FeeSplitter.Schedule.A, expectedPrimary, expectedTreasury, expectedBuyback);
+
+        vm.prank(caller);
+        splitter.split(address(token), AMOUNT, primary, FeeSplitter.Schedule.A);
+
+        assertEq(token.balanceOf(primary), expectedPrimary);
+        assertEq(token.balanceOf(treasury), expectedTreasury);
+        assertEq(token.balanceOf(buyback), expectedBuyback);
+        assertEq(token.balanceOf(address(splitter)), 0); // no residual
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Schedule B: 90/5/5
+    // ─────────────────────────────────────────────────────────────
+
+    function test_split_scheduleB_amounts() public {
+        // 10 000 tokens → primary=9000, treasury=500, buyback=500
+        uint256 expectedPrimary = 9000e18;
+        uint256 expectedTreasury = 500e18;
+        uint256 expectedBuyback = 500e18;
+
+        vm.prank(caller);
+        splitter.split(address(token), AMOUNT, primary, FeeSplitter.Schedule.B);
+
+        assertEq(token.balanceOf(primary), expectedPrimary);
+        assertEq(token.balanceOf(treasury), expectedTreasury);
+        assertEq(token.balanceOf(buyback), expectedBuyback);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Dust handling
+    // ─────────────────────────────────────────────────────────────
+
+    function test_split_dust_goesToPrimary() public {
+        // 1 token — 3% treasury = 0, 2% buyback = 0, primary gets all 1
+        uint256 tiny = 1;
+        token.mint(caller, tiny);
+        vm.prank(caller);
+        token.approve(address(splitter), type(uint256).max);
+
+        vm.prank(caller);
+        splitter.split(address(token), tiny, primary, FeeSplitter.Schedule.A);
+
+        assertEq(token.balanceOf(primary), tiny);
+        assertEq(token.balanceOf(treasury), 0);
+        assertEq(token.balanceOf(buyback), 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // previewSplit
+    // ─────────────────────────────────────────────────────────────
+
+    function test_previewSplit_scheduleA() public view {
+        (uint256 p, uint256 t, uint256 b) = splitter.previewSplit(AMOUNT, FeeSplitter.Schedule.A);
+        assertEq(p, 9500e18);
+        assertEq(t, 300e18);
+        assertEq(b, 200e18);
+        assertEq(p + t + b, AMOUNT);
+    }
+
+    function test_previewSplit_scheduleB() public view {
+        (uint256 p, uint256 t, uint256 b) = splitter.previewSplit(AMOUNT, FeeSplitter.Schedule.B);
+        assertEq(p, 9000e18);
+        assertEq(t, 500e18);
+        assertEq(b, 500e18);
+        assertEq(p + t + b, AMOUNT);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Revert paths
+    // ─────────────────────────────────────────────────────────────
+
+    function test_split_revert_notCaller() public {
+        vm.expectRevert();
+        vm.prank(stranger);
+        splitter.split(address(token), AMOUNT, primary, FeeSplitter.Schedule.A);
+    }
+
+    function test_split_revert_zeroToken() public {
+        vm.expectRevert(FeeSplitter.ZeroAddress.selector);
+        vm.prank(caller);
+        splitter.split(address(0), AMOUNT, primary, FeeSplitter.Schedule.A);
+    }
+
+    function test_split_revert_zeroPrimary() public {
+        vm.expectRevert(FeeSplitter.ZeroAddress.selector);
+        vm.prank(caller);
+        splitter.split(address(token), AMOUNT, address(0), FeeSplitter.Schedule.A);
+    }
+
+    function test_split_revert_zeroAmount() public {
+        vm.expectRevert(FeeSplitter.ZeroAmount.selector);
+        vm.prank(caller);
+        splitter.split(address(token), 0, primary, FeeSplitter.Schedule.A);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Admin
+    // ─────────────────────────────────────────────────────────────
+
+    function test_setTreasury() public {
+        address newTreasury = makeAddr("newTreasury");
+        vm.expectEmit(true, true, false, false);
+        emit TreasuryUpdated(treasury, newTreasury);
+        vm.prank(admin);
+        splitter.setTreasury(newTreasury);
+        assertEq(splitter.treasury(), newTreasury);
+    }
+
+    function test_setTreasury_revert_zero() public {
+        vm.expectRevert(FeeSplitter.ZeroAddress.selector);
+        vm.prank(admin);
+        splitter.setTreasury(address(0));
+    }
+
+    function test_setTreasury_revert_notAdmin() public {
+        vm.expectRevert();
+        vm.prank(stranger);
+        splitter.setTreasury(makeAddr("x"));
+    }
+
+    function test_setBuybackBurner() public {
+        address newBurner = makeAddr("newBurner");
+        vm.expectEmit(true, true, false, false);
+        emit BuybackBurnerUpdated(buyback, newBurner);
+        vm.prank(admin);
+        splitter.setBuybackBurner(newBurner);
+        assertEq(splitter.buybackBurner(), newBurner);
+    }
+
+    function test_setBuybackBurner_revert_zero() public {
+        vm.expectRevert(FeeSplitter.ZeroAddress.selector);
+        vm.prank(admin);
+        splitter.setBuybackBurner(address(0));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Fuzz: sum invariant
+    // ─────────────────────────────────────────────────────────────
+
+    function testFuzz_split_sumInvariant_scheduleA(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        token.mint(caller, amount);
+        vm.prank(caller);
+        token.approve(address(splitter), type(uint256).max);
+
+        uint256 callerBefore = token.balanceOf(caller);
+
+        vm.prank(caller);
+        splitter.split(address(token), amount, primary, FeeSplitter.Schedule.A);
+
+        uint256 totalOut = token.balanceOf(primary) + token.balanceOf(treasury) + token.balanceOf(buyback);
+        assertEq(totalOut, amount);
+        assertEq(token.balanceOf(caller), callerBefore - amount);
+        assertEq(token.balanceOf(address(splitter)), 0);
+    }
+
+    function testFuzz_split_sumInvariant_scheduleB(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        token.mint(caller, amount);
+        vm.prank(caller);
+        token.approve(address(splitter), type(uint256).max);
+
+        vm.prank(caller);
+        splitter.split(address(token), amount, primary, FeeSplitter.Schedule.B);
+
+        uint256 totalOut = token.balanceOf(primary) + token.balanceOf(treasury) + token.balanceOf(buyback);
+        assertEq(totalOut, amount);
+        assertEq(token.balanceOf(address(splitter)), 0);
+    }
+
+    function testFuzz_previewSplit_sumInvariant(uint256 amount) public view {
+        amount = bound(amount, 0, type(uint128).max);
+        (uint256 p, uint256 t, uint256 b) = splitter.previewSplit(amount, FeeSplitter.Schedule.A);
+        assertEq(p + t + b, amount);
+        (p, t, b) = splitter.previewSplit(amount, FeeSplitter.Schedule.B);
+        assertEq(p + t + b, amount);
+    }
+}


### PR DESCRIPTION
Phase \`fee-splitter\` of \`M3 — acp v2 contracts e2e on base sepolia\`.

closes #57

Verification: \`.claude/cron/last-verify-M3-fee-splitter.log\`

## Changes
- `contracts/evm/src/acp/FeeSplitter.sol`:
  - Schedule A (95/3/2): primary=95%, treasury=3%, buyback=2%
  - Schedule B (90/5/5): primary=90%, treasury=5%, buyback=5%
  - `previewSplit` pure view for off-chain previews
  - Dust from integer division goes to primary
  - CALLER_ROLE gating
- `contracts/evm/test/acp/FeeSplitter.t.sol` — 17 tests
  - Sum invariant fuzz for both schedules

## Verify
- forge build: green
- forge test (17/17 pass)
- slither: 0 findings