### PR TITLE
phase(M3/permit2-fund): acp v2 contracts e2e on base sepolia

### DIFF
--- a/contracts/evm/src/acp/Escrow.sol
+++ b/contracts/evm/src/acp/Escrow.sol
@@ -32,9 +32,7 @@ contract Escrow is AccessControl, ReentrancyGuard {
     mapping(address => mapping(uint256 => mapping(address => uint256))) public balances;
 
     event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
-    event Released(
-        address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount
-    );
+    event Released(address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount);
     event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
 
     error ZeroAddress();
@@ -129,11 +127,7 @@ contract Escrow is AccessControl, ReentrancyGuard {
     /// @param depositor Owner of the escrowed balance.
     /// @param jobId Job identifier.
     /// @param token ERC-20 token address.
-    function refund(address depositor, uint256 jobId, address token)
-        external
-        nonReentrant
-        onlyRole(RELEASER_ROLE)
-    {
+    function refund(address depositor, uint256 jobId, address token) external nonReentrant onlyRole(RELEASER_ROLE) {
         uint256 bal = balances[depositor][jobId][token];
         if (bal == 0) revert InsufficientBalance(0, 1);
         balances[depositor][jobId][token] = 0;

--- a/contracts/evm/src/acp/Escrow.sol
+++ b/contracts/evm/src/acp/Escrow.sol
@@ -5,66 +5,37 @@ import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IPermit2} from "./IPermit2.sol";
 
 /// @title Escrow
-/// @notice Multi-token escrow with atomic multi-recipient release.
-/// @dev    Design decisions:
-///           - Each escrow entry is identified by a (depositor, jobId) pair.  The jobId
-///             is an opaque uint256 supplied by the caller (typically the JobFactory
-///             counter); it need not be unique across depositors.
-///           - Funds are held in this contract; individual balances are tracked per
-///             (depositor, jobId, token) to allow multiple tokens per job.
-///           - `release` atomically transfers to N recipients in a single call.
-///           - `refund` returns all tokens to the depositor (dispute resolved in
-///             depositor's favour, or admin override).
-///           - RELEASER_ROLE: addresses allowed to call `release` and `refund`
-///             (typically the Job contract or an arbiter).
-///           - ADMIN_ROLE: can grant/revoke roles, emergency-pause.
-///
-///         CEI: all storage writes happen before external SafeERC20 transfers.
-///         ReentrancyGuard on `fund`, `release`, `refund`.
+/// @notice Multi-token escrow with atomic multi-recipient release and Permit2 support.
+/// @dev    Funds are held in this contract; balances tracked per (depositor, jobId, token).
+///         `release` atomically transfers to N recipients.
+///         `fundWithPermit2` allows gasless ERC-20 approval via Permit2 EIP-712 signature.
+///         RELEASER_ROLE: addresses allowed to call `release` and `refund`.
+///         CEI: all storage writes before external SafeERC20/Permit2 transfers.
+///         ReentrancyGuard on `fund`, `fundWithPermit2`, `release`, `refund`.
 contract Escrow is AccessControl, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    // ─────────────────────────────────────────────────────────────
-    // Roles
-    // ─────────────────────────────────────────────────────────────
-
     bytes32 public constant RELEASER_ROLE = keccak256("RELEASER_ROLE");
 
-    // ─────────────────────────────────────────────────────────────
-    // Types
-    // ─────────────────────────────────────────────────────────────
+    /// @notice Canonical Permit2 contract (immutable).
+    IPermit2 public immutable permit2;
 
-    /// @notice A single recipient in a multi-recipient release.
     struct Recipient {
         address to;
         uint256 amount;
     }
 
-    // ─────────────────────────────────────────────────────────────
-    // Storage
-    // ─────────────────────────────────────────────────────────────
-
     /// @notice depositor => jobId => token => escrowed balance.
     mapping(address => mapping(uint256 => mapping(address => uint256))) public balances;
 
-    // ─────────────────────────────────────────────────────────────
-    // Events
-    // ─────────────────────────────────────────────────────────────
-
-    /// @notice Emitted when tokens are deposited into escrow.
     event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
-
-    /// @notice Emitted for each recipient in an atomic release.
-    event Released(address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount);
-
-    /// @notice Emitted when the full balance is refunded to the depositor.
+    event Released(
+        address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount
+    );
     event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
-
-    // ─────────────────────────────────────────────────────────────
-    // Errors
-    // ─────────────────────────────────────────────────────────────
 
     error ZeroAddress();
     error ZeroAmount();
@@ -74,111 +45,107 @@ contract Escrow is AccessControl, ReentrancyGuard {
     error RecipientZeroAmount(uint256 index);
     error SumExceedsBalance(uint256 sum, uint256 balance);
 
-    // ─────────────────────────────────────────────────────────────
-    // Constructor
-    // ─────────────────────────────────────────────────────────────
-
-    /// @param admin Address granted DEFAULT_ADMIN_ROLE and RELEASER_ROLE on deployment.
-    constructor(address admin) {
+    /// @param admin    Address granted DEFAULT_ADMIN_ROLE and RELEASER_ROLE.
+    /// @param _permit2 Permit2 contract address (canonical: 0x000000000022D473030F116dDEE9F6B43aC78BA3).
+    constructor(address admin, address _permit2) {
         if (admin == address(0)) revert ZeroAddress();
+        if (_permit2 == address(0)) revert ZeroAddress();
+        permit2 = IPermit2(_permit2);
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(RELEASER_ROLE, admin);
     }
 
-    // ─────────────────────────────────────────────────────────────
-    // Fund
-    // ─────────────────────────────────────────────────────────────
-
-    /// @notice Deposit `amount` of `token` into escrow for a specific job.
-    /// @dev    Caller must have approved this contract for at least `amount` of `token`.
-    /// @param  depositor Address whose balance increases (usually msg.sender; can be different
-    ///                   for forwarded deposits, e.g. from JobFactory on behalf of principal).
-    /// @param  jobId     Opaque identifier tying this deposit to a specific job.
-    /// @param  token     ERC-20 token address.
-    /// @param  amount    Amount to deposit (must be > 0).
+    /// @notice Deposit via standard ERC-20 approve+transferFrom.
+    /// @param depositor Address whose balance increases.
+    /// @param jobId Opaque job identifier.
+    /// @param token ERC-20 token address.
+    /// @param amount Amount to deposit (must be > 0).
     function fund(address depositor, uint256 jobId, address token, uint256 amount) external nonReentrant {
         if (depositor == address(0)) revert ZeroAddress();
         if (token == address(0)) revert ZeroAddress();
         if (amount == 0) revert ZeroAmount();
-
-        // Effects
         balances[depositor][jobId][token] += amount;
-
         emit Funded(depositor, jobId, token, amount);
-
-        // Interaction (after state update)
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
     }
 
-    // ─────────────────────────────────────────────────────────────
-    // Release
-    // ─────────────────────────────────────────────────────────────
+    /// @notice Deposit via Permit2 signed transfer (no prior approve needed).
+    /// @param depositor Address whose balance increases (must be the Permit2 signer).
+    /// @param jobId Opaque job identifier.
+    /// @param token ERC-20 token address.
+    /// @param amount Amount to deposit (must be > 0).
+    /// @param permit Permit2 PermitTransferFrom struct.
+    /// @param signature EIP-712 signature by depositor over permit.
+    function fundWithPermit2(
+        address depositor,
+        uint256 jobId,
+        address token,
+        uint256 amount,
+        IPermit2.PermitTransferFrom calldata permit,
+        bytes calldata signature
+    ) external nonReentrant {
+        if (depositor == address(0)) revert ZeroAddress();
+        if (token == address(0)) revert ZeroAddress();
+        if (amount == 0) revert ZeroAmount();
+        // Effects before interaction (CEI)
+        balances[depositor][jobId][token] += amount;
+        emit Funded(depositor, jobId, token, amount);
+        // Interaction via Permit2
+        permit2.permitTransferFrom(
+            permit,
+            IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: amount}),
+            depositor,
+            signature
+        );
+    }
 
-    /// @notice Atomically release funds to multiple recipients in a single call.
-    /// @dev    The sum of all `recipient.amount` values must be <= the escrowed balance.
-    ///         Callers must hold RELEASER_ROLE.
-    /// @param  depositor  Owner of the escrowed balance.
-    /// @param  jobId      Job identifier.
-    /// @param  token      ERC-20 token address.
-    /// @param  recipients Array of (address, amount) pairs.  Must be non-empty.
+    /// @notice Atomically release funds to multiple recipients.
+    /// @param depositor Owner of the escrowed balance.
+    /// @param jobId Job identifier.
+    /// @param token ERC-20 token address.
+    /// @param recipients Array of (address, amount) pairs.
     function release(address depositor, uint256 jobId, address token, Recipient[] calldata recipients)
         external
         nonReentrant
         onlyRole(RELEASER_ROLE)
     {
         if (recipients.length == 0) revert EmptyRecipients();
-
         uint256 total = 0;
         for (uint256 i = 0; i < recipients.length; ++i) {
             if (recipients[i].to == address(0)) revert RecipientZeroAddress(i);
             if (recipients[i].amount == 0) revert RecipientZeroAmount(i);
             total += recipients[i].amount;
         }
-
         uint256 bal = balances[depositor][jobId][token];
         if (total > bal) revert SumExceedsBalance(total, bal);
-
-        // Effects — deduct full sum atomically before any transfer
         balances[depositor][jobId][token] = bal - total;
-
-        // Interactions
         for (uint256 i = 0; i < recipients.length; ++i) {
             emit Released(depositor, jobId, token, recipients[i].to, recipients[i].amount);
             IERC20(token).safeTransfer(recipients[i].to, recipients[i].amount);
         }
     }
 
-    // ─────────────────────────────────────────────────────────────
-    // Refund
-    // ─────────────────────────────────────────────────────────────
-
-    /// @notice Refund the entire escrowed balance for a job back to the depositor.
-    /// @dev    Callers must hold RELEASER_ROLE.
-    /// @param  depositor  Owner of the escrowed balance.
-    /// @param  jobId      Job identifier.
-    /// @param  token      ERC-20 token address.
-    function refund(address depositor, uint256 jobId, address token) external nonReentrant onlyRole(RELEASER_ROLE) {
+    /// @notice Refund entire escrowed balance back to depositor.
+    /// @param depositor Owner of the escrowed balance.
+    /// @param jobId Job identifier.
+    /// @param token ERC-20 token address.
+    function refund(address depositor, uint256 jobId, address token)
+        external
+        nonReentrant
+        onlyRole(RELEASER_ROLE)
+    {
         uint256 bal = balances[depositor][jobId][token];
         if (bal == 0) revert InsufficientBalance(0, 1);
-
-        // Effects
         balances[depositor][jobId][token] = 0;
-
         emit Refunded(depositor, jobId, token, bal);
-
-        // Interaction
         IERC20(token).safeTransfer(depositor, bal);
     }
 
-    // ─────────────────────────────────────────────────────────────
-    // Views
-    // ─────────────────────────────────────────────────────────────
-
     /// @notice Return the escrowed balance for a (depositor, jobId, token) triple.
-    /// @param  depositor Address of the depositor.
-    /// @param  jobId     Job identifier.
-    /// @param  token     ERC-20 token address.
-    /// @return balance   Current escrowed amount.
+    /// @param depositor Address of the depositor.
+    /// @param jobId Job identifier.
+    /// @param token ERC-20 token address.
+    /// @return balance Current escrowed amount.
     function getBalance(address depositor, uint256 jobId, address token) external view returns (uint256 balance) {
         balance = balances[depositor][jobId][token];
     }

--- a/contracts/evm/src/acp/IPermit2.sol
+++ b/contracts/evm/src/acp/IPermit2.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title IPermit2
+/// @notice Minimal Permit2 interface used by Escrow.fundWithPermit2.
+interface IPermit2 {
+    struct TokenPermissions {
+        address token;
+        uint256 amount;
+    }
+    struct PermitTransferFrom {
+        TokenPermissions permitted;
+        uint256 nonce;
+        uint256 deadline;
+    }
+    struct SignatureTransferDetails {
+        address to;
+        uint256 requestedAmount;
+    }
+    /// @notice Transfer tokens using a signed Permit2 message.
+    /// @param permit Permit data (token, amount, nonce, deadline).
+    /// @param transferDetails Transfer destination and amount.
+    /// @param owner The account whose tokens will be transferred.
+    /// @param signature EIP-712 signature over the permit.
+    function permitTransferFrom(
+        PermitTransferFrom calldata permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    ) external;
+}

--- a/contracts/evm/src/acp/IPermit2.sol
+++ b/contracts/evm/src/acp/IPermit2.sol
@@ -8,11 +8,13 @@ interface IPermit2 {
         address token;
         uint256 amount;
     }
+
     struct PermitTransferFrom {
         TokenPermissions permitted;
         uint256 nonce;
         uint256 deadline;
     }
+
     struct SignatureTransferDetails {
         address to;
         uint256 requestedAmount;

--- a/contracts/evm/test/acp/Escrow.t.sol
+++ b/contracts/evm/test/acp/Escrow.t.sol
@@ -33,7 +33,7 @@ contract EscrowTest is Test {
     event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
 
     function setUp() public {
-        escrow = new Escrow(admin);
+        escrow = new Escrow(admin, address(0x000000000022D473030F116dDEE9F6B43aC78BA3));
         tokenA = new MockERC20();
         tokenB = new MockERC20();
 

--- a/contracts/evm/test/acp/EscrowPermit2.t.sol
+++ b/contracts/evm/test/acp/EscrowPermit2.t.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Escrow} from "../../src/acp/Escrow.sol";
+import {IPermit2} from "../../src/acp/IPermit2.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Mock", "MCK") {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract MockPermit2 {
+    function permitTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+}
+
+contract EscrowPermit2Test is Test {
+    MockPermit2 internal mockPermit2;
+    Escrow internal escrow;
+    MockToken internal token;
+
+    address internal admin = makeAddr("admin");
+    address internal depositor = makeAddr("depositor");
+    address internal releaser = makeAddr("releaser");
+
+    uint256 internal constant AMOUNT = 500e18;
+    uint256 internal constant JOB_ID = 7;
+
+    event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount);
+
+    function setUp() public {
+        mockPermit2 = new MockPermit2();
+        escrow = new Escrow(admin, address(mockPermit2));
+        token = new MockToken();
+
+        bytes32 releaserRole = escrow.RELEASER_ROLE();
+        vm.prank(admin);
+        escrow.grantRole(releaserRole, releaser);
+
+        token.mint(depositor, AMOUNT * 10);
+        vm.prank(depositor);
+        token.approve(address(mockPermit2), type(uint256).max);
+    }
+
+    function test_constructor_setsPermit2() public view {
+        assertEq(address(escrow.permit2()), address(mockPermit2));
+    }
+
+    function test_fundWithPermit2_success() public {
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({token: address(token), amount: AMOUNT}),
+            nonce: 0,
+            deadline: block.timestamp + 1 hours
+        });
+        vm.expectEmit(true, true, true, true);
+        emit Funded(depositor, JOB_ID, address(token), AMOUNT);
+        escrow.fundWithPermit2(depositor, JOB_ID, address(token), AMOUNT, permit, hex"1234");
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(token)), AMOUNT);
+        assertEq(token.balanceOf(address(escrow)), AMOUNT);
+    }
+
+    function test_fundWithPermit2_revert_zeroDepositor() public {
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({token: address(token), amount: AMOUNT}),
+            nonce: 0,
+            deadline: block.timestamp + 1 hours
+        });
+        vm.expectRevert(Escrow.ZeroAddress.selector);
+        escrow.fundWithPermit2(address(0), JOB_ID, address(token), AMOUNT, permit, hex"");
+    }
+
+    function test_fundWithPermit2_revert_zeroToken() public {
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({token: address(0), amount: AMOUNT}),
+            nonce: 0,
+            deadline: block.timestamp + 1 hours
+        });
+        vm.expectRevert(Escrow.ZeroAddress.selector);
+        escrow.fundWithPermit2(depositor, JOB_ID, address(0), AMOUNT, permit, hex"");
+    }
+
+    function test_fundWithPermit2_revert_zeroAmount() public {
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({token: address(token), amount: 0}),
+            nonce: 0,
+            deadline: block.timestamp + 1 hours
+        });
+        vm.expectRevert(Escrow.ZeroAmount.selector);
+        escrow.fundWithPermit2(depositor, JOB_ID, address(token), 0, permit, hex"");
+    }
+
+    function test_fundWithPermit2_constructor_revert_zeroPermit2() public {
+        vm.expectRevert(Escrow.ZeroAddress.selector);
+        new Escrow(admin, address(0));
+    }
+
+    /// @notice Standard fund() still works after Permit2 constructor change.
+    function test_fund_standardPath_stillWorks() public {
+        token.mint(address(this), AMOUNT);
+        token.approve(address(escrow), AMOUNT);
+        escrow.fund(depositor, JOB_ID, address(token), AMOUNT);
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(token)), AMOUNT);
+    }
+
+    function testFuzz_fundWithPermit2_amounts(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        token.mint(depositor, amount);
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({token: address(token), amount: amount}),
+            nonce: 0,
+            deadline: block.timestamp + 1 hours
+        });
+        escrow.fundWithPermit2(depositor, JOB_ID, address(token), amount, permit, hex"1234");
+        assertGe(escrow.getBalance(depositor, JOB_ID, address(token)), amount);
+    }
+
+    function testFuzz_fundWithPermit2_and_release_invariant(uint256 amount) public {
+        amount = bound(amount, 1, type(uint128).max);
+        token.mint(depositor, amount);
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({token: address(token), amount: amount}),
+            nonce: 0,
+            deadline: block.timestamp + 1 hours
+        });
+        escrow.fundWithPermit2(depositor, JOB_ID, address(token), amount, permit, hex"1234");
+
+        address recipient = makeAddr("recv");
+        Escrow.Recipient[] memory recs = new Escrow.Recipient[](1);
+        recs[0] = Escrow.Recipient({to: recipient, amount: amount});
+        vm.prank(releaser);
+        escrow.release(depositor, JOB_ID, address(token), recs);
+
+        assertEq(token.balanceOf(recipient), amount);
+        assertEq(escrow.getBalance(depositor, JOB_ID, address(token)), 0);
+    }
+}

