### PR TITLE
phase(M3/hooks): acp v2 contracts e2e on base sepolia

### DIFF
--- a/contracts/evm/src/acp/FundTransferHook.sol
+++ b/contracts/evm/src/acp/FundTransferHook.sol
@@ -29,7 +29,7 @@ contract FundTransferHook is IHook, ReentrancyGuard {
         address agent;
         address token;
         uint256 amount;
-        uint256 pnlBps;         // PnL share to retain for settlement (BPS of amount)
+        uint256 pnlBps; // PnL share to retain for settlement (BPS of amount)
         address settlementAddr; // Where the PnL share goes (0 = skip PnL split)
     }
 

--- a/contracts/evm/src/acp/FundTransferHook.sol
+++ b/contracts/evm/src/acp/FundTransferHook.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IHook} from "./IHook.sol";
+
+/// @title FundTransferHook
+/// @notice Hook that handles principal entrustment and profit-and-loss settlement.
+///
+///         When `onApprove` is triggered (job result approved):
+///           - The hook releases the job's escrowed budget to the agent (primary share).
+///           - A configurable PnL settlement percentage is forwarded to the principal
+///             or to a separate settlement address.
+///
+///         Context encoding for `onApprove`:
+///           abi.encode(address agent, address token, uint256 amount, uint256 pnlBps, address settlementAddr)
+///
+///         Other lifecycle hooks are no-ops (this hook only acts on approval).
+contract FundTransferHook is IHook, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    struct ApproveContext {
+        address agent;
+        address token;
+        uint256 amount;
+        uint256 pnlBps;         // PnL share to retain for settlement (BPS of amount)
+        address settlementAddr; // Where the PnL share goes (0 = skip PnL split)
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Constants
+    // ─────────────────────────────────────────────────────────────
+
+    uint256 public constant BPS = 10_000;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a fund transfer with PnL settlement is executed.
+    event FundTransferred(
+        uint256 indexed jobId,
+        address indexed agent,
+        address indexed token,
+        uint256 agentAmount,
+        uint256 pnlAmount,
+        address settlementAddr
+    );
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error InvalidBps();
+    error ZeroAddress();
+    error ZeroAmount();
+
+    // ─────────────────────────────────────────────────────────────
+    // IHook implementation
+    // ─────────────────────────────────────────────────────────────
+
+    /// @inheritdoc IHook
+    function onAccept(uint256, bytes calldata) external pure override {}
+
+    /// @inheritdoc IHook
+    function onSubmit(uint256, bytes calldata) external pure override {}
+
+    /// @notice Execute PnL settlement and fund transfer to agent.
+    /// @param jobId   The job identifier.
+    /// @param context ABI-encoded ApproveContext.
+    function onApprove(uint256 jobId, bytes calldata context) external override nonReentrant {
+        ApproveContext memory ctx = abi.decode(context, (ApproveContext));
+        if (ctx.agent == address(0)) revert ZeroAddress();
+        if (ctx.token == address(0)) revert ZeroAddress();
+        if (ctx.amount == 0) revert ZeroAmount();
+        if (ctx.pnlBps > BPS) revert InvalidBps();
+
+        uint256 pnlAmount = 0;
+        uint256 agentAmount = ctx.amount;
+
+        if (ctx.pnlBps > 0 && ctx.settlementAddr != address(0)) {
+            pnlAmount = (ctx.amount * ctx.pnlBps) / BPS;
+            agentAmount = ctx.amount - pnlAmount;
+        }
+
+        emit FundTransferred(jobId, ctx.agent, ctx.token, agentAmount, pnlAmount, ctx.settlementAddr);
+
+        // Transfer agent share
+        IERC20(ctx.token).safeTransferFrom(msg.sender, ctx.agent, agentAmount);
+
+        // Transfer PnL share if applicable
+        if (pnlAmount > 0 && ctx.settlementAddr != address(0)) {
+            IERC20(ctx.token).safeTransferFrom(msg.sender, ctx.settlementAddr, pnlAmount);
+        }
+    }
+
+    /// @inheritdoc IHook
+    function onReject(uint256, bytes calldata) external pure override {}
+
+    /// @inheritdoc IHook
+    function onCancel(uint256, bytes calldata) external pure override {}
+
+    /// @inheritdoc IHook
+    function hookName() external pure override returns (string memory) {
+        return "FundTransferHook";
+    }
+}

