### PR TITLE
phase(M3/buyback-burner): acp v2 contracts e2e on base sepolia

### DIFF
--- a/contracts/evm/src/acp/BuybackBurner.sol
+++ b/contracts/evm/src/acp/BuybackBurner.sol
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @dev Minimal interface for Uniswap V2 router used by this contract.
+interface IUniswapV2Router02 {
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external;
+}
+
+/// @dev ERC-20 with burn capability.
+interface IERC20Burnable is IERC20 {
+    /// @dev Burns `amount` of the caller's own tokens.
+    function burn(uint256 amount) external;
+}
+
+/// @title BuybackBurner
+/// @notice Receives a payment token, swaps it for TITU on Uniswap V2, then burns
+///         the TITU using ERC20Burnable.burnFrom.
+/// @dev    Role model:
+///           - DEFAULT_ADMIN_ROLE: update router, path, and slippage parameters.
+///           - EXECUTOR_ROLE: allowed to call `buybackAndBurn`.
+///
+///         Slippage: caller supplies `amountOutMin`; the contract enforces a
+///         global floor `minOutBps` (in BPS of input amount) as an extra safety
+///         net. Set `minOutBps = 0` to disable the floor (not recommended).
+///
+///         CEI: safeApprove the router, then swap, then burn.  No state changes
+///         occur after the external calls, so ReentrancyGuard covers residual risk.
+contract BuybackBurner is AccessControl, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ─────────────────────────────────────────────────────────────
+    // Roles
+    // ─────────────────────────────────────────────────────────────
+
+    bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
+
+    // ─────────────────────────────────────────────────────────────
+    // Constants
+    // ─────────────────────────────────────────────────────────────
+
+    uint256 public constant BPS = 10_000;
+
+    // ─────────────────────────────────────────────────────────────
+    // State
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Uniswap V2 compatible router.
+    IUniswapV2Router02 public router;
+
+    /// @notice Payment token received from FeeSplitter (e.g. USDC).
+    address public immutable paymentToken;
+
+    /// @notice TITU token that is bought and burned.
+    IERC20Burnable public immutable titu;
+
+    /// @notice Swap path from paymentToken → TITU.  Must start with paymentToken
+    ///         and end with address(titu).  May include intermediate hops.
+    address[] public swapPath;
+
+    /// @notice Minimum output in BPS of the input amount.  Acts as a global floor.
+    ///         E.g. 9000 = 90%. Set to 0 to disable.
+    uint256 public minOutBps;
+
+    /// @notice Swap deadline extension in seconds added to block.timestamp.
+    uint256 public immutable swapDeadlineBuffer;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a buyback-and-burn is executed.
+    event BuybackAndBurn(
+        address indexed executor, address indexed paymentToken, uint256 amountIn, uint256 tituBurned
+    );
+
+    /// @notice Emitted when router is updated.
+    event RouterUpdated(address indexed oldRouter, address indexed newRouter);
+
+    /// @notice Emitted when swap path is updated.
+    event SwapPathUpdated(address[] path);
+
+    /// @notice Emitted when min-out BPS floor is updated.
+    event MinOutBpsUpdated(uint256 oldBps, uint256 newBps);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error InvalidSwapPath();
+    error InvalidBps();
+    error InsufficientAmountOut(uint256 amountIn, uint256 minOut, uint256 actualOut);
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    /// @param admin             Address granted DEFAULT_ADMIN_ROLE.
+    /// @param _router           Uniswap V2 router address.
+    /// @param _paymentToken     ERC-20 received and swapped.
+    /// @param _titu             TITU token address (must implement burnFrom).
+    /// @param _swapPath         Initial swap path (must start with _paymentToken, end with _titu).
+    /// @param _minOutBps        Minimum output BPS (0–10 000).
+    /// @param _swapDeadlineBuffer Seconds added to block.timestamp for swap deadline.
+    constructor(
+        address admin,
+        address _router,
+        address _paymentToken,
+        address _titu,
+        address[] memory _swapPath,
+        uint256 _minOutBps,
+        uint256 _swapDeadlineBuffer
+    ) {
+        if (admin == address(0)) revert ZeroAddress();
+        if (_router == address(0)) revert ZeroAddress();
+        if (_paymentToken == address(0)) revert ZeroAddress();
+        if (_titu == address(0)) revert ZeroAddress();
+        if (_minOutBps > BPS) revert InvalidBps();
+        _validatePath(_swapPath, _paymentToken, _titu);
+
+        router = IUniswapV2Router02(_router);
+        paymentToken = _paymentToken;
+        titu = IERC20Burnable(_titu);
+        swapPath = _swapPath;
+        minOutBps = _minOutBps;
+        swapDeadlineBuffer = _swapDeadlineBuffer;
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(EXECUTOR_ROLE, admin);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Core action
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Swap all held `paymentToken` for TITU via Uniswap V2 and burn the TITU.
+    /// @dev    Caller must hold EXECUTOR_ROLE.
+    /// @param  amountIn    Amount of paymentToken to swap.
+    /// @param  amountOutMin Minimum TITU out (caller's slippage tolerance).
+    function buybackAndBurn(uint256 amountIn, uint256 amountOutMin) external nonReentrant onlyRole(EXECUTOR_ROLE) {
+        if (amountIn == 0) revert ZeroAmount();
+
+        // Enforce global floor if configured
+        if (minOutBps > 0) {
+            uint256 floor = (amountIn * minOutBps) / BPS;
+            if (amountOutMin < floor) {
+                amountOutMin = floor;
+            }
+        }
+
+        address _paymentToken = paymentToken;
+        address _titu = address(titu);
+
+        // Record TITU balance before swap to calculate actual amount received
+        uint256 tituBefore = titu.balanceOf(address(this));
+
+        // Set exact approval for router (forceApprove resets to 0 first, safe for USDT-like tokens)
+        IERC20(_paymentToken).forceApprove(address(router), amountIn);
+
+        // Swap paymentToken → TITU; tokens land in this contract
+        // slither-disable-next-line timestamp
+        router.swapExactTokensForTokensSupportingFeeOnTransferTokens(
+            amountIn, amountOutMin, swapPath, address(this), block.timestamp + swapDeadlineBuffer
+        );
+
+        uint256 tituReceived = titu.balanceOf(address(this)) - tituBefore;
+
+        // Reset router allowance to 0 (defensive)
+        IERC20(_paymentToken).forceApprove(address(router), 0);
+
+        // Burn — ERC20Burnable.burn burns caller's own tokens (no allowance needed)
+        titu.burn(tituReceived);
+
+        emit BuybackAndBurn(msg.sender, _paymentToken, amountIn, tituReceived);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Admin configuration
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Update the Uniswap V2 router address.
+    /// @param  newRouter New router address (must be non-zero).
+    function setRouter(address newRouter) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newRouter == address(0)) revert ZeroAddress();
+        address old = address(router);
+        router = IUniswapV2Router02(newRouter);
+        emit RouterUpdated(old, newRouter);
+    }
+
+    /// @notice Update the swap path.
+    /// @param  path New swap path; must start with paymentToken and end with titu.
+    function setSwapPath(address[] calldata path) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _validatePath(path, paymentToken, address(titu));
+        swapPath = path;
+        emit SwapPathUpdated(path);
+    }
+
+    /// @notice Update the minimum output BPS floor.
+    /// @param  newBps New BPS value (0–10 000).
+    function setMinOutBps(uint256 newBps) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newBps > BPS) revert InvalidBps();
+        uint256 old = minOutBps;
+        minOutBps = newBps;
+        emit MinOutBpsUpdated(old, newBps);
+    }
+
+    /// @notice Rescue ERC-20 tokens accidentally sent to this contract (excludes paymentToken mid-swap).
+    /// @param  tokenAddr Token to rescue.
+    /// @param  to        Recipient.
+    /// @param  amount    Amount to rescue.
+    function rescueTokens(address tokenAddr, address to, uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (to == address(0)) revert ZeroAddress();
+        IERC20(tokenAddr).safeTransfer(to, amount);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Return the full swap path array.
+    /// @return path Swap path.
+    function getSwapPath() external view returns (address[] memory path) {
+        path = swapPath;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Internal helpers
+    // ─────────────────────────────────────────────────────────────
+
+    function _validatePath(address[] memory path, address _paymentToken, address _titu) internal pure {
+        if (path.length < 2) revert InvalidSwapPath();
+        if (path[0] != _paymentToken) revert InvalidSwapPath();
+        if (path[path.length - 1] != _titu) revert InvalidSwapPath();
+    }
+}

--- a/contracts/evm/src/acp/BuybackBurner.sol
+++ b/contracts/evm/src/acp/BuybackBurner.sol
@@ -80,9 +80,7 @@ contract BuybackBurner is AccessControl, ReentrancyGuard {
     // ─────────────────────────────────────────────────────────────
 
     /// @notice Emitted when a buyback-and-burn is executed.
-    event BuybackAndBurn(
-        address indexed executor, address indexed paymentToken, uint256 amountIn, uint256 tituBurned
-    );
+    event BuybackAndBurn(address indexed executor, address indexed paymentToken, uint256 amountIn, uint256 tituBurned);
 
     /// @notice Emitted when router is updated.
     event RouterUpdated(address indexed oldRouter, address indexed newRouter);

--- a/contracts/evm/test/acp/BuybackBurner.t.sol
+++ b/contracts/evm/test/acp/BuybackBurner.t.sol
@@ -67,9 +67,7 @@ contract BuybackBurnerTest is Test {
     uint256 internal constant FIXED_OUTPUT = 950e18;
     uint256 internal constant AMOUNT_IN = 1000e18;
 
-    event BuybackAndBurn(
-        address indexed executor, address indexed paymentToken, uint256 amountIn, uint256 tituBurned
-    );
+    event BuybackAndBurn(address indexed executor, address indexed paymentToken, uint256 amountIn, uint256 tituBurned);
 
     function setUp() public {
         payment = new MockPaymentToken();
@@ -87,7 +85,7 @@ contract BuybackBurnerTest is Test {
             address(titu),
             path,
             9000, // 90% min out floor
-            300   // 5 min swap deadline
+            300 // 5 min swap deadline
         );
 
         // Grant executor role
@@ -263,9 +261,8 @@ contract BuybackBurnerTest is Test {
         address[] memory path = new address[](2);
         path[0] = address(payment);
         path[1] = address(titu);
-        BuybackBurner fuzzBurner = new BuybackBurner(
-            admin, address(router), address(payment), address(titu), path, 0, 300
-        );
+        BuybackBurner fuzzBurner =
+            new BuybackBurner(admin, address(router), address(payment), address(titu), path, 0, 300);
         bytes32 executorRole = fuzzBurner.EXECUTOR_ROLE();
         vm.prank(admin);
         fuzzBurner.grantRole(executorRole, executor);

--- a/contracts/evm/test/acp/BuybackBurner.t.sol
+++ b/contracts/evm/test/acp/BuybackBurner.t.sol
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {BuybackBurner, IUniswapV2Router02} from "../../src/acp/BuybackBurner.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @dev Minimal payment token (e.g. USDC mock)
+contract MockPaymentToken is ERC20 {
+    constructor() ERC20("USDC", "USDC") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @dev TITU mock with ERC20Burnable
+contract MockTITU is ERC20Burnable {
+    constructor() ERC20("TITU", "TITU") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @dev Mock Uniswap V2 router that simulates a swap by transferring mockTitu
+///      to `to` in exchange for paymentToken from msg.sender.
+contract MockUniRouter {
+    MockTITU public titu;
+    uint256 public fixedOutput; // how much TITU the router returns per swap
+
+    constructor(MockTITU _titu, uint256 _fixedOutput) {
+        titu = _titu;
+        fixedOutput = _fixedOutput;
+    }
+
+    /// @dev Pulls paymentToken from msg.sender (the burner contract), then transfers TITU to `to`.
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 /*deadline*/
+    ) external {
+        // Pull paymentToken
+        IERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
+        // Enforce slippage
+        require(fixedOutput >= amountOutMin, "slippage");
+        // Transfer TITU to recipient
+        titu.mint(to, fixedOutput);
+    }
+}
+
+contract BuybackBurnerTest is Test {
+    MockPaymentToken internal payment;
+    MockTITU internal titu;
+    MockUniRouter internal router;
+    BuybackBurner internal burner;
+
+    address internal admin = makeAddr("admin");
+    address internal executor = makeAddr("executor");
+    address internal stranger = makeAddr("stranger");
+
+    // FIXED_OUTPUT must be >= floor = AMOUNT_IN * minOutBps / 10000 = 1000e18 * 9000 / 10000 = 900e18
+    uint256 internal constant FIXED_OUTPUT = 950e18;
+    uint256 internal constant AMOUNT_IN = 1000e18;
+
+    event BuybackAndBurn(
+        address indexed executor, address indexed paymentToken, uint256 amountIn, uint256 tituBurned
+    );
+
+    function setUp() public {
+        payment = new MockPaymentToken();
+        titu = new MockTITU();
+        router = new MockUniRouter(titu, FIXED_OUTPUT);
+
+        address[] memory path = new address[](2);
+        path[0] = address(payment);
+        path[1] = address(titu);
+
+        burner = new BuybackBurner(
+            admin,
+            address(router),
+            address(payment),
+            address(titu),
+            path,
+            9000, // 90% min out floor
+            300   // 5 min swap deadline
+        );
+
+        // Grant executor role
+        bytes32 executorRole = burner.EXECUTOR_ROLE();
+        vm.prank(admin);
+        burner.grantRole(executorRole, executor);
+
+        // Fund burner with payment tokens (no pre-approval needed; contract manages it)
+        payment.mint(address(burner), AMOUNT_IN * 10);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    function test_constructor_setsState() public view {
+        assertEq(address(burner.router()), address(router));
+        assertEq(burner.paymentToken(), address(payment));
+        assertEq(address(burner.titu()), address(titu));
+        assertEq(burner.minOutBps(), 9000);
+        assertEq(burner.swapDeadlineBuffer(), 300);
+        address[] memory path = burner.getSwapPath();
+        assertEq(path[0], address(payment));
+        assertEq(path[1], address(titu));
+    }
+
+    function test_constructor_revert_zeroAdmin() public {
+        address[] memory path = new address[](2);
+        path[0] = address(payment);
+        path[1] = address(titu);
+        vm.expectRevert(BuybackBurner.ZeroAddress.selector);
+        new BuybackBurner(address(0), address(router), address(payment), address(titu), path, 9000, 300);
+    }
+
+    function test_constructor_revert_invalidBps() public {
+        address[] memory path = new address[](2);
+        path[0] = address(payment);
+        path[1] = address(titu);
+        vm.expectRevert(BuybackBurner.InvalidBps.selector);
+        new BuybackBurner(admin, address(router), address(payment), address(titu), path, 10_001, 300);
+    }
+
+    function test_constructor_revert_invalidPath_tooShort() public {
+        address[] memory path = new address[](1);
+        path[0] = address(payment);
+        vm.expectRevert(BuybackBurner.InvalidSwapPath.selector);
+        new BuybackBurner(admin, address(router), address(payment), address(titu), path, 9000, 300);
+    }
+
+    function test_constructor_revert_invalidPath_wrongStart() public {
+        address[] memory path = new address[](2);
+        path[0] = makeAddr("other");
+        path[1] = address(titu);
+        vm.expectRevert(BuybackBurner.InvalidSwapPath.selector);
+        new BuybackBurner(admin, address(router), address(payment), address(titu), path, 9000, 300);
+    }
+
+    function test_constructor_revert_invalidPath_wrongEnd() public {
+        address[] memory path = new address[](2);
+        path[0] = address(payment);
+        path[1] = makeAddr("other");
+        vm.expectRevert(BuybackBurner.InvalidSwapPath.selector);
+        new BuybackBurner(admin, address(router), address(payment), address(titu), path, 9000, 300);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // buybackAndBurn happy path
+    // ─────────────────────────────────────────────────────────────
+
+    function test_buybackAndBurn_burnsCorrectAmount() public {
+        uint256 tituSupplyBefore = titu.totalSupply();
+
+        // Don't check the tituBurned data field since it depends on the mock's fixedOutput
+        vm.expectEmit(true, true, false, false);
+        emit BuybackAndBurn(executor, address(payment), AMOUNT_IN, FIXED_OUTPUT);
+
+        vm.prank(executor);
+        burner.buybackAndBurn(AMOUNT_IN, 1);
+
+        // TITU total supply reduced by FIXED_OUTPUT
+        assertEq(titu.totalSupply(), tituSupplyBefore); // mint then burn = net 0 change in supply
+        // But burner holds 0 TITU
+        assertEq(titu.balanceOf(address(burner)), 0);
+    }
+
+    function test_buybackAndBurn_revert_notExecutor() public {
+        vm.expectRevert();
+        vm.prank(stranger);
+        burner.buybackAndBurn(AMOUNT_IN, 1);
+    }
+
+    function test_buybackAndBurn_revert_zeroAmount() public {
+        vm.expectRevert(BuybackBurner.ZeroAmount.selector);
+        vm.prank(executor);
+        burner.buybackAndBurn(0, 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Admin: setRouter
+    // ─────────────────────────────────────────────────────────────
+
+    function test_setRouter() public {
+        address newRouter = makeAddr("newRouter");
+        vm.prank(admin);
+        burner.setRouter(newRouter);
+        assertEq(address(burner.router()), newRouter);
+    }
+
+    function test_setRouter_revert_zero() public {
+        vm.expectRevert(BuybackBurner.ZeroAddress.selector);
+        vm.prank(admin);
+        burner.setRouter(address(0));
+    }
+
+    function test_setRouter_revert_notAdmin() public {
+        vm.expectRevert();
+        vm.prank(stranger);
+        burner.setRouter(makeAddr("x"));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Admin: setSwapPath
+    // ─────────────────────────────────────────────────────────────
+
+    function test_setSwapPath_withHop() public {
+        address hop = makeAddr("WETH");
+        address[] memory path = new address[](3);
+        path[0] = address(payment);
+        path[1] = hop;
+        path[2] = address(titu);
+
+        vm.prank(admin);
+        burner.setSwapPath(path);
+
+        address[] memory stored = burner.getSwapPath();
+        assertEq(stored.length, 3);
+        assertEq(stored[1], hop);
+    }
+
+    function test_setSwapPath_revert_invalidPath() public {
+        address[] memory path = new address[](2);
+        path[0] = makeAddr("bad");
+        path[1] = address(titu);
+        vm.expectRevert(BuybackBurner.InvalidSwapPath.selector);
+        vm.prank(admin);
+        burner.setSwapPath(path);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Admin: setMinOutBps
+    // ─────────────────────────────────────────────────────────────
+
+    function test_setMinOutBps() public {
+        vm.prank(admin);
+        burner.setMinOutBps(8500);
+        assertEq(burner.minOutBps(), 8500);
+    }
+
+    function test_setMinOutBps_revert_tooHigh() public {
+        vm.expectRevert(BuybackBurner.InvalidBps.selector);
+        vm.prank(admin);
+        burner.setMinOutBps(10_001);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Fuzz
+    // ─────────────────────────────────────────────────────────────
+
+    function testFuzz_buybackAndBurn_variousAmounts(uint256 amountIn) public {
+        amountIn = bound(amountIn, 1, type(uint128).max);
+
+        // Deploy a burner with minOutBps=0 (no floor) so the fixed-output mock always passes
+        address[] memory path = new address[](2);
+        path[0] = address(payment);
+        path[1] = address(titu);
+        BuybackBurner fuzzBurner = new BuybackBurner(
+            admin, address(router), address(payment), address(titu), path, 0, 300
+        );
+        bytes32 executorRole = fuzzBurner.EXECUTOR_ROLE();
+        vm.prank(admin);
+        fuzzBurner.grantRole(executorRole, executor);
+
+        payment.mint(address(fuzzBurner), amountIn);
+
+        uint256 supplyBefore = titu.totalSupply();
+        vm.prank(executor);
+        fuzzBurner.buybackAndBurn(amountIn, 0);
+        // Router mints FIXED_OUTPUT and contract burns it, net supply unchanged
+        assertEq(titu.totalSupply(), supplyBefore);
+        assertEq(titu.balanceOf(address(fuzzBurner)), 0);
+    }
+}


### PR DESCRIPTION
Phase \`buyback-burner\` of \`M3 — acp v2 contracts e2e on base sepolia\`.

closes #58

Verification: \`.claude/cron/last-verify-M3-buyback-burner.log\`

## Changes
- `contracts/evm/src/acp/BuybackBurner.sol`:
  - Receives paymentToken, swaps via Uni V2 `swapExactTokensForTokensSupportingFeeOnTransferTokens`
  - Burns TITU via `ERC20Burnable.burn` (direct own-token burn, no allowance needed)
  - `forceApprove` for router; resets to 0 after swap
  - Global `minOutBps` floor enforced on every swap
  - EXECUTOR_ROLE gated; admin-configurable router, path, minOutBps
  - `paymentToken`, `titu`, `swapDeadlineBuffer` are immutable
- `contracts/evm/test/acp/BuybackBurner.t.sol` — 17 tests including fuzz with mock router

## Verify
- forge build: green
- forge test (17/17 pass)
- slither: 0 findings