--- a/contracts/evm/test/acp/EscrowPermit2.t.sol
+++ b/contracts/evm/test/acp/EscrowPermit2.t.sol
@@ -8,7 +8,10 @@ import {IPermit2} from "../../src/acp/IPermit2.sol";
 
 contract MockToken is ERC20 {
     constructor() ERC20("Mock", "MCK") {}
-    function mint(address to, uint256 amount) external { _mint(to, amount); }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
 }
 
 contract MockPermit2 {


### PR DESCRIPTION
Phase \`permit2-fund\` of \`M3 — acp v2 contracts e2e on base sepolia\`.

closes #64

Verification: \`.claude/cron/last-verify-M3-permit2-fund.log\`

## Changes
- `contracts/evm/src/acp/IPermit2.sol` — minimal Permit2 interface (PermitTransferFrom + permitTransferFrom)
- `contracts/evm/src/acp/Escrow.sol` — added `fundWithPermit2`:
  - Constructor now takes `permit2` address (immutable)
  - `fundWithPermit2(depositor, jobId, token, amount, permit, signature)` — CEI: state write before Permit2 call
  - All existing `fund/release/refund` functionality preserved
- `contracts/evm/test/acp/EscrowPermit2.t.sol` — 9 tests with mock Permit2
  - Fuzz: deposit + release invariant via Permit2 path

## Verify
- forge build: green
- forge test (9/9 EscrowPermit2, 21/21 EscrowTest pass)
- slither: 0 findings