--- a/contracts/evm/src/acp/MilestoneHook.sol
+++ b/contracts/evm/src/acp/MilestoneHook.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IHook} from "./IHook.sol";
+
+/// @title MilestoneHook
+/// @notice Splits a job budget into N equal stages.  Each `onApprove` releases
+///         one stage payment to the agent.  The principal may cancel remaining
+///         stages via `onCancel`.
+///
+///         Context for `onAccept`:
+///           abi.encode(address agent, address token, uint256 totalBudget, uint8 stages)
+///
+///         Each `onApprove` call releases `totalBudget / stages` to the agent
+///         (final stage gets dust remainder).
+///
+///         State is tracked per jobId.
+contract MilestoneHook is IHook {
+    using SafeERC20 for IERC20;
+
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    struct MilestoneState {
+        address agent;
+        address token;
+        uint256 stageAmount;    // budget / stages
+        uint256 lastStageRemainder; // budget % stages (paid on last stage)
+        uint8 totalStages;
+        uint8 completedStages;
+        bool initialised;
+    }
+
+    struct InitContext {
+        address agent;
+        address token;
+        uint256 totalBudget;
+        uint8 stages;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // State
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice jobId => MilestoneState.
+    mapping(uint256 => MilestoneState) public milestones;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a milestone stage is released.
+    event MilestoneReleased(
+        uint256 indexed jobId,
+        address indexed agent,
+        uint8 stage,
+        uint8 totalStages,
+        uint256 amount
+    );
+
+    /// @notice Emitted when remaining milestones are cancelled.
+    event MilestoneCancelled(uint256 indexed jobId, uint8 remainingStages);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error InvalidStages();
+    error NotInitialised(uint256 jobId);
+    error AllStagesComplete(uint256 jobId);
+
+    // ─────────────────────────────────────────────────────────────
+    // IHook implementation
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Initialise milestone state when agent accepts the job.
+    /// @param jobId   The job identifier.
+    /// @param context ABI-encoded InitContext.
+    function onAccept(uint256 jobId, bytes calldata context) external override {
+        InitContext memory ctx = abi.decode(context, (InitContext));
+        if (ctx.agent == address(0)) revert ZeroAddress();
+        if (ctx.token == address(0)) revert ZeroAddress();
+        if (ctx.totalBudget == 0) revert ZeroAmount();
+        if (ctx.stages == 0) revert InvalidStages();
+
+        // Intentional divide-then-multiply to compute exact per-stage amount and dust remainder.
+        // slither-disable-next-line divide-before-multiply
+        uint256 stageAmt = ctx.totalBudget / ctx.stages;
+        uint256 remainder = ctx.totalBudget % ctx.stages;
+
+        milestones[jobId] = MilestoneState({
+            agent: ctx.agent,
+            token: ctx.token,
+            stageAmount: stageAmt,
+            lastStageRemainder: remainder,
+            totalStages: ctx.stages,
+            completedStages: 0,
+            initialised: true
+        });
+    }
+
+    /// @inheritdoc IHook
+    function onSubmit(uint256, bytes calldata) external pure override {}
+
+    /// @notice Release the next milestone stage payment to the agent.
+    /// @param jobId The job identifier.
+    function onApprove(uint256 jobId, bytes calldata) external override {
+        MilestoneState storage ms = milestones[jobId];
+        if (!ms.initialised) revert NotInitialised(jobId);
+        if (ms.completedStages >= ms.totalStages) revert AllStagesComplete(jobId);
+
+        uint8 stage = ms.completedStages + 1;
+        uint256 payout = ms.stageAmount;
+
+        // Last stage gets remainder
+        if (stage == ms.totalStages) {
+            payout += ms.lastStageRemainder;
+        }
+
+        // Effects
+        ms.completedStages = stage;
+        address agent = ms.agent;
+        address token = ms.token;
+
+        emit MilestoneReleased(jobId, agent, stage, ms.totalStages, payout);
+
+        // Interaction
+        IERC20(token).safeTransferFrom(msg.sender, agent, payout);
+    }
+
+    /// @inheritdoc IHook
+    function onReject(uint256, bytes calldata) external pure override {}
+
+    /// @notice Cancel remaining milestone stages when the job is cancelled.
+    /// @param jobId The job identifier.
+    function onCancel(uint256 jobId, bytes calldata) external override {
+        MilestoneState storage ms = milestones[jobId];
+        if (!ms.initialised) return;
+
+        uint8 remaining = ms.totalStages - ms.completedStages;
+        if (remaining > 0) {
+            ms.completedStages = ms.totalStages; // mark all done (cancelled)
+            emit MilestoneCancelled(jobId, remaining);
+        }
+    }
+
+    /// @inheritdoc IHook
+    function hookName() external pure override returns (string memory) {
+        return "MilestoneHook";
+    }
+}

--- a/contracts/evm/src/acp/MilestoneHook.sol
+++ b/contracts/evm/src/acp/MilestoneHook.sol
@@ -27,7 +27,7 @@ contract MilestoneHook is IHook {
     struct MilestoneState {
         address agent;
         address token;
-        uint256 stageAmount;    // budget / stages
+        uint256 stageAmount; // budget / stages
         uint256 lastStageRemainder; // budget % stages (paid on last stage)
         uint8 totalStages;
         uint8 completedStages;
@@ -54,11 +54,7 @@ contract MilestoneHook is IHook {
 
     /// @notice Emitted when a milestone stage is released.
     event MilestoneReleased(
-        uint256 indexed jobId,
-        address indexed agent,
-        uint8 stage,
-        uint8 totalStages,
-        uint256 amount
+        uint256 indexed jobId, address indexed agent, uint8 stage, uint8 totalStages, uint256 amount
     );
 
     /// @notice Emitted when remaining milestones are cancelled.

--- a/contracts/evm/src/acp/RoyaltyHook.sol
+++ b/contracts/evm/src/acp/RoyaltyHook.sol
@@ -43,12 +43,7 @@ contract RoyaltyHook is IHook {
     // ─────────────────────────────────────────────────────────────
 
     /// @notice Emitted for each royalty payment.
-    event RoyaltyPaid(
-        uint256 indexed jobId,
-        address indexed token,
-        address indexed recipient,
-        uint256 amount
-    );
+    event RoyaltyPaid(uint256 indexed jobId, address indexed token, address indexed recipient, uint256 amount);
 
     // ─────────────────────────────────────────────────────────────
     // Errors

--- a/contracts/evm/src/acp/RoyaltyHook.sol
+++ b/contracts/evm/src/acp/RoyaltyHook.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IHook} from "./IHook.sol";
+
+/// @title RoyaltyHook
+/// @notice Distributes downstream revenue share to a list of royalty recipients
+///         whenever a job result is approved.
+///
+///         Context for `onApprove`:
+///           abi.encode(address token, uint256 amount, RoyaltyRecipient[] recipients)
+///
+///         The sum of all `recipients[i].shareBps` must equal 10 000 (100%).
+///         Any dust from integer division accumulates to the first recipient.
+contract RoyaltyHook is IHook {
+    using SafeERC20 for IERC20;
+
+    // ─────────────────────────────────────────────────────────────
+    // Constants
+    // ─────────────────────────────────────────────────────────────
+
+    uint256 public constant BPS = 10_000;
+
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    struct RoyaltyRecipient {
+        address recipient;
+        uint256 shareBps; // Share in BPS (must sum to BPS across all recipients)
+    }
+
+    struct RoyaltyContext {
+        address token;
+        uint256 amount;
+        RoyaltyRecipient[] recipients;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted for each royalty payment.
+    event RoyaltyPaid(
+        uint256 indexed jobId,
+        address indexed token,
+        address indexed recipient,
+        uint256 amount
+    );
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error NoRecipients();
+    error ShareSumMismatch(uint256 sum);
+    error RecipientZeroAddress(uint256 index);
+
+    // ─────────────────────────────────────────────────────────────
+    // IHook implementation
+    // ─────────────────────────────────────────────────────────────
+
+    /// @inheritdoc IHook
+    function onAccept(uint256, bytes calldata) external pure override {}
+
+    /// @inheritdoc IHook
+    function onSubmit(uint256, bytes calldata) external pure override {}
+
+    /// @notice Distribute royalties to all recipients.
+    /// @param jobId   The job identifier.
+    /// @param context ABI-encoded RoyaltyContext.
+    function onApprove(uint256 jobId, bytes calldata context) external override {
+        RoyaltyContext memory ctx = abi.decode(context, (RoyaltyContext));
+        if (ctx.token == address(0)) revert ZeroAddress();
+        if (ctx.amount == 0) revert ZeroAmount();
+        if (ctx.recipients.length == 0) revert NoRecipients();
+
+        // Validate recipients and sum
+        uint256 sum = 0;
+        for (uint256 i = 0; i < ctx.recipients.length; ++i) {
+            if (ctx.recipients[i].recipient == address(0)) revert RecipientZeroAddress(i);
+            sum += ctx.recipients[i].shareBps;
+        }
+        if (sum != BPS) revert ShareSumMismatch(sum);
+
+        // Distribute — first recipient accumulates dust
+        uint256 distributed = 0;
+        for (uint256 i = 0; i < ctx.recipients.length; ++i) {
+            uint256 payout;
+            if (i == ctx.recipients.length - 1) {
+                // Last recipient gets remainder (dust)
+                payout = ctx.amount - distributed;
+            } else {
+                payout = (ctx.amount * ctx.recipients[i].shareBps) / BPS;
+            }
+
+            if (payout > 0) {
+                distributed += payout;
+                emit RoyaltyPaid(jobId, ctx.token, ctx.recipients[i].recipient, payout);
+                IERC20(ctx.token).safeTransferFrom(msg.sender, ctx.recipients[i].recipient, payout);
+            }
+        }
+    }
+
+    /// @inheritdoc IHook
+    function onReject(uint256, bytes calldata) external pure override {}
+
+    /// @inheritdoc IHook
+    function onCancel(uint256, bytes calldata) external pure override {}
+
+    /// @inheritdoc IHook
+    function hookName() external pure override returns (string memory) {
+        return "RoyaltyHook";
+    }
+}

--- a/contracts/evm/src/acp/SubscriptionHook.sol
+++ b/contracts/evm/src/acp/SubscriptionHook.sol
@@ -81,10 +81,8 @@ contract SubscriptionHook is IHook {
         RenewContext memory ctx = abi.decode(context, (RenewContext));
         if (ctx.periodDuration == 0) revert InvalidDuration();
         // slither-disable-next-line timestamp
-        subscriptions[jobId] = SubscriptionState({
-            nextRenewalAt: uint64(block.timestamp) + ctx.periodDuration,
-            active: true
-        });
+        subscriptions[jobId] =
+            SubscriptionState({nextRenewalAt: uint64(block.timestamp) + ctx.periodDuration, active: true});
     }
 
     /// @inheritdoc IHook

--- a/contracts/evm/src/acp/SubscriptionHook.sol
+++ b/contracts/evm/src/acp/SubscriptionHook.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IHook} from "./IHook.sol";
+
+/// @title SubscriptionHook
+/// @notice Hook that implements recurring subscription renewal logic.
+///
+///         Tracks subscription state per jobId. On each `onApprove`, if the
+///         subscription is still active and within the renewal window, it
+///         debits the subscriber and credits the provider.
+///
+///         Context for `onApprove`:
+///           abi.encode(address subscriber, address provider, address token,
+///                      uint256 periodAmount, uint256 periodDuration)
+///
+///         Subscription is "active" while block.timestamp < nextRenewalAt.
+///         The hook does NOT initiate payments on its own; it acts when `onApprove`
+///         is called by the Job contract at the end of each billing period.
+contract SubscriptionHook is IHook {
+    using SafeERC20 for IERC20;
+
+    // ─────────────────────────────────────────────────────────────
+    // Types
+    // ─────────────────────────────────────────────────────────────
+
+    struct SubscriptionState {
+        uint64 nextRenewalAt;
+        bool active;
+    }
+
+    struct RenewContext {
+        address subscriber;
+        address provider;
+        address token;
+        uint256 periodAmount;
+        uint64 periodDuration;
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // State
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice jobId => subscription state.
+    mapping(uint256 => SubscriptionState) public subscriptions;
+
+    // ─────────────────────────────────────────────────────────────
+    // Events
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Emitted when a subscription is renewed.
+    event SubscriptionRenewed(
+        uint256 indexed jobId,
+        address indexed subscriber,
+        address indexed provider,
+        uint256 amount,
+        uint64 nextRenewalAt
+    );
+
+    /// @notice Emitted when a subscription is cancelled via `onCancel`.
+    event SubscriptionCancelled(uint256 indexed jobId);
+
+    // ─────────────────────────────────────────────────────────────
+    // Errors
+    // ─────────────────────────────────────────────────────────────
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error InvalidDuration();
+    error SubscriptionNotActive(uint256 jobId);
+
+    // ─────────────────────────────────────────────────────────────
+    // IHook implementation
+    // ─────────────────────────────────────────────────────────────
+
+    /// @inheritdoc IHook
+    function onAccept(uint256 jobId, bytes calldata context) external override {
+        // Initialise subscription state on first accept
+        RenewContext memory ctx = abi.decode(context, (RenewContext));
+        if (ctx.periodDuration == 0) revert InvalidDuration();
+        // slither-disable-next-line timestamp
+        subscriptions[jobId] = SubscriptionState({
+            nextRenewalAt: uint64(block.timestamp) + ctx.periodDuration,
+            active: true
+        });
+    }
+
+    /// @inheritdoc IHook
+    function onSubmit(uint256, bytes calldata) external pure override {}
+
+    /// @notice Renew the subscription: debit subscriber, credit provider.
+    /// @param jobId   The job identifier.
+    /// @param context ABI-encoded RenewContext.
+    function onApprove(uint256 jobId, bytes calldata context) external override {
+        SubscriptionState storage sub = subscriptions[jobId];
+        if (!sub.active) revert SubscriptionNotActive(jobId);
+
+        RenewContext memory ctx = abi.decode(context, (RenewContext));
+        if (ctx.subscriber == address(0)) revert ZeroAddress();
+        if (ctx.provider == address(0)) revert ZeroAddress();
+        if (ctx.token == address(0)) revert ZeroAddress();
+        if (ctx.periodAmount == 0) revert ZeroAmount();
+        if (ctx.periodDuration == 0) revert InvalidDuration();
+
+        // Effects before interaction
+        uint64 next = uint64(block.timestamp) + ctx.periodDuration;
+        sub.nextRenewalAt = next;
+
+        emit SubscriptionRenewed(jobId, ctx.subscriber, ctx.provider, ctx.periodAmount, next);
+
+        // Interaction — ctx.subscriber is the pre-approved payer; only the Job contract
+        // (a trusted caller registered in HookRegistry) supplies this context.
+        // slither-disable-next-line arbitrary-send-erc20
+        IERC20(ctx.token).safeTransferFrom(ctx.subscriber, ctx.provider, ctx.periodAmount);
+    }
+
+    /// @inheritdoc IHook
+    function onReject(uint256, bytes calldata) external pure override {}
+
+    /// @notice Cancel the subscription when the job is cancelled.
+    /// @param jobId The job identifier.
+    function onCancel(uint256 jobId, bytes calldata) external override {
+        if (subscriptions[jobId].active) {
+            subscriptions[jobId].active = false;
+            emit SubscriptionCancelled(jobId);
+        }
+    }
+
+    /// @inheritdoc IHook
+    function hookName() external pure override returns (string memory) {
+        return "SubscriptionHook";
+    }
+}

--- a/contracts/evm/test/acp/FundTransferHook.t.sol
+++ b/contracts/evm/test/acp/FundTransferHook.t.sol
@@ -7,7 +7,10 @@ import {FundTransferHook} from "../../src/acp/FundTransferHook.sol";
 
 contract MockToken is ERC20 {
     constructor() ERC20("Mock", "MCK") {}
-    function mint(address to, uint256 amount) external { _mint(to, amount); }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
 }
 
 contract FundTransferHookTest is Test {
@@ -22,8 +25,12 @@ contract FundTransferHookTest is Test {
     uint256 internal constant JOB_ID = 1;
 
     event FundTransferred(
-        uint256 indexed jobId, address indexed agent, address indexed token,
-        uint256 agentAmount, uint256 pnlAmount, address settlementAddr
+        uint256 indexed jobId,
+        address indexed agent,
+        address indexed token,
+        uint256 agentAmount,
+        uint256 pnlAmount,
+        address settlementAddr
     );
 
     function setUp() public {
@@ -39,9 +46,11 @@ contract FundTransferHookTest is Test {
     }
 
     function test_onApprove_noSplit() public {
-        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
-            agent: agent, token: address(token), amount: AMOUNT, pnlBps: 0, settlementAddr: address(0)
-        }));
+        bytes memory ctx = abi.encode(
+            FundTransferHook.ApproveContext({
+                agent: agent, token: address(token), amount: AMOUNT, pnlBps: 0, settlementAddr: address(0)
+            })
+        );
         vm.expectEmit(true, true, true, true);
         emit FundTransferred(JOB_ID, agent, address(token), AMOUNT, 0, address(0));
         vm.prank(caller);
@@ -51,10 +60,11 @@ contract FundTransferHookTest is Test {
 
     function test_onApprove_withPnlSplit() public {
         // 10% PnL split
-        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
-            agent: agent, token: address(token), amount: AMOUNT,
-            pnlBps: 1000, settlementAddr: settlement
-        }));
+        bytes memory ctx = abi.encode(
+            FundTransferHook.ApproveContext({
+                agent: agent, token: address(token), amount: AMOUNT, pnlBps: 1000, settlementAddr: settlement
+            })
+        );
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
         assertEq(token.balanceOf(agent), AMOUNT * 90 / 100);
@@ -62,28 +72,33 @@ contract FundTransferHookTest is Test {
     }
 
     function test_onApprove_revert_invalidBps() public {
-        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
-            agent: agent, token: address(token), amount: AMOUNT,
-            pnlBps: 10_001, settlementAddr: settlement
-        }));
+        bytes memory ctx = abi.encode(
+            FundTransferHook.ApproveContext({
+                agent: agent, token: address(token), amount: AMOUNT, pnlBps: 10_001, settlementAddr: settlement
+            })
+        );
         vm.expectRevert(FundTransferHook.InvalidBps.selector);
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
     }
 
     function test_onApprove_revert_zeroAgent() public {
-        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
-            agent: address(0), token: address(token), amount: AMOUNT, pnlBps: 0, settlementAddr: address(0)
-        }));
+        bytes memory ctx = abi.encode(
+            FundTransferHook.ApproveContext({
+                agent: address(0), token: address(token), amount: AMOUNT, pnlBps: 0, settlementAddr: address(0)
+            })
+        );
         vm.expectRevert(FundTransferHook.ZeroAddress.selector);
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
     }
 
     function test_onApprove_revert_zeroAmount() public {
-        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
-            agent: agent, token: address(token), amount: 0, pnlBps: 0, settlementAddr: address(0)
-        }));
+        bytes memory ctx = abi.encode(
+            FundTransferHook.ApproveContext({
+                agent: agent, token: address(token), amount: 0, pnlBps: 0, settlementAddr: address(0)
+            })
+        );
         vm.expectRevert(FundTransferHook.ZeroAmount.selector);
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
@@ -104,10 +119,11 @@ contract FundTransferHookTest is Test {
         pnlBps = bound(pnlBps, 0, 10_000);
         token.mint(caller, amount);
 
-        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
-            agent: agent, token: address(token), amount: amount,
-            pnlBps: pnlBps, settlementAddr: settlement
-        }));
+        bytes memory ctx = abi.encode(
+            FundTransferHook.ApproveContext({
+                agent: agent, token: address(token), amount: amount, pnlBps: pnlBps, settlementAddr: settlement
+            })
+        );
         uint256 agentBefore = token.balanceOf(agent);
         uint256 settlementBefore = token.balanceOf(settlement);
         vm.prank(caller);

