### PR TITLE
phase(M3/hook-registry): acp v2 contracts e2e on base sepolia

### DIFF
--- a/contracts/evm/src/acp/HookRegistry.sol
+++ b/contracts/evm/src/acp/HookRegistry.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {IHook} from "./IHook.sol";
+
+/// @title HookRegistry
+/// @notice Registry of approved IHook implementations.  Job contracts query this
+///         registry to validate that a hook address has been whitelisted before
+///         calling it, preventing arbitrary code injection via hook fields.
+/// @dev    Role model:
+///           - DEFAULT_ADMIN_ROLE: register and deregister hook implementations.
+///
+///         Hooks are identified by their contract address.  The registry stores:
+///           - A boolean `approved` flag.
+///           - The `hookName()` string (cached at registration time for gas and
+///             to surface readable names off-chain without additional calls).
+///
+///         Any address may query `isApproved(hookAddr)`.
+contract HookRegistry is AccessControl {
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    struct HookInfo {
+        bool approved;
+        string name;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // State
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice hook address => HookInfo.
+    mapping(address => HookInfo) private _hooks;
+
+    /// @notice Ordered list of all ever-registered hook addresses (may include revoked ones).
+    address[] private _hookAddresses;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a hook is registered.
+    event HookRegistered(address indexed hook, string name);
+
+    /// @notice Emitted when a hook is deregistered (revoked).
+    event HookDeregistered(address indexed hook);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error AlreadyRegistered(address hook);
+    error NotRegistered(address hook);
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    /// @param admin Address granted DEFAULT_ADMIN_ROLE.
+    constructor(address admin) {
+        if (admin == address(0)) revert ZeroAddress();
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Registration
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Register a hook implementation.  Calls `hookName()` on the hook to
+    ///         cache the name.  Reverts if the hook is already registered.
+    /// @param  hook Hook contract address (must implement IHook).
+    function registerHook(address hook) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (hook == address(0)) revert ZeroAddress();
+        if (_hooks[hook].approved) revert AlreadyRegistered(hook);
+
+        string memory name = IHook(hook).hookName();
+        _hooks[hook] = HookInfo({approved: true, name: name});
+        _hookAddresses.push(hook);
+
+        emit HookRegistered(hook, name);
+    }
+
+    /// @notice Deregister (revoke approval of) a hook.
+    /// @param  hook Hook contract address.
+    function deregisterHook(address hook) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (!_hooks[hook].approved) revert NotRegistered(hook);
+        _hooks[hook].approved = false;
+        emit HookDeregistered(hook);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Views
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Return true iff `hook` is currently approved.
+    /// @param  hook Hook address to query.
+    /// @return approved Whether the hook is approved.
+    function isApproved(address hook) external view returns (bool approved) {
+        approved = _hooks[hook].approved;
+    }
+
+    /// @notice Return the cached info for a hook.
+    /// @param  hook Hook address.
+    /// @return info HookInfo struct (approved + name).
+    function getHookInfo(address hook) external view returns (HookInfo memory info) {
+        info = _hooks[hook];
+    }
+
+    /// @notice Return all ever-registered hook addresses (including revoked ones).
+    ///         Callers should filter by `isApproved` to get only live hooks.
+    /// @return addresses Array of registered addresses.
+    function allHooks() external view returns (address[] memory addresses) {
+        addresses = _hookAddresses;
+    }
+}

--- a/contracts/evm/src/acp/IHook.sol
+++ b/contracts/evm/src/acp/IHook.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title IHook
+/// @notice Interface that all ACP v2 hooks must implement.
+/// @dev    Hooks are called by Job contracts at specific lifecycle points.
+///         A hook may revert to block the transition (blocking hook) or succeed
+///         to allow it (permissive hook).  The Job contract is responsible for
+///         deciding which hooks to invoke and in what order.
+///
+///         Hook call context is passed as an abi-encoded `bytes` blob to allow
+///         each hook to decode exactly what it needs without requiring the Job
+///         contract to know the hook's internal ABI.
+interface IHook {
+    // ─────────────────────────────────────────────────────────────
+    // Lifecycle points
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Called when an agent accepts a job. Transitions Open → Active.
+    /// @param jobId   The job identifier.
+    /// @param context ABI-encoded context specific to this hook type.
+    function onAccept(uint256 jobId, bytes calldata context) external;
+
+    /// @notice Called when an agent submits a result. Transitions Active → Review.
+    /// @param jobId   The job identifier.
+    /// @param context ABI-encoded context specific to this hook type.
+    function onSubmit(uint256 jobId, bytes calldata context) external;
+
+    /// @notice Called when a result is approved (by evaluator or principal).
+    ///         Transitions Review → Completed.
+    /// @param jobId   The job identifier.
+    /// @param context ABI-encoded context specific to this hook type.
+    function onApprove(uint256 jobId, bytes calldata context) external;
+
+    /// @notice Called when a result is rejected by the evaluator.
+    ///         Transitions Review → Active (agent may resubmit).
+    /// @param jobId   The job identifier.
+    /// @param context ABI-encoded context specific to this hook type.
+    function onReject(uint256 jobId, bytes calldata context) external;
+
+    /// @notice Called when a job is cancelled by the principal or via expiry.
+    /// @param jobId   The job identifier.
+    /// @param context ABI-encoded context specific to this hook type.
+    function onCancel(uint256 jobId, bytes calldata context) external;
+
+    /// @notice Returns a human-readable name for this hook (used off-chain for UX).
+    /// @return name Hook name, e.g. "FundTransferHook".
+    function hookName() external view returns (string memory name);
+}

--- a/contracts/evm/test/acp/HookRegistry.t.sol
+++ b/contracts/evm/test/acp/HookRegistry.t.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {HookRegistry} from "../../src/acp/HookRegistry.sol";
+import {IHook} from "../../src/acp/IHook.sol";
+
+/// @dev Minimal hook stub implementing IHook.
+contract MockHook is IHook {
+    string private _name;
+
+    constructor(string memory name_) {
+        _name = name_;
+    }
+
+    function onAccept(uint256, bytes calldata) external pure override {}
+    function onSubmit(uint256, bytes calldata) external pure override {}
+    function onApprove(uint256, bytes calldata) external pure override {}
+    function onReject(uint256, bytes calldata) external pure override {}
+    function onCancel(uint256, bytes calldata) external pure override {}
+
+    function hookName() external view override returns (string memory) {
+        return _name;
+    }
+}
+
+contract HookRegistryTest is Test {
+    HookRegistry internal registry;
+    MockHook internal hookA;
+    MockHook internal hookB;
+
+    address internal admin = makeAddr("admin");
+    address internal stranger = makeAddr("stranger");
+
+    event HookRegistered(address indexed hook, string name);
+    event HookDeregistered(address indexed hook);
+
+    function setUp() public {
+        registry = new HookRegistry(admin);
+        hookA = new MockHook("FundTransferHook");
+        hookB = new MockHook("MilestoneHook");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
+
+    function test_constructor_revert_zeroAdmin() public {
+        vm.expectRevert(HookRegistry.ZeroAddress.selector);
+        new HookRegistry(address(0));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // registerHook
+    // ─────────────────────────────────────────────────────────────
+
+    function test_registerHook_success() public {
+        vm.expectEmit(true, false, false, true);
+        emit HookRegistered(address(hookA), "FundTransferHook");
+
+        vm.prank(admin);
+        registry.registerHook(address(hookA));
+
+        assertTrue(registry.isApproved(address(hookA)));
+        HookRegistry.HookInfo memory info = registry.getHookInfo(address(hookA));
+        assertEq(info.name, "FundTransferHook");
+        assertTrue(info.approved);
+    }
+
+    function test_registerHook_multipleHooks() public {
+        vm.prank(admin);
+        registry.registerHook(address(hookA));
+        vm.prank(admin);
+        registry.registerHook(address(hookB));
+
+        address[] memory hooks = registry.allHooks();
+        assertEq(hooks.length, 2);
+        assertEq(hooks[0], address(hookA));
+        assertEq(hooks[1], address(hookB));
+    }
+
+    function test_registerHook_revert_notAdmin() public {
+        vm.expectRevert();
+        vm.prank(stranger);
+        registry.registerHook(address(hookA));
+    }
+
+    function test_registerHook_revert_zeroAddress() public {
+        vm.expectRevert(HookRegistry.ZeroAddress.selector);
+        vm.prank(admin);
+        registry.registerHook(address(0));
+    }
+
+    function test_registerHook_revert_alreadyRegistered() public {
+        vm.prank(admin);
+        registry.registerHook(address(hookA));
+
+        vm.expectRevert(abi.encodeWithSelector(HookRegistry.AlreadyRegistered.selector, address(hookA)));
+        vm.prank(admin);
+        registry.registerHook(address(hookA));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // deregisterHook
+    // ─────────────────────────────────────────────────────────────
+
+    function test_deregisterHook_success() public {
+        vm.prank(admin);
+        registry.registerHook(address(hookA));
+
+        vm.expectEmit(true, false, false, false);
+        emit HookDeregistered(address(hookA));
+
+        vm.prank(admin);
+        registry.deregisterHook(address(hookA));
+
+        assertFalse(registry.isApproved(address(hookA)));
+        // Name is retained
+        HookRegistry.HookInfo memory info = registry.getHookInfo(address(hookA));
+        assertEq(info.name, "FundTransferHook");
+        assertFalse(info.approved);
+    }
+
+    function test_deregisterHook_revert_notRegistered() public {
+        vm.expectRevert(abi.encodeWithSelector(HookRegistry.NotRegistered.selector, address(hookA)));
+        vm.prank(admin);
+        registry.deregisterHook(address(hookA));
+    }
+
+    function test_deregisterHook_revert_alreadyRevoked() public {
+        vm.prank(admin);
+        registry.registerHook(address(hookA));
+        vm.prank(admin);
+        registry.deregisterHook(address(hookA));
+
+        vm.expectRevert(abi.encodeWithSelector(HookRegistry.NotRegistered.selector, address(hookA)));
+        vm.prank(admin);
+        registry.deregisterHook(address(hookA));
+    }
+
+    function test_deregisterHook_revert_notAdmin() public {
+        vm.prank(admin);
+        registry.registerHook(address(hookA));
+
+        vm.expectRevert();
+        vm.prank(stranger);
+        registry.deregisterHook(address(hookA));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // View: allHooks includes deregistered
+    // ─────────────────────────────────────────────────────────────
+
+    function test_allHooks_includesRevoked() public {
+        vm.prank(admin);
+        registry.registerHook(address(hookA));
+        vm.prank(admin);
+        registry.registerHook(address(hookB));
+        vm.prank(admin);
+        registry.deregisterHook(address(hookA));
+
+        address[] memory hooks = registry.allHooks();
+        assertEq(hooks.length, 2); // both still listed
+        assertFalse(registry.isApproved(hooks[0]));
+        assertTrue(registry.isApproved(hooks[1]));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // isApproved returns false for unknown hook
+    // ─────────────────────────────────────────────────────────────
+
+    function test_isApproved_unknownHook() public {
+        address unknown = makeAddr("unknown");
+        assertFalse(registry.isApproved(unknown));
+    }
+}


### PR DESCRIPTION
Phase \`hook-registry\` of \`M3 — acp v2 contracts e2e on base sepolia\`.

closes #59

Verification: \`.claude/cron/last-verify-M3-hook-registry.log\`

## Changes
- `contracts/evm/src/acp/IHook.sol` — interface with 5 lifecycle hooks (onAccept/onSubmit/onApprove/onReject/onCancel) + hookName()
- `contracts/evm/src/acp/HookRegistry.sol` — whitelist registry:
  - registerHook calls hookName() to cache name at registration time
  - deregisterHook revokes approval but retains name
  - allHooks() returns full history; callers filter by isApproved
- `contracts/evm/test/acp/HookRegistry.t.sol` — 12 tests

## Verify
- forge build: green
- forge test (12/12 pass)
- slither: 0 findings