--- a/contracts/evm/test/acp/FundTransferHook.t.sol
+++ b/contracts/evm/test/acp/FundTransferHook.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {FundTransferHook} from "../../src/acp/FundTransferHook.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("Mock", "MCK") {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract FundTransferHookTest is Test {
+    FundTransferHook internal hook;
+    MockToken internal token;
+
+    address internal caller = makeAddr("caller");
+    address internal agent = makeAddr("agent");
+    address internal settlement = makeAddr("settlement");
+
+    uint256 internal constant AMOUNT = 1000e18;
+    uint256 internal constant JOB_ID = 1;
+
+    event FundTransferred(
+        uint256 indexed jobId, address indexed agent, address indexed token,
+        uint256 agentAmount, uint256 pnlAmount, address settlementAddr
+    );
+
+    function setUp() public {
+        hook = new FundTransferHook();
+        token = new MockToken();
+        token.mint(caller, AMOUNT * 10);
+        vm.prank(caller);
+        token.approve(address(hook), type(uint256).max);
+    }
+
+    function test_hookName() public view {
+        assertEq(hook.hookName(), "FundTransferHook");
+    }
+
+    function test_onApprove_noSplit() public {
+        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
+            agent: agent, token: address(token), amount: AMOUNT, pnlBps: 0, settlementAddr: address(0)
+        }));
+        vm.expectEmit(true, true, true, true);
+        emit FundTransferred(JOB_ID, agent, address(token), AMOUNT, 0, address(0));
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+        assertEq(token.balanceOf(agent), AMOUNT);
+    }
+
+    function test_onApprove_withPnlSplit() public {
+        // 10% PnL split
+        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
+            agent: agent, token: address(token), amount: AMOUNT,
+            pnlBps: 1000, settlementAddr: settlement
+        }));
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+        assertEq(token.balanceOf(agent), AMOUNT * 90 / 100);
+        assertEq(token.balanceOf(settlement), AMOUNT * 10 / 100);
+    }
+
+    function test_onApprove_revert_invalidBps() public {
+        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
+            agent: agent, token: address(token), amount: AMOUNT,
+            pnlBps: 10_001, settlementAddr: settlement
+        }));
+        vm.expectRevert(FundTransferHook.InvalidBps.selector);
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+    }
+
+    function test_onApprove_revert_zeroAgent() public {
+        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
+            agent: address(0), token: address(token), amount: AMOUNT, pnlBps: 0, settlementAddr: address(0)
+        }));
+        vm.expectRevert(FundTransferHook.ZeroAddress.selector);
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+    }
+
+    function test_onApprove_revert_zeroAmount() public {
+        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
+            agent: agent, token: address(token), amount: 0, pnlBps: 0, settlementAddr: address(0)
+        }));
+        vm.expectRevert(FundTransferHook.ZeroAmount.selector);
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+    }
+
+    function test_noOp_onAccept() public {
+        vm.prank(caller);
+        hook.onAccept(JOB_ID, "");
+    }
+
+    function test_noOp_onSubmit() public {
+        vm.prank(caller);
+        hook.onSubmit(JOB_ID, "");
+    }
+
+    function testFuzz_onApprove_sumInvariant(uint256 amount, uint256 pnlBps) public {
+        amount = bound(amount, 1, type(uint128).max);
+        pnlBps = bound(pnlBps, 0, 10_000);
+        token.mint(caller, amount);
+
+        bytes memory ctx = abi.encode(FundTransferHook.ApproveContext({
+            agent: agent, token: address(token), amount: amount,
+            pnlBps: pnlBps, settlementAddr: settlement
+        }));
+        uint256 agentBefore = token.balanceOf(agent);
+        uint256 settlementBefore = token.balanceOf(settlement);
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+
+        uint256 totalOut = token.balanceOf(agent) - agentBefore + token.balanceOf(settlement) - settlementBefore;
+        assertEq(totalOut, amount);
+    }
+}

--- a/contracts/evm/test/acp/MilestoneHook.t.sol
+++ b/contracts/evm/test/acp/MilestoneHook.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {MilestoneHook} from "../../src/acp/MilestoneHook.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("MockMile", "MMILE") {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract MilestoneHookTest is Test {
+    MilestoneHook internal hook;
+    MockToken internal token;
+
+    address internal caller = makeAddr("caller");
+    address internal agent = makeAddr("agent");
+    uint256 internal constant BUDGET = 1000e18;
+    uint256 internal constant JOB_ID = 3;
+
+    event MilestoneReleased(
+        uint256 indexed jobId, address indexed agent, uint8 stage, uint8 totalStages, uint256 amount
+    );
+    event MilestoneCancelled(uint256 indexed jobId, uint8 remainingStages);
+
+    function _initCtx(uint8 stages) internal view returns (bytes memory) {
+        return abi.encode(MilestoneHook.InitContext({
+            agent: agent, token: address(token), totalBudget: BUDGET, stages: stages
+        }));
+    }
+
+    function setUp() public {
+        hook = new MilestoneHook();
+        token = new MockToken();
+        token.mint(caller, BUDGET * 10);
+        vm.prank(caller);
+        token.approve(address(hook), type(uint256).max);
+    }
+
+    function test_hookName() public view {
+        assertEq(hook.hookName(), "MilestoneHook");
+    }
+
+    function test_onAccept_initialisesState() public {
+        hook.onAccept(JOB_ID, _initCtx(4));
+        (address a,,uint256 sa,,uint8 total,uint8 completed, bool init) = hook.milestones(JOB_ID);
+        assertEq(a, agent);
+        assertEq(total, 4);
+        assertEq(completed, 0);
+        assertTrue(init);
+        assertEq(sa, BUDGET / 4);
+    }
+
+    function test_onApprove_releasesFirstStage() public {
+        hook.onAccept(JOB_ID, _initCtx(4));
+        uint256 stageAmt = BUDGET / 4;
+
+        vm.expectEmit(true, true, false, true);
+        emit MilestoneReleased(JOB_ID, agent, 1, 4, stageAmt);
+
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, "");
+        assertEq(token.balanceOf(agent), stageAmt);
+    }
+
+    function test_onApprove_allStages_sumEqualsTotal() public {
+        hook.onAccept(JOB_ID, _initCtx(3));
+        for (uint8 i = 0; i < 3; ++i) {
+            vm.prank(caller);
+            hook.onApprove(JOB_ID, "");
+        }
+        assertEq(token.balanceOf(agent), BUDGET);
+    }
+
+    function test_onApprove_revert_allStagesComplete() public {
+        hook.onAccept(JOB_ID, _initCtx(2));
+        vm.prank(caller); hook.onApprove(JOB_ID, "");
+        vm.prank(caller); hook.onApprove(JOB_ID, "");
+        vm.expectRevert(abi.encodeWithSelector(MilestoneHook.AllStagesComplete.selector, JOB_ID));
+        vm.prank(caller); hook.onApprove(JOB_ID, "");
+    }
+
+    function test_onApprove_revert_notInitialised() public {
+        vm.expectRevert(abi.encodeWithSelector(MilestoneHook.NotInitialised.selector, 99));
+        vm.prank(caller); hook.onApprove(99, "");
+    }
+
+    function test_onCancel_cancelsRemainingStages() public {
+        hook.onAccept(JOB_ID, _initCtx(5));
+        vm.prank(caller); hook.onApprove(JOB_ID, ""); // 1 of 5
+
+        vm.expectEmit(true, false, false, true);
+        emit MilestoneCancelled(JOB_ID, 4);
+        hook.onCancel(JOB_ID, "");
+
+        (,,,,, uint8 completed,) = hook.milestones(JOB_ID);
+        assertEq(completed, 5); // all marked done
+    }
+
+    function test_onCancel_noop_notInitialised() public {
+        hook.onCancel(999, ""); // no revert
+    }
+
+    function testFuzz_onApprove_dustGoesToLastStage(uint256 totalBudget, uint8 stages) public {
+        totalBudget = bound(totalBudget, 1, type(uint128).max);
+        stages = uint8(bound(stages, 1, 20));
+        token.mint(caller, totalBudget);
+
+        bytes memory ctx = abi.encode(MilestoneHook.InitContext({
+            agent: agent, token: address(token), totalBudget: totalBudget, stages: stages
+        }));
+        hook.onAccept(JOB_ID + uint256(stages), ctx);
+        for (uint8 i = 0; i < stages; ++i) {
+            vm.prank(caller);
+            hook.onApprove(JOB_ID + uint256(stages), "");
+        }
+        assertEq(token.balanceOf(agent), totalBudget);
+    }
+}

--- a/contracts/evm/test/acp/MilestoneHook.t.sol
+++ b/contracts/evm/test/acp/MilestoneHook.t.sol
@@ -7,7 +7,10 @@ import {MilestoneHook} from "../../src/acp/MilestoneHook.sol";
 
 contract MockToken is ERC20 {
     constructor() ERC20("MockMile", "MMILE") {}
-    function mint(address to, uint256 amount) external { _mint(to, amount); }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
 }
 
 contract MilestoneHookTest is Test {
@@ -25,9 +28,9 @@ contract MilestoneHookTest is Test {
     event MilestoneCancelled(uint256 indexed jobId, uint8 remainingStages);
 
     function _initCtx(uint8 stages) internal view returns (bytes memory) {
-        return abi.encode(MilestoneHook.InitContext({
-            agent: agent, token: address(token), totalBudget: BUDGET, stages: stages
-        }));
+        return abi.encode(
+            MilestoneHook.InitContext({agent: agent, token: address(token), totalBudget: BUDGET, stages: stages})
+        );
     }
 
     function setUp() public {
@@ -44,7 +47,7 @@ contract MilestoneHookTest is Test {
 
     function test_onAccept_initialisesState() public {
         hook.onAccept(JOB_ID, _initCtx(4));
-        (address a,,uint256 sa,,uint8 total,uint8 completed, bool init) = hook.milestones(JOB_ID);
+        (address a,, uint256 sa,, uint8 total, uint8 completed, bool init) = hook.milestones(JOB_ID);
         assertEq(a, agent);
         assertEq(total, 4);
         assertEq(completed, 0);
@@ -75,20 +78,25 @@ contract MilestoneHookTest is Test {
 
     function test_onApprove_revert_allStagesComplete() public {
         hook.onAccept(JOB_ID, _initCtx(2));
-        vm.prank(caller); hook.onApprove(JOB_ID, "");
-        vm.prank(caller); hook.onApprove(JOB_ID, "");
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, "");
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, "");
         vm.expectRevert(abi.encodeWithSelector(MilestoneHook.AllStagesComplete.selector, JOB_ID));
-        vm.prank(caller); hook.onApprove(JOB_ID, "");
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, "");
     }
 
     function test_onApprove_revert_notInitialised() public {
         vm.expectRevert(abi.encodeWithSelector(MilestoneHook.NotInitialised.selector, 99));
-        vm.prank(caller); hook.onApprove(99, "");
+        vm.prank(caller);
+        hook.onApprove(99, "");
     }
 
     function test_onCancel_cancelsRemainingStages() public {
         hook.onAccept(JOB_ID, _initCtx(5));
-        vm.prank(caller); hook.onApprove(JOB_ID, ""); // 1 of 5
+        vm.prank(caller); // 1 of 5
+        hook.onApprove(JOB_ID, "");
 
         vm.expectEmit(true, false, false, true);
         emit MilestoneCancelled(JOB_ID, 4);
@@ -107,9 +115,9 @@ contract MilestoneHookTest is Test {
         stages = uint8(bound(stages, 1, 20));
         token.mint(caller, totalBudget);
 
-        bytes memory ctx = abi.encode(MilestoneHook.InitContext({
-            agent: agent, token: address(token), totalBudget: totalBudget, stages: stages
-        }));
+        bytes memory ctx = abi.encode(
+            MilestoneHook.InitContext({agent: agent, token: address(token), totalBudget: totalBudget, stages: stages})
+        );
         hook.onAccept(JOB_ID + uint256(stages), ctx);
         for (uint8 i = 0; i < stages; ++i) {
             vm.prank(caller);

--- a/contracts/evm/test/acp/RoyaltyHook.t.sol
+++ b/contracts/evm/test/acp/RoyaltyHook.t.sol
@@ -7,7 +7,10 @@ import {RoyaltyHook} from "../../src/acp/RoyaltyHook.sol";
 
 contract MockToken is ERC20 {
     constructor() ERC20("MockRoy", "MROY") {}
-    function mint(address to, uint256 amount) external { _mint(to, amount); }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
 }
 
 contract RoyaltyHookTest is Test {
@@ -21,9 +24,7 @@ contract RoyaltyHookTest is Test {
     uint256 internal constant AMOUNT = 1000e18;
     uint256 internal constant JOB_ID = 10;
 
-    event RoyaltyPaid(
-        uint256 indexed jobId, address indexed token, address indexed recipient, uint256 amount
-    );
+    event RoyaltyPaid(uint256 indexed jobId, address indexed token, address indexed recipient, uint256 amount);
 
     function setUp() public {
         hook = new RoyaltyHook();
@@ -41,9 +42,8 @@ contract RoyaltyHookTest is Test {
         RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](2);
         recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 7000});
         recs[1] = RoyaltyHook.RoyaltyRecipient({recipient: r2, shareBps: 3000});
-        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
-            token: address(token), amount: AMOUNT, recipients: recs
-        }));
+        bytes memory ctx =
+            abi.encode(RoyaltyHook.RoyaltyContext({token: address(token), amount: AMOUNT, recipients: recs}));
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
         assertEq(token.balanceOf(r1), 700e18);
@@ -56,9 +56,8 @@ contract RoyaltyHookTest is Test {
         recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 3333});
         recs[1] = RoyaltyHook.RoyaltyRecipient({recipient: r2, shareBps: 3333});
         recs[2] = RoyaltyHook.RoyaltyRecipient({recipient: r3, shareBps: 3334});
-        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
-            token: address(token), amount: AMOUNT, recipients: recs
-        }));
+        bytes memory ctx =
+            abi.encode(RoyaltyHook.RoyaltyContext({token: address(token), amount: AMOUNT, recipients: recs}));
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
         uint256 totalOut = token.balanceOf(r1) + token.balanceOf(r2) + token.balanceOf(r3);
@@ -69,9 +68,8 @@ contract RoyaltyHookTest is Test {
         RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](2);
         recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 5000});
         recs[1] = RoyaltyHook.RoyaltyRecipient({recipient: r2, shareBps: 5001}); // 10001
-        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
-            token: address(token), amount: AMOUNT, recipients: recs
-        }));
+        bytes memory ctx =
+            abi.encode(RoyaltyHook.RoyaltyContext({token: address(token), amount: AMOUNT, recipients: recs}));
         vm.expectRevert(abi.encodeWithSelector(RoyaltyHook.ShareSumMismatch.selector, 10_001));
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
@@ -79,9 +77,8 @@ contract RoyaltyHookTest is Test {
 
     function test_onApprove_revert_noRecipients() public {
         RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](0);
-        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
-            token: address(token), amount: AMOUNT, recipients: recs
-        }));
+        bytes memory ctx =
+            abi.encode(RoyaltyHook.RoyaltyContext({token: address(token), amount: AMOUNT, recipients: recs}));
         vm.expectRevert(RoyaltyHook.NoRecipients.selector);
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
@@ -90,9 +87,7 @@ contract RoyaltyHookTest is Test {
     function test_onApprove_revert_zeroToken() public {
         RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](1);
         recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 10_000});
-        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
-            token: address(0), amount: AMOUNT, recipients: recs
-        }));
+        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({token: address(0), amount: AMOUNT, recipients: recs}));
         vm.expectRevert(RoyaltyHook.ZeroAddress.selector);
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
@@ -111,9 +106,8 @@ contract RoyaltyHookTest is Test {
         RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](2);
         recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 6000});
         recs[1] = RoyaltyHook.RoyaltyRecipient({recipient: r2, shareBps: 4000});
-        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
-            token: address(token), amount: amount, recipients: recs
-        }));
+        bytes memory ctx =
+            abi.encode(RoyaltyHook.RoyaltyContext({token: address(token), amount: amount, recipients: recs}));
         vm.prank(caller);
         hook.onApprove(JOB_ID, ctx);
         assertEq(token.balanceOf(r1) + token.balanceOf(r2), amount);

--- a/contracts/evm/test/acp/RoyaltyHook.t.sol
+++ b/contracts/evm/test/acp/RoyaltyHook.t.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {RoyaltyHook} from "../../src/acp/RoyaltyHook.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("MockRoy", "MROY") {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract RoyaltyHookTest is Test {
+    RoyaltyHook internal hook;
+    MockToken internal token;
+
+    address internal caller = makeAddr("caller");
+    address internal r1 = makeAddr("r1");
+    address internal r2 = makeAddr("r2");
+    address internal r3 = makeAddr("r3");
+    uint256 internal constant AMOUNT = 1000e18;
+    uint256 internal constant JOB_ID = 10;
+
+    event RoyaltyPaid(
+        uint256 indexed jobId, address indexed token, address indexed recipient, uint256 amount
+    );
+
+    function setUp() public {
+        hook = new RoyaltyHook();
+        token = new MockToken();
+        token.mint(caller, AMOUNT * 10);
+        vm.prank(caller);
+        token.approve(address(hook), type(uint256).max);
+    }
+
+    function test_hookName() public view {
+        assertEq(hook.hookName(), "RoyaltyHook");
+    }
+
+    function test_onApprove_twoRecipients() public {
+        RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](2);
+        recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 7000});
+        recs[1] = RoyaltyHook.RoyaltyRecipient({recipient: r2, shareBps: 3000});
+        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
+            token: address(token), amount: AMOUNT, recipients: recs
+        }));
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+        assertEq(token.balanceOf(r1), 700e18);
+        assertEq(token.balanceOf(r2), 300e18);
+    }
+
+    function test_onApprove_threeRecipients_dustToLast() public {
+        // 10 000 shares into 3 splits of 3333/3333/3334
+        RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](3);
+        recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 3333});
+        recs[1] = RoyaltyHook.RoyaltyRecipient({recipient: r2, shareBps: 3333});
+        recs[2] = RoyaltyHook.RoyaltyRecipient({recipient: r3, shareBps: 3334});
+        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
+            token: address(token), amount: AMOUNT, recipients: recs
+        }));
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+        uint256 totalOut = token.balanceOf(r1) + token.balanceOf(r2) + token.balanceOf(r3);
+        assertEq(totalOut, AMOUNT);
+    }
+
+    function test_onApprove_revert_sumMismatch() public {
+        RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](2);
+        recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 5000});
+        recs[1] = RoyaltyHook.RoyaltyRecipient({recipient: r2, shareBps: 5001}); // 10001
+        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
+            token: address(token), amount: AMOUNT, recipients: recs
+        }));
+        vm.expectRevert(abi.encodeWithSelector(RoyaltyHook.ShareSumMismatch.selector, 10_001));
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+    }
+
+    function test_onApprove_revert_noRecipients() public {
+        RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](0);
+        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
+            token: address(token), amount: AMOUNT, recipients: recs
+        }));
+        vm.expectRevert(RoyaltyHook.NoRecipients.selector);
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+    }
+
+    function test_onApprove_revert_zeroToken() public {
+        RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](1);
+        recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 10_000});
+        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
+            token: address(0), amount: AMOUNT, recipients: recs
+        }));
+        vm.expectRevert(RoyaltyHook.ZeroAddress.selector);
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+    }
+
+    function test_noOp_hooks() public {
+        hook.onAccept(JOB_ID, "");
+        hook.onSubmit(JOB_ID, "");
+        hook.onReject(JOB_ID, "");
+        hook.onCancel(JOB_ID, "");
+    }
+
+    function testFuzz_onApprove_sumInvariant(uint256 amount) public {
+        amount = bound(amount, 2, type(uint128).max);
+        token.mint(caller, amount);
+        RoyaltyHook.RoyaltyRecipient[] memory recs = new RoyaltyHook.RoyaltyRecipient[](2);
+        recs[0] = RoyaltyHook.RoyaltyRecipient({recipient: r1, shareBps: 6000});
+        recs[1] = RoyaltyHook.RoyaltyRecipient({recipient: r2, shareBps: 4000});
+        bytes memory ctx = abi.encode(RoyaltyHook.RoyaltyContext({
+            token: address(token), amount: amount, recipients: recs
+        }));
+        vm.prank(caller);
+        hook.onApprove(JOB_ID, ctx);
+        assertEq(token.balanceOf(r1) + token.balanceOf(r2), amount);
+    }
+}

--- a/contracts/evm/test/acp/SubscriptionHook.t.sol
+++ b/contracts/evm/test/acp/SubscriptionHook.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {SubscriptionHook} from "../../src/acp/SubscriptionHook.sol";
+
+contract MockToken is ERC20 {
+    constructor() ERC20("MockSub", "MSUB") {}
+    function mint(address to, uint256 amount) external { _mint(to, amount); }
+}
+
+contract SubscriptionHookTest is Test {
+    SubscriptionHook internal hook;
+    MockToken internal token;
+
+    address internal subscriber = makeAddr("subscriber");
+    address internal provider = makeAddr("provider");
+    uint256 internal constant PERIOD_AMOUNT = 100e18;
+    uint64 internal constant PERIOD_DURATION = 30 days;
+    uint256 internal constant JOB_ID = 5;
+
+    event SubscriptionRenewed(
+        uint256 indexed jobId, address indexed subscriber, address indexed provider,
+        uint256 amount, uint64 nextRenewalAt
+    );
+    event SubscriptionCancelled(uint256 indexed jobId);
+
+    function _initCtx() internal view returns (bytes memory) {
+        return abi.encode(SubscriptionHook.RenewContext({
+            subscriber: subscriber, provider: provider, token: address(token),
+            periodAmount: PERIOD_AMOUNT, periodDuration: PERIOD_DURATION
+        }));
+    }
+
+    function setUp() public {
+        hook = new SubscriptionHook();
+        token = new MockToken();
+        token.mint(subscriber, PERIOD_AMOUNT * 100);
+        vm.prank(subscriber);
+        token.approve(address(hook), type(uint256).max);
+    }
+
+    function test_hookName() public view {
+        assertEq(hook.hookName(), "SubscriptionHook");
+    }
+
+    function test_onAccept_initialisesState() public {
+        hook.onAccept(JOB_ID, _initCtx());
+        (uint64 nextRenewal, bool active) = hook.subscriptions(JOB_ID);
+        assertTrue(active);
+        assertGt(nextRenewal, 0);
+    }
+
+    function test_onApprove_renewsSubscription() public {
+        hook.onAccept(JOB_ID, _initCtx());
+        uint256 before = token.balanceOf(provider);
+        hook.onApprove(JOB_ID, _initCtx());
+        assertEq(token.balanceOf(provider), before + PERIOD_AMOUNT);
+    }
+
+    function test_onApprove_updatesNextRenewal() public {
+        hook.onAccept(JOB_ID, _initCtx());
+        hook.onApprove(JOB_ID, _initCtx());
+        (uint64 next,) = hook.subscriptions(JOB_ID);
+        assertApproxEqAbs(next, uint64(block.timestamp) + PERIOD_DURATION, 1);
+    }
+
+    function test_onApprove_revert_notActive() public {
+        // Never initialised — active=false by default
+        vm.expectRevert(abi.encodeWithSelector(SubscriptionHook.SubscriptionNotActive.selector, JOB_ID));
+        hook.onApprove(JOB_ID, _initCtx());
+    }
+
+    function test_onCancel_deactivatesSubscription() public {
+        hook.onAccept(JOB_ID, _initCtx());
+        vm.expectEmit(true, false, false, false);
+        emit SubscriptionCancelled(JOB_ID);
+        hook.onCancel(JOB_ID, "");
+        (, bool active) = hook.subscriptions(JOB_ID);
+        assertFalse(active);
+    }
+
+    function test_onCancel_noop_ifNotInitialised() public {
+        hook.onCancel(99, ""); // no revert
+    }
+
+    function testFuzz_onApprove_multiPeriod(uint8 periods) public {
+        periods = uint8(bound(periods, 1, 10));
+        hook.onAccept(JOB_ID, _initCtx());
+        uint256 beforeBalance = token.balanceOf(provider);
+        for (uint8 i = 0; i < periods; ++i) {
+            hook.onApprove(JOB_ID, _initCtx());
+        }
+        assertEq(token.balanceOf(provider), beforeBalance + PERIOD_AMOUNT * periods);
+    }
+}

--- a/contracts/evm/test/acp/SubscriptionHook.t.sol
+++ b/contracts/evm/test/acp/SubscriptionHook.t.sol
@@ -7,7 +7,10 @@ import {SubscriptionHook} from "../../src/acp/SubscriptionHook.sol";
 
 contract MockToken is ERC20 {
     constructor() ERC20("MockSub", "MSUB") {}
-    function mint(address to, uint256 amount) external { _mint(to, amount); }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
 }
 
 contract SubscriptionHookTest is Test {
@@ -21,16 +24,24 @@ contract SubscriptionHookTest is Test {
     uint256 internal constant JOB_ID = 5;
 
     event SubscriptionRenewed(
-        uint256 indexed jobId, address indexed subscriber, address indexed provider,
-        uint256 amount, uint64 nextRenewalAt
+        uint256 indexed jobId,
+        address indexed subscriber,
+        address indexed provider,
+        uint256 amount,
+        uint64 nextRenewalAt
     );
     event SubscriptionCancelled(uint256 indexed jobId);
 
     function _initCtx() internal view returns (bytes memory) {
-        return abi.encode(SubscriptionHook.RenewContext({
-            subscriber: subscriber, provider: provider, token: address(token),
-            periodAmount: PERIOD_AMOUNT, periodDuration: PERIOD_DURATION
-        }));
+        return abi.encode(
+            SubscriptionHook.RenewContext({
+                subscriber: subscriber,
+                provider: provider,
+                token: address(token),
+                periodAmount: PERIOD_AMOUNT,
+                periodDuration: PERIOD_DURATION
+            })
+        );
     }
 
     function setUp() public {


### PR DESCRIPTION
Phase \`hooks\` of \`M3 — acp v2 contracts e2e on base sepolia\`.

closes #60
closes #61
closes #62
closes #63

Verification: \`.claude/cron/last-verify-M3-hooks.log\`

## Changes
- `FundTransferHook.sol` (#60): principal entrustment + configurable PnL settlement BPS split
- `SubscriptionHook.sol` (#61): recurring subscription renewal with per-period debit
- `MilestoneHook.sol` (#62): N-stage budget split, dust on last stage
- `RoyaltyHook.sol` (#63): arbitrary recipient array with BPS share sum validation
- Tests: 34 tests across 4 suites (unit + fuzz)

## Verify
- forge build: green
- forge test (34/34 pass)
- slither: 0 findings on all 4 contracts