### PR TITLE
feat(indexer): abigen bindings and handlers for acp v2 contracts

### DIFF
--- a/services/indexer-go/internal/abi/acp_agent_registry.go
+++ b/services/indexer-go/internal/abi/acp_agent_registry.go
@@ -1,0 +1,2795 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// AgentRegistryAgentInfo is an auto generated low-level Go binding around an user-defined struct.
+type AgentRegistryAgentInfo struct {
+	Controller      common.Address
+	MetadataURI     string
+	Capabilities    *big.Int
+	ReputationScore *big.Int
+	RegisteredAt    *big.Int
+	Active          bool
+}
+
+// AgentRegistryMetaData contains all meta data concerning the AgentRegistry contract.
+var AgentRegistryMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"admin\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"PAUSER_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"SCORER_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"acceptControllerTransfer\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"agentsByController\",\"inputs\":[{\"name\":\"controller\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"ids\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"cancelControllerTransfer\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getAgent\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"info\",\"type\":\"tuple\",\"internalType\":\"structAgentRegistry.AgentInfo\",\"components\":[{\"name\":\"controller\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"metadataURI\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"capabilities\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"reputationScore\",\"type\":\"int256\",\"internalType\":\"int256\"},{\"name\":\"registeredAt\",\"type\":\"uint48\",\"internalType\":\"uint48\"},{\"name\":\"active\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pendingController\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"proposed\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"postScore\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"delta\",\"type\":\"int256\",\"internalType\":\"int256\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"proposeControllerTransfer\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"proposed\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"register\",\"inputs\":[{\"name\":\"controller\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"metadataURI\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"capabilities\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"scorerNonce\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setActive\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"active\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setCapabilities\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"capabilities\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setMetadata\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"metadataURI\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalAgents\",\"inputs\":[],\"outputs\":[{\"name\":\"count\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"ActiveStatusChanged\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"active\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"AgentRegistered\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"controller\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"metadataURI\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"capabilities\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"CapabilitiesUpdated\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"capabilities\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ControllerTransferAccepted\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"oldController\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newController\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ControllerTransferCancelled\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ControllerTransferProposed\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"proposed\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MetadataUpdated\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"metadataURI\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ScorePosted\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"scorer\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"delta\",\"type\":\"int256\",\"indexed\":false,\"internalType\":\"int256\"},{\"name\":\"newTotal\",\"type\":\"int256\",\"indexed\":false,\"internalType\":\"int256\"},{\"name\":\"nonce\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AgentInactive\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"AgentNotFound\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"EmptyMetadataURI\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidNonce\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"expected\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"provided\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NoPendingTransfer\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotController\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NotProposedController\",\"inputs\":[{\"name\":\"agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"caller\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]}]",
+}
+
+// AgentRegistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use AgentRegistryMetaData.ABI instead.
+var AgentRegistryABI = AgentRegistryMetaData.ABI
+
+// AgentRegistry is an auto generated Go binding around an Ethereum contract.
+type AgentRegistry struct {
+	AgentRegistryCaller     // Read-only binding to the contract
+	AgentRegistryTransactor // Write-only binding to the contract
+	AgentRegistryFilterer   // Log filterer for contract events
+}
+
+// AgentRegistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type AgentRegistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AgentRegistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type AgentRegistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AgentRegistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type AgentRegistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AgentRegistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type AgentRegistrySession struct {
+	Contract     *AgentRegistry    // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// AgentRegistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type AgentRegistryCallerSession struct {
+	Contract *AgentRegistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts        // Call options to use throughout this session
+}
+
+// AgentRegistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type AgentRegistryTransactorSession struct {
+	Contract     *AgentRegistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// AgentRegistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type AgentRegistryRaw struct {
+	Contract *AgentRegistry // Generic contract binding to access the raw methods on
+}
+
+// AgentRegistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type AgentRegistryCallerRaw struct {
+	Contract *AgentRegistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// AgentRegistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type AgentRegistryTransactorRaw struct {
+	Contract *AgentRegistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewAgentRegistry creates a new instance of AgentRegistry, bound to a specific deployed contract.
+func NewAgentRegistry(address common.Address, backend bind.ContractBackend) (*AgentRegistry, error) {
+	contract, err := bindAgentRegistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistry{AgentRegistryCaller: AgentRegistryCaller{contract: contract}, AgentRegistryTransactor: AgentRegistryTransactor{contract: contract}, AgentRegistryFilterer: AgentRegistryFilterer{contract: contract}}, nil
+}
+
+// NewAgentRegistryCaller creates a new read-only instance of AgentRegistry, bound to a specific deployed contract.
+func NewAgentRegistryCaller(address common.Address, caller bind.ContractCaller) (*AgentRegistryCaller, error) {
+	contract, err := bindAgentRegistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryCaller{contract: contract}, nil
+}
+
+// NewAgentRegistryTransactor creates a new write-only instance of AgentRegistry, bound to a specific deployed contract.
+func NewAgentRegistryTransactor(address common.Address, transactor bind.ContractTransactor) (*AgentRegistryTransactor, error) {
+	contract, err := bindAgentRegistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryTransactor{contract: contract}, nil
+}
+
+// NewAgentRegistryFilterer creates a new log filterer instance of AgentRegistry, bound to a specific deployed contract.
+func NewAgentRegistryFilterer(address common.Address, filterer bind.ContractFilterer) (*AgentRegistryFilterer, error) {
+	contract, err := bindAgentRegistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryFilterer{contract: contract}, nil
+}
+
+// bindAgentRegistry binds a generic wrapper to an already deployed contract.
+func bindAgentRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := AgentRegistryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AgentRegistry *AgentRegistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AgentRegistry.Contract.AgentRegistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AgentRegistry *AgentRegistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.AgentRegistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AgentRegistry *AgentRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.AgentRegistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_AgentRegistry *AgentRegistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AgentRegistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_AgentRegistry *AgentRegistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_AgentRegistry *AgentRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_AgentRegistry *AgentRegistryCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_AgentRegistry *AgentRegistrySession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _AgentRegistry.Contract.DEFAULTADMINROLE(&_AgentRegistry.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_AgentRegistry *AgentRegistryCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _AgentRegistry.Contract.DEFAULTADMINROLE(&_AgentRegistry.CallOpts)
+}
+
+// PAUSERROLE is a free data retrieval call binding the contract method 0xe63ab1e9.
+//
+// Solidity: function PAUSER_ROLE() view returns(bytes32)
+func (_AgentRegistry *AgentRegistryCaller) PAUSERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "PAUSER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// PAUSERROLE is a free data retrieval call binding the contract method 0xe63ab1e9.
+//
+// Solidity: function PAUSER_ROLE() view returns(bytes32)
+func (_AgentRegistry *AgentRegistrySession) PAUSERROLE() ([32]byte, error) {
+	return _AgentRegistry.Contract.PAUSERROLE(&_AgentRegistry.CallOpts)
+}
+
+// PAUSERROLE is a free data retrieval call binding the contract method 0xe63ab1e9.
+//
+// Solidity: function PAUSER_ROLE() view returns(bytes32)
+func (_AgentRegistry *AgentRegistryCallerSession) PAUSERROLE() ([32]byte, error) {
+	return _AgentRegistry.Contract.PAUSERROLE(&_AgentRegistry.CallOpts)
+}
+
+// SCORERROLE is a free data retrieval call binding the contract method 0xa4d6d495.
+//
+// Solidity: function SCORER_ROLE() view returns(bytes32)
+func (_AgentRegistry *AgentRegistryCaller) SCORERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "SCORER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// SCORERROLE is a free data retrieval call binding the contract method 0xa4d6d495.
+//
+// Solidity: function SCORER_ROLE() view returns(bytes32)
+func (_AgentRegistry *AgentRegistrySession) SCORERROLE() ([32]byte, error) {
+	return _AgentRegistry.Contract.SCORERROLE(&_AgentRegistry.CallOpts)
+}
+
+// SCORERROLE is a free data retrieval call binding the contract method 0xa4d6d495.
+//
+// Solidity: function SCORER_ROLE() view returns(bytes32)
+func (_AgentRegistry *AgentRegistryCallerSession) SCORERROLE() ([32]byte, error) {
+	return _AgentRegistry.Contract.SCORERROLE(&_AgentRegistry.CallOpts)
+}
+
+// AgentsByController is a free data retrieval call binding the contract method 0x53c0ada8.
+//
+// Solidity: function agentsByController(address controller) view returns(uint256[] ids)
+func (_AgentRegistry *AgentRegistryCaller) AgentsByController(opts *bind.CallOpts, controller common.Address) ([]*big.Int, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "agentsByController", controller)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// AgentsByController is a free data retrieval call binding the contract method 0x53c0ada8.
+//
+// Solidity: function agentsByController(address controller) view returns(uint256[] ids)
+func (_AgentRegistry *AgentRegistrySession) AgentsByController(controller common.Address) ([]*big.Int, error) {
+	return _AgentRegistry.Contract.AgentsByController(&_AgentRegistry.CallOpts, controller)
+}
+
+// AgentsByController is a free data retrieval call binding the contract method 0x53c0ada8.
+//
+// Solidity: function agentsByController(address controller) view returns(uint256[] ids)
+func (_AgentRegistry *AgentRegistryCallerSession) AgentsByController(controller common.Address) ([]*big.Int, error) {
+	return _AgentRegistry.Contract.AgentsByController(&_AgentRegistry.CallOpts, controller)
+}
+
+// GetAgent is a free data retrieval call binding the contract method 0x2de5aaf7.
+//
+// Solidity: function getAgent(uint256 agentId) view returns((address,string,uint256,int256,uint48,bool) info)
+func (_AgentRegistry *AgentRegistryCaller) GetAgent(opts *bind.CallOpts, agentId *big.Int) (AgentRegistryAgentInfo, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "getAgent", agentId)
+
+	if err != nil {
+		return *new(AgentRegistryAgentInfo), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(AgentRegistryAgentInfo)).(*AgentRegistryAgentInfo)
+
+	return out0, err
+
+}
+
+// GetAgent is a free data retrieval call binding the contract method 0x2de5aaf7.
+//
+// Solidity: function getAgent(uint256 agentId) view returns((address,string,uint256,int256,uint48,bool) info)
+func (_AgentRegistry *AgentRegistrySession) GetAgent(agentId *big.Int) (AgentRegistryAgentInfo, error) {
+	return _AgentRegistry.Contract.GetAgent(&_AgentRegistry.CallOpts, agentId)
+}
+
+// GetAgent is a free data retrieval call binding the contract method 0x2de5aaf7.
+//
+// Solidity: function getAgent(uint256 agentId) view returns((address,string,uint256,int256,uint48,bool) info)
+func (_AgentRegistry *AgentRegistryCallerSession) GetAgent(agentId *big.Int) (AgentRegistryAgentInfo, error) {
+	return _AgentRegistry.Contract.GetAgent(&_AgentRegistry.CallOpts, agentId)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_AgentRegistry *AgentRegistryCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_AgentRegistry *AgentRegistrySession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _AgentRegistry.Contract.GetRoleAdmin(&_AgentRegistry.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_AgentRegistry *AgentRegistryCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _AgentRegistry.Contract.GetRoleAdmin(&_AgentRegistry.CallOpts, role)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_AgentRegistry *AgentRegistryCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_AgentRegistry *AgentRegistrySession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _AgentRegistry.Contract.HasRole(&_AgentRegistry.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_AgentRegistry *AgentRegistryCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _AgentRegistry.Contract.HasRole(&_AgentRegistry.CallOpts, role, account)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_AgentRegistry *AgentRegistryCaller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_AgentRegistry *AgentRegistrySession) Paused() (bool, error) {
+	return _AgentRegistry.Contract.Paused(&_AgentRegistry.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_AgentRegistry *AgentRegistryCallerSession) Paused() (bool, error) {
+	return _AgentRegistry.Contract.Paused(&_AgentRegistry.CallOpts)
+}
+
+// PendingController is a free data retrieval call binding the contract method 0x5c3bd345.
+//
+// Solidity: function pendingController(uint256 agentId) view returns(address proposed)
+func (_AgentRegistry *AgentRegistryCaller) PendingController(opts *bind.CallOpts, agentId *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "pendingController", agentId)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PendingController is a free data retrieval call binding the contract method 0x5c3bd345.
+//
+// Solidity: function pendingController(uint256 agentId) view returns(address proposed)
+func (_AgentRegistry *AgentRegistrySession) PendingController(agentId *big.Int) (common.Address, error) {
+	return _AgentRegistry.Contract.PendingController(&_AgentRegistry.CallOpts, agentId)
+}
+
+// PendingController is a free data retrieval call binding the contract method 0x5c3bd345.
+//
+// Solidity: function pendingController(uint256 agentId) view returns(address proposed)
+func (_AgentRegistry *AgentRegistryCallerSession) PendingController(agentId *big.Int) (common.Address, error) {
+	return _AgentRegistry.Contract.PendingController(&_AgentRegistry.CallOpts, agentId)
+}
+
+// ScorerNonce is a free data retrieval call binding the contract method 0x2d462cea.
+//
+// Solidity: function scorerNonce(uint256 ) view returns(uint256)
+func (_AgentRegistry *AgentRegistryCaller) ScorerNonce(opts *bind.CallOpts, arg0 *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "scorerNonce", arg0)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ScorerNonce is a free data retrieval call binding the contract method 0x2d462cea.
+//
+// Solidity: function scorerNonce(uint256 ) view returns(uint256)
+func (_AgentRegistry *AgentRegistrySession) ScorerNonce(arg0 *big.Int) (*big.Int, error) {
+	return _AgentRegistry.Contract.ScorerNonce(&_AgentRegistry.CallOpts, arg0)
+}
+
+// ScorerNonce is a free data retrieval call binding the contract method 0x2d462cea.
+//
+// Solidity: function scorerNonce(uint256 ) view returns(uint256)
+func (_AgentRegistry *AgentRegistryCallerSession) ScorerNonce(arg0 *big.Int) (*big.Int, error) {
+	return _AgentRegistry.Contract.ScorerNonce(&_AgentRegistry.CallOpts, arg0)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_AgentRegistry *AgentRegistryCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_AgentRegistry *AgentRegistrySession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _AgentRegistry.Contract.SupportsInterface(&_AgentRegistry.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_AgentRegistry *AgentRegistryCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _AgentRegistry.Contract.SupportsInterface(&_AgentRegistry.CallOpts, interfaceId)
+}
+
+// TotalAgents is a free data retrieval call binding the contract method 0xc5053712.
+//
+// Solidity: function totalAgents() view returns(uint256 count)
+func (_AgentRegistry *AgentRegistryCaller) TotalAgents(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _AgentRegistry.contract.Call(opts, &out, "totalAgents")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalAgents is a free data retrieval call binding the contract method 0xc5053712.
+//
+// Solidity: function totalAgents() view returns(uint256 count)
+func (_AgentRegistry *AgentRegistrySession) TotalAgents() (*big.Int, error) {
+	return _AgentRegistry.Contract.TotalAgents(&_AgentRegistry.CallOpts)
+}
+
+// TotalAgents is a free data retrieval call binding the contract method 0xc5053712.
+//
+// Solidity: function totalAgents() view returns(uint256 count)
+func (_AgentRegistry *AgentRegistryCallerSession) TotalAgents() (*big.Int, error) {
+	return _AgentRegistry.Contract.TotalAgents(&_AgentRegistry.CallOpts)
+}
+
+// AcceptControllerTransfer is a paid mutator transaction binding the contract method 0xf87ebe5e.
+//
+// Solidity: function acceptControllerTransfer(uint256 agentId) returns()
+func (_AgentRegistry *AgentRegistryTransactor) AcceptControllerTransfer(opts *bind.TransactOpts, agentId *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "acceptControllerTransfer", agentId)
+}
+
+// AcceptControllerTransfer is a paid mutator transaction binding the contract method 0xf87ebe5e.
+//
+// Solidity: function acceptControllerTransfer(uint256 agentId) returns()
+func (_AgentRegistry *AgentRegistrySession) AcceptControllerTransfer(agentId *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.AcceptControllerTransfer(&_AgentRegistry.TransactOpts, agentId)
+}
+
+// AcceptControllerTransfer is a paid mutator transaction binding the contract method 0xf87ebe5e.
+//
+// Solidity: function acceptControllerTransfer(uint256 agentId) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) AcceptControllerTransfer(agentId *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.AcceptControllerTransfer(&_AgentRegistry.TransactOpts, agentId)
+}
+
+// CancelControllerTransfer is a paid mutator transaction binding the contract method 0x5d71e0a1.
+//
+// Solidity: function cancelControllerTransfer(uint256 agentId) returns()
+func (_AgentRegistry *AgentRegistryTransactor) CancelControllerTransfer(opts *bind.TransactOpts, agentId *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "cancelControllerTransfer", agentId)
+}
+
+// CancelControllerTransfer is a paid mutator transaction binding the contract method 0x5d71e0a1.
+//
+// Solidity: function cancelControllerTransfer(uint256 agentId) returns()
+func (_AgentRegistry *AgentRegistrySession) CancelControllerTransfer(agentId *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.CancelControllerTransfer(&_AgentRegistry.TransactOpts, agentId)
+}
+
+// CancelControllerTransfer is a paid mutator transaction binding the contract method 0x5d71e0a1.
+//
+// Solidity: function cancelControllerTransfer(uint256 agentId) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) CancelControllerTransfer(agentId *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.CancelControllerTransfer(&_AgentRegistry.TransactOpts, agentId)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_AgentRegistry *AgentRegistryTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_AgentRegistry *AgentRegistrySession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.GrantRole(&_AgentRegistry.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.GrantRole(&_AgentRegistry.TransactOpts, role, account)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_AgentRegistry *AgentRegistryTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_AgentRegistry *AgentRegistrySession) Pause() (*types.Transaction, error) {
+	return _AgentRegistry.Contract.Pause(&_AgentRegistry.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) Pause() (*types.Transaction, error) {
+	return _AgentRegistry.Contract.Pause(&_AgentRegistry.TransactOpts)
+}
+
+// PostScore is a paid mutator transaction binding the contract method 0x9c641ce0.
+//
+// Solidity: function postScore(uint256 agentId, int256 delta, uint256 nonce) returns()
+func (_AgentRegistry *AgentRegistryTransactor) PostScore(opts *bind.TransactOpts, agentId *big.Int, delta *big.Int, nonce *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "postScore", agentId, delta, nonce)
+}
+
+// PostScore is a paid mutator transaction binding the contract method 0x9c641ce0.
+//
+// Solidity: function postScore(uint256 agentId, int256 delta, uint256 nonce) returns()
+func (_AgentRegistry *AgentRegistrySession) PostScore(agentId *big.Int, delta *big.Int, nonce *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.PostScore(&_AgentRegistry.TransactOpts, agentId, delta, nonce)
+}
+
+// PostScore is a paid mutator transaction binding the contract method 0x9c641ce0.
+//
+// Solidity: function postScore(uint256 agentId, int256 delta, uint256 nonce) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) PostScore(agentId *big.Int, delta *big.Int, nonce *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.PostScore(&_AgentRegistry.TransactOpts, agentId, delta, nonce)
+}
+
+// ProposeControllerTransfer is a paid mutator transaction binding the contract method 0x98310b5e.
+//
+// Solidity: function proposeControllerTransfer(uint256 agentId, address proposed) returns()
+func (_AgentRegistry *AgentRegistryTransactor) ProposeControllerTransfer(opts *bind.TransactOpts, agentId *big.Int, proposed common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "proposeControllerTransfer", agentId, proposed)
+}
+
+// ProposeControllerTransfer is a paid mutator transaction binding the contract method 0x98310b5e.
+//
+// Solidity: function proposeControllerTransfer(uint256 agentId, address proposed) returns()
+func (_AgentRegistry *AgentRegistrySession) ProposeControllerTransfer(agentId *big.Int, proposed common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.ProposeControllerTransfer(&_AgentRegistry.TransactOpts, agentId, proposed)
+}
+
+// ProposeControllerTransfer is a paid mutator transaction binding the contract method 0x98310b5e.
+//
+// Solidity: function proposeControllerTransfer(uint256 agentId, address proposed) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) ProposeControllerTransfer(agentId *big.Int, proposed common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.ProposeControllerTransfer(&_AgentRegistry.TransactOpts, agentId, proposed)
+}
+
+// Register is a paid mutator transaction binding the contract method 0xfc0d1b84.
+//
+// Solidity: function register(address controller, string metadataURI, uint256 capabilities) returns(uint256 agentId)
+func (_AgentRegistry *AgentRegistryTransactor) Register(opts *bind.TransactOpts, controller common.Address, metadataURI string, capabilities *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "register", controller, metadataURI, capabilities)
+}
+
+// Register is a paid mutator transaction binding the contract method 0xfc0d1b84.
+//
+// Solidity: function register(address controller, string metadataURI, uint256 capabilities) returns(uint256 agentId)
+func (_AgentRegistry *AgentRegistrySession) Register(controller common.Address, metadataURI string, capabilities *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.Register(&_AgentRegistry.TransactOpts, controller, metadataURI, capabilities)
+}
+
+// Register is a paid mutator transaction binding the contract method 0xfc0d1b84.
+//
+// Solidity: function register(address controller, string metadataURI, uint256 capabilities) returns(uint256 agentId)
+func (_AgentRegistry *AgentRegistryTransactorSession) Register(controller common.Address, metadataURI string, capabilities *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.Register(&_AgentRegistry.TransactOpts, controller, metadataURI, capabilities)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_AgentRegistry *AgentRegistryTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_AgentRegistry *AgentRegistrySession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.RenounceRole(&_AgentRegistry.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.RenounceRole(&_AgentRegistry.TransactOpts, role, callerConfirmation)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_AgentRegistry *AgentRegistryTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_AgentRegistry *AgentRegistrySession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.RevokeRole(&_AgentRegistry.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.RevokeRole(&_AgentRegistry.TransactOpts, role, account)
+}
+
+// SetActive is a paid mutator transaction binding the contract method 0xe60a955d.
+//
+// Solidity: function setActive(uint256 agentId, bool active) returns()
+func (_AgentRegistry *AgentRegistryTransactor) SetActive(opts *bind.TransactOpts, agentId *big.Int, active bool) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "setActive", agentId, active)
+}
+
+// SetActive is a paid mutator transaction binding the contract method 0xe60a955d.
+//
+// Solidity: function setActive(uint256 agentId, bool active) returns()
+func (_AgentRegistry *AgentRegistrySession) SetActive(agentId *big.Int, active bool) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.SetActive(&_AgentRegistry.TransactOpts, agentId, active)
+}
+
+// SetActive is a paid mutator transaction binding the contract method 0xe60a955d.
+//
+// Solidity: function setActive(uint256 agentId, bool active) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) SetActive(agentId *big.Int, active bool) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.SetActive(&_AgentRegistry.TransactOpts, agentId, active)
+}
+
+// SetCapabilities is a paid mutator transaction binding the contract method 0xb3473f83.
+//
+// Solidity: function setCapabilities(uint256 agentId, uint256 capabilities) returns()
+func (_AgentRegistry *AgentRegistryTransactor) SetCapabilities(opts *bind.TransactOpts, agentId *big.Int, capabilities *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "setCapabilities", agentId, capabilities)
+}
+
+// SetCapabilities is a paid mutator transaction binding the contract method 0xb3473f83.
+//
+// Solidity: function setCapabilities(uint256 agentId, uint256 capabilities) returns()
+func (_AgentRegistry *AgentRegistrySession) SetCapabilities(agentId *big.Int, capabilities *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.SetCapabilities(&_AgentRegistry.TransactOpts, agentId, capabilities)
+}
+
+// SetCapabilities is a paid mutator transaction binding the contract method 0xb3473f83.
+//
+// Solidity: function setCapabilities(uint256 agentId, uint256 capabilities) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) SetCapabilities(agentId *big.Int, capabilities *big.Int) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.SetCapabilities(&_AgentRegistry.TransactOpts, agentId, capabilities)
+}
+
+// SetMetadata is a paid mutator transaction binding the contract method 0x593aa283.
+//
+// Solidity: function setMetadata(uint256 agentId, string metadataURI) returns()
+func (_AgentRegistry *AgentRegistryTransactor) SetMetadata(opts *bind.TransactOpts, agentId *big.Int, metadataURI string) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "setMetadata", agentId, metadataURI)
+}
+
+// SetMetadata is a paid mutator transaction binding the contract method 0x593aa283.
+//
+// Solidity: function setMetadata(uint256 agentId, string metadataURI) returns()
+func (_AgentRegistry *AgentRegistrySession) SetMetadata(agentId *big.Int, metadataURI string) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.SetMetadata(&_AgentRegistry.TransactOpts, agentId, metadataURI)
+}
+
+// SetMetadata is a paid mutator transaction binding the contract method 0x593aa283.
+//
+// Solidity: function setMetadata(uint256 agentId, string metadataURI) returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) SetMetadata(agentId *big.Int, metadataURI string) (*types.Transaction, error) {
+	return _AgentRegistry.Contract.SetMetadata(&_AgentRegistry.TransactOpts, agentId, metadataURI)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_AgentRegistry *AgentRegistryTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AgentRegistry.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_AgentRegistry *AgentRegistrySession) Unpause() (*types.Transaction, error) {
+	return _AgentRegistry.Contract.Unpause(&_AgentRegistry.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_AgentRegistry *AgentRegistryTransactorSession) Unpause() (*types.Transaction, error) {
+	return _AgentRegistry.Contract.Unpause(&_AgentRegistry.TransactOpts)
+}
+
+// AgentRegistryActiveStatusChangedIterator is returned from FilterActiveStatusChanged and is used to iterate over the raw logs and unpacked data for ActiveStatusChanged events raised by the AgentRegistry contract.
+type AgentRegistryActiveStatusChangedIterator struct {
+	Event *AgentRegistryActiveStatusChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryActiveStatusChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryActiveStatusChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryActiveStatusChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryActiveStatusChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryActiveStatusChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryActiveStatusChanged represents a ActiveStatusChanged event raised by the AgentRegistry contract.
+type AgentRegistryActiveStatusChanged struct {
+	AgentId *big.Int
+	Active  bool
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterActiveStatusChanged is a free log retrieval operation binding the contract event 0x632239944907e2f939f78bb06a2d210ac62cc0fbe3bff1b6244b4883721df129.
+//
+// Solidity: event ActiveStatusChanged(uint256 indexed agentId, bool active)
+func (_AgentRegistry *AgentRegistryFilterer) FilterActiveStatusChanged(opts *bind.FilterOpts, agentId []*big.Int) (*AgentRegistryActiveStatusChangedIterator, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "ActiveStatusChanged", agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryActiveStatusChangedIterator{contract: _AgentRegistry.contract, event: "ActiveStatusChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchActiveStatusChanged is a free log subscription operation binding the contract event 0x632239944907e2f939f78bb06a2d210ac62cc0fbe3bff1b6244b4883721df129.
+//
+// Solidity: event ActiveStatusChanged(uint256 indexed agentId, bool active)
+func (_AgentRegistry *AgentRegistryFilterer) WatchActiveStatusChanged(opts *bind.WatchOpts, sink chan<- *AgentRegistryActiveStatusChanged, agentId []*big.Int) (event.Subscription, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "ActiveStatusChanged", agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryActiveStatusChanged)
+				if err := _AgentRegistry.contract.UnpackLog(event, "ActiveStatusChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseActiveStatusChanged is a log parse operation binding the contract event 0x632239944907e2f939f78bb06a2d210ac62cc0fbe3bff1b6244b4883721df129.
+//
+// Solidity: event ActiveStatusChanged(uint256 indexed agentId, bool active)
+func (_AgentRegistry *AgentRegistryFilterer) ParseActiveStatusChanged(log types.Log) (*AgentRegistryActiveStatusChanged, error) {
+	event := new(AgentRegistryActiveStatusChanged)
+	if err := _AgentRegistry.contract.UnpackLog(event, "ActiveStatusChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryAgentRegisteredIterator is returned from FilterAgentRegistered and is used to iterate over the raw logs and unpacked data for AgentRegistered events raised by the AgentRegistry contract.
+type AgentRegistryAgentRegisteredIterator struct {
+	Event *AgentRegistryAgentRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryAgentRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryAgentRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryAgentRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryAgentRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryAgentRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryAgentRegistered represents a AgentRegistered event raised by the AgentRegistry contract.
+type AgentRegistryAgentRegistered struct {
+	AgentId      *big.Int
+	Controller   common.Address
+	MetadataURI  string
+	Capabilities *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterAgentRegistered is a free log retrieval operation binding the contract event 0xc29f819ac362ff9c94de06666235808451aafd8894a2dffb86a080a965efeae3.
+//
+// Solidity: event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities)
+func (_AgentRegistry *AgentRegistryFilterer) FilterAgentRegistered(opts *bind.FilterOpts, agentId []*big.Int, controller []common.Address) (*AgentRegistryAgentRegisteredIterator, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+	var controllerRule []interface{}
+	for _, controllerItem := range controller {
+		controllerRule = append(controllerRule, controllerItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "AgentRegistered", agentIdRule, controllerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryAgentRegisteredIterator{contract: _AgentRegistry.contract, event: "AgentRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchAgentRegistered is a free log subscription operation binding the contract event 0xc29f819ac362ff9c94de06666235808451aafd8894a2dffb86a080a965efeae3.
+//
+// Solidity: event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities)
+func (_AgentRegistry *AgentRegistryFilterer) WatchAgentRegistered(opts *bind.WatchOpts, sink chan<- *AgentRegistryAgentRegistered, agentId []*big.Int, controller []common.Address) (event.Subscription, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+	var controllerRule []interface{}
+	for _, controllerItem := range controller {
+		controllerRule = append(controllerRule, controllerItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "AgentRegistered", agentIdRule, controllerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryAgentRegistered)
+				if err := _AgentRegistry.contract.UnpackLog(event, "AgentRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAgentRegistered is a log parse operation binding the contract event 0xc29f819ac362ff9c94de06666235808451aafd8894a2dffb86a080a965efeae3.
+//
+// Solidity: event AgentRegistered(uint256 indexed agentId, address indexed controller, string metadataURI, uint256 capabilities)
+func (_AgentRegistry *AgentRegistryFilterer) ParseAgentRegistered(log types.Log) (*AgentRegistryAgentRegistered, error) {
+	event := new(AgentRegistryAgentRegistered)
+	if err := _AgentRegistry.contract.UnpackLog(event, "AgentRegistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryCapabilitiesUpdatedIterator is returned from FilterCapabilitiesUpdated and is used to iterate over the raw logs and unpacked data for CapabilitiesUpdated events raised by the AgentRegistry contract.
+type AgentRegistryCapabilitiesUpdatedIterator struct {
+	Event *AgentRegistryCapabilitiesUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryCapabilitiesUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryCapabilitiesUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryCapabilitiesUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryCapabilitiesUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryCapabilitiesUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryCapabilitiesUpdated represents a CapabilitiesUpdated event raised by the AgentRegistry contract.
+type AgentRegistryCapabilitiesUpdated struct {
+	AgentId      *big.Int
+	Capabilities *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterCapabilitiesUpdated is a free log retrieval operation binding the contract event 0x2852a2d71dd37e385f378b5a9e262f9d2ed0cf51b7312a5f9229cc5cd39ea4c1.
+//
+// Solidity: event CapabilitiesUpdated(uint256 indexed agentId, uint256 capabilities)
+func (_AgentRegistry *AgentRegistryFilterer) FilterCapabilitiesUpdated(opts *bind.FilterOpts, agentId []*big.Int) (*AgentRegistryCapabilitiesUpdatedIterator, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "CapabilitiesUpdated", agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryCapabilitiesUpdatedIterator{contract: _AgentRegistry.contract, event: "CapabilitiesUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchCapabilitiesUpdated is a free log subscription operation binding the contract event 0x2852a2d71dd37e385f378b5a9e262f9d2ed0cf51b7312a5f9229cc5cd39ea4c1.
+//
+// Solidity: event CapabilitiesUpdated(uint256 indexed agentId, uint256 capabilities)
+func (_AgentRegistry *AgentRegistryFilterer) WatchCapabilitiesUpdated(opts *bind.WatchOpts, sink chan<- *AgentRegistryCapabilitiesUpdated, agentId []*big.Int) (event.Subscription, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "CapabilitiesUpdated", agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryCapabilitiesUpdated)
+				if err := _AgentRegistry.contract.UnpackLog(event, "CapabilitiesUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseCapabilitiesUpdated is a log parse operation binding the contract event 0x2852a2d71dd37e385f378b5a9e262f9d2ed0cf51b7312a5f9229cc5cd39ea4c1.
+//
+// Solidity: event CapabilitiesUpdated(uint256 indexed agentId, uint256 capabilities)
+func (_AgentRegistry *AgentRegistryFilterer) ParseCapabilitiesUpdated(log types.Log) (*AgentRegistryCapabilitiesUpdated, error) {
+	event := new(AgentRegistryCapabilitiesUpdated)
+	if err := _AgentRegistry.contract.UnpackLog(event, "CapabilitiesUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryControllerTransferAcceptedIterator is returned from FilterControllerTransferAccepted and is used to iterate over the raw logs and unpacked data for ControllerTransferAccepted events raised by the AgentRegistry contract.
+type AgentRegistryControllerTransferAcceptedIterator struct {
+	Event *AgentRegistryControllerTransferAccepted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryControllerTransferAcceptedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryControllerTransferAccepted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryControllerTransferAccepted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryControllerTransferAcceptedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryControllerTransferAcceptedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryControllerTransferAccepted represents a ControllerTransferAccepted event raised by the AgentRegistry contract.
+type AgentRegistryControllerTransferAccepted struct {
+	AgentId       *big.Int
+	OldController common.Address
+	NewController common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterControllerTransferAccepted is a free log retrieval operation binding the contract event 0x969d6b1394c5147c28489f50960712e680e34e1e14ea24ff72bd52f315930c3a.
+//
+// Solidity: event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController)
+func (_AgentRegistry *AgentRegistryFilterer) FilterControllerTransferAccepted(opts *bind.FilterOpts, agentId []*big.Int, oldController []common.Address, newController []common.Address) (*AgentRegistryControllerTransferAcceptedIterator, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+	var oldControllerRule []interface{}
+	for _, oldControllerItem := range oldController {
+		oldControllerRule = append(oldControllerRule, oldControllerItem)
+	}
+	var newControllerRule []interface{}
+	for _, newControllerItem := range newController {
+		newControllerRule = append(newControllerRule, newControllerItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "ControllerTransferAccepted", agentIdRule, oldControllerRule, newControllerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryControllerTransferAcceptedIterator{contract: _AgentRegistry.contract, event: "ControllerTransferAccepted", logs: logs, sub: sub}, nil
+}
+
+// WatchControllerTransferAccepted is a free log subscription operation binding the contract event 0x969d6b1394c5147c28489f50960712e680e34e1e14ea24ff72bd52f315930c3a.
+//
+// Solidity: event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController)
+func (_AgentRegistry *AgentRegistryFilterer) WatchControllerTransferAccepted(opts *bind.WatchOpts, sink chan<- *AgentRegistryControllerTransferAccepted, agentId []*big.Int, oldController []common.Address, newController []common.Address) (event.Subscription, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+	var oldControllerRule []interface{}
+	for _, oldControllerItem := range oldController {
+		oldControllerRule = append(oldControllerRule, oldControllerItem)
+	}
+	var newControllerRule []interface{}
+	for _, newControllerItem := range newController {
+		newControllerRule = append(newControllerRule, newControllerItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "ControllerTransferAccepted", agentIdRule, oldControllerRule, newControllerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryControllerTransferAccepted)
+				if err := _AgentRegistry.contract.UnpackLog(event, "ControllerTransferAccepted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseControllerTransferAccepted is a log parse operation binding the contract event 0x969d6b1394c5147c28489f50960712e680e34e1e14ea24ff72bd52f315930c3a.
+//
+// Solidity: event ControllerTransferAccepted(uint256 indexed agentId, address indexed oldController, address indexed newController)
+func (_AgentRegistry *AgentRegistryFilterer) ParseControllerTransferAccepted(log types.Log) (*AgentRegistryControllerTransferAccepted, error) {
+	event := new(AgentRegistryControllerTransferAccepted)
+	if err := _AgentRegistry.contract.UnpackLog(event, "ControllerTransferAccepted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryControllerTransferCancelledIterator is returned from FilterControllerTransferCancelled and is used to iterate over the raw logs and unpacked data for ControllerTransferCancelled events raised by the AgentRegistry contract.
+type AgentRegistryControllerTransferCancelledIterator struct {
+	Event *AgentRegistryControllerTransferCancelled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryControllerTransferCancelledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryControllerTransferCancelled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryControllerTransferCancelled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryControllerTransferCancelledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryControllerTransferCancelledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryControllerTransferCancelled represents a ControllerTransferCancelled event raised by the AgentRegistry contract.
+type AgentRegistryControllerTransferCancelled struct {
+	AgentId *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterControllerTransferCancelled is a free log retrieval operation binding the contract event 0x5d4293db10304d02137eb59859f20bef23395587c83ae50ada99be07f7aa9aad.
+//
+// Solidity: event ControllerTransferCancelled(uint256 indexed agentId)
+func (_AgentRegistry *AgentRegistryFilterer) FilterControllerTransferCancelled(opts *bind.FilterOpts, agentId []*big.Int) (*AgentRegistryControllerTransferCancelledIterator, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "ControllerTransferCancelled", agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryControllerTransferCancelledIterator{contract: _AgentRegistry.contract, event: "ControllerTransferCancelled", logs: logs, sub: sub}, nil
+}
+
+// WatchControllerTransferCancelled is a free log subscription operation binding the contract event 0x5d4293db10304d02137eb59859f20bef23395587c83ae50ada99be07f7aa9aad.
+//
+// Solidity: event ControllerTransferCancelled(uint256 indexed agentId)
+func (_AgentRegistry *AgentRegistryFilterer) WatchControllerTransferCancelled(opts *bind.WatchOpts, sink chan<- *AgentRegistryControllerTransferCancelled, agentId []*big.Int) (event.Subscription, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "ControllerTransferCancelled", agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryControllerTransferCancelled)
+				if err := _AgentRegistry.contract.UnpackLog(event, "ControllerTransferCancelled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseControllerTransferCancelled is a log parse operation binding the contract event 0x5d4293db10304d02137eb59859f20bef23395587c83ae50ada99be07f7aa9aad.
+//
+// Solidity: event ControllerTransferCancelled(uint256 indexed agentId)
+func (_AgentRegistry *AgentRegistryFilterer) ParseControllerTransferCancelled(log types.Log) (*AgentRegistryControllerTransferCancelled, error) {
+	event := new(AgentRegistryControllerTransferCancelled)
+	if err := _AgentRegistry.contract.UnpackLog(event, "ControllerTransferCancelled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryControllerTransferProposedIterator is returned from FilterControllerTransferProposed and is used to iterate over the raw logs and unpacked data for ControllerTransferProposed events raised by the AgentRegistry contract.
+type AgentRegistryControllerTransferProposedIterator struct {
+	Event *AgentRegistryControllerTransferProposed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryControllerTransferProposedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryControllerTransferProposed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryControllerTransferProposed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryControllerTransferProposedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryControllerTransferProposedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryControllerTransferProposed represents a ControllerTransferProposed event raised by the AgentRegistry contract.
+type AgentRegistryControllerTransferProposed struct {
+	AgentId  *big.Int
+	Proposed common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterControllerTransferProposed is a free log retrieval operation binding the contract event 0x41b8c1345e7590a4eb37c55b8c1cef180d9d1c694be1ae96d015bfe11a278e22.
+//
+// Solidity: event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed)
+func (_AgentRegistry *AgentRegistryFilterer) FilterControllerTransferProposed(opts *bind.FilterOpts, agentId []*big.Int, proposed []common.Address) (*AgentRegistryControllerTransferProposedIterator, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+	var proposedRule []interface{}
+	for _, proposedItem := range proposed {
+		proposedRule = append(proposedRule, proposedItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "ControllerTransferProposed", agentIdRule, proposedRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryControllerTransferProposedIterator{contract: _AgentRegistry.contract, event: "ControllerTransferProposed", logs: logs, sub: sub}, nil
+}
+
+// WatchControllerTransferProposed is a free log subscription operation binding the contract event 0x41b8c1345e7590a4eb37c55b8c1cef180d9d1c694be1ae96d015bfe11a278e22.
+//
+// Solidity: event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed)
+func (_AgentRegistry *AgentRegistryFilterer) WatchControllerTransferProposed(opts *bind.WatchOpts, sink chan<- *AgentRegistryControllerTransferProposed, agentId []*big.Int, proposed []common.Address) (event.Subscription, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+	var proposedRule []interface{}
+	for _, proposedItem := range proposed {
+		proposedRule = append(proposedRule, proposedItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "ControllerTransferProposed", agentIdRule, proposedRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryControllerTransferProposed)
+				if err := _AgentRegistry.contract.UnpackLog(event, "ControllerTransferProposed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseControllerTransferProposed is a log parse operation binding the contract event 0x41b8c1345e7590a4eb37c55b8c1cef180d9d1c694be1ae96d015bfe11a278e22.
+//
+// Solidity: event ControllerTransferProposed(uint256 indexed agentId, address indexed proposed)
+func (_AgentRegistry *AgentRegistryFilterer) ParseControllerTransferProposed(log types.Log) (*AgentRegistryControllerTransferProposed, error) {
+	event := new(AgentRegistryControllerTransferProposed)
+	if err := _AgentRegistry.contract.UnpackLog(event, "ControllerTransferProposed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryMetadataUpdatedIterator is returned from FilterMetadataUpdated and is used to iterate over the raw logs and unpacked data for MetadataUpdated events raised by the AgentRegistry contract.
+type AgentRegistryMetadataUpdatedIterator struct {
+	Event *AgentRegistryMetadataUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryMetadataUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryMetadataUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryMetadataUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryMetadataUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryMetadataUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryMetadataUpdated represents a MetadataUpdated event raised by the AgentRegistry contract.
+type AgentRegistryMetadataUpdated struct {
+	AgentId     *big.Int
+	MetadataURI string
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterMetadataUpdated is a free log retrieval operation binding the contract event 0x459157ba24c7ab9878b165ef465fa6ae2ab42bcd8445f576be378768b0c47309.
+//
+// Solidity: event MetadataUpdated(uint256 indexed agentId, string metadataURI)
+func (_AgentRegistry *AgentRegistryFilterer) FilterMetadataUpdated(opts *bind.FilterOpts, agentId []*big.Int) (*AgentRegistryMetadataUpdatedIterator, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "MetadataUpdated", agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryMetadataUpdatedIterator{contract: _AgentRegistry.contract, event: "MetadataUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMetadataUpdated is a free log subscription operation binding the contract event 0x459157ba24c7ab9878b165ef465fa6ae2ab42bcd8445f576be378768b0c47309.
+//
+// Solidity: event MetadataUpdated(uint256 indexed agentId, string metadataURI)
+func (_AgentRegistry *AgentRegistryFilterer) WatchMetadataUpdated(opts *bind.WatchOpts, sink chan<- *AgentRegistryMetadataUpdated, agentId []*big.Int) (event.Subscription, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "MetadataUpdated", agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryMetadataUpdated)
+				if err := _AgentRegistry.contract.UnpackLog(event, "MetadataUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMetadataUpdated is a log parse operation binding the contract event 0x459157ba24c7ab9878b165ef465fa6ae2ab42bcd8445f576be378768b0c47309.
+//
+// Solidity: event MetadataUpdated(uint256 indexed agentId, string metadataURI)
+func (_AgentRegistry *AgentRegistryFilterer) ParseMetadataUpdated(log types.Log) (*AgentRegistryMetadataUpdated, error) {
+	event := new(AgentRegistryMetadataUpdated)
+	if err := _AgentRegistry.contract.UnpackLog(event, "MetadataUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the AgentRegistry contract.
+type AgentRegistryPausedIterator struct {
+	Event *AgentRegistryPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryPaused represents a Paused event raised by the AgentRegistry contract.
+type AgentRegistryPaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_AgentRegistry *AgentRegistryFilterer) FilterPaused(opts *bind.FilterOpts) (*AgentRegistryPausedIterator, error) {
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryPausedIterator{contract: _AgentRegistry.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_AgentRegistry *AgentRegistryFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *AgentRegistryPaused) (event.Subscription, error) {
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryPaused)
+				if err := _AgentRegistry.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_AgentRegistry *AgentRegistryFilterer) ParsePaused(log types.Log) (*AgentRegistryPaused, error) {
+	event := new(AgentRegistryPaused)
+	if err := _AgentRegistry.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the AgentRegistry contract.
+type AgentRegistryRoleAdminChangedIterator struct {
+	Event *AgentRegistryRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryRoleAdminChanged represents a RoleAdminChanged event raised by the AgentRegistry contract.
+type AgentRegistryRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_AgentRegistry *AgentRegistryFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*AgentRegistryRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryRoleAdminChangedIterator{contract: _AgentRegistry.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_AgentRegistry *AgentRegistryFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *AgentRegistryRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryRoleAdminChanged)
+				if err := _AgentRegistry.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_AgentRegistry *AgentRegistryFilterer) ParseRoleAdminChanged(log types.Log) (*AgentRegistryRoleAdminChanged, error) {
+	event := new(AgentRegistryRoleAdminChanged)
+	if err := _AgentRegistry.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the AgentRegistry contract.
+type AgentRegistryRoleGrantedIterator struct {
+	Event *AgentRegistryRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryRoleGranted represents a RoleGranted event raised by the AgentRegistry contract.
+type AgentRegistryRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_AgentRegistry *AgentRegistryFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*AgentRegistryRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryRoleGrantedIterator{contract: _AgentRegistry.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_AgentRegistry *AgentRegistryFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *AgentRegistryRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryRoleGranted)
+				if err := _AgentRegistry.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_AgentRegistry *AgentRegistryFilterer) ParseRoleGranted(log types.Log) (*AgentRegistryRoleGranted, error) {
+	event := new(AgentRegistryRoleGranted)
+	if err := _AgentRegistry.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the AgentRegistry contract.
+type AgentRegistryRoleRevokedIterator struct {
+	Event *AgentRegistryRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryRoleRevoked represents a RoleRevoked event raised by the AgentRegistry contract.
+type AgentRegistryRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_AgentRegistry *AgentRegistryFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*AgentRegistryRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryRoleRevokedIterator{contract: _AgentRegistry.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_AgentRegistry *AgentRegistryFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *AgentRegistryRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryRoleRevoked)
+				if err := _AgentRegistry.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_AgentRegistry *AgentRegistryFilterer) ParseRoleRevoked(log types.Log) (*AgentRegistryRoleRevoked, error) {
+	event := new(AgentRegistryRoleRevoked)
+	if err := _AgentRegistry.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryScorePostedIterator is returned from FilterScorePosted and is used to iterate over the raw logs and unpacked data for ScorePosted events raised by the AgentRegistry contract.
+type AgentRegistryScorePostedIterator struct {
+	Event *AgentRegistryScorePosted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryScorePostedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryScorePosted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryScorePosted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryScorePostedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryScorePostedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryScorePosted represents a ScorePosted event raised by the AgentRegistry contract.
+type AgentRegistryScorePosted struct {
+	AgentId  *big.Int
+	Scorer   common.Address
+	Delta    *big.Int
+	NewTotal *big.Int
+	Nonce    *big.Int
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterScorePosted is a free log retrieval operation binding the contract event 0xa19792167f6e5259706dc8bacefe76b932fe47d8538e98761711b78e49129e3a.
+//
+// Solidity: event ScorePosted(uint256 indexed agentId, address indexed scorer, int256 delta, int256 newTotal, uint256 nonce)
+func (_AgentRegistry *AgentRegistryFilterer) FilterScorePosted(opts *bind.FilterOpts, agentId []*big.Int, scorer []common.Address) (*AgentRegistryScorePostedIterator, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+	var scorerRule []interface{}
+	for _, scorerItem := range scorer {
+		scorerRule = append(scorerRule, scorerItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "ScorePosted", agentIdRule, scorerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryScorePostedIterator{contract: _AgentRegistry.contract, event: "ScorePosted", logs: logs, sub: sub}, nil
+}
+
+// WatchScorePosted is a free log subscription operation binding the contract event 0xa19792167f6e5259706dc8bacefe76b932fe47d8538e98761711b78e49129e3a.
+//
+// Solidity: event ScorePosted(uint256 indexed agentId, address indexed scorer, int256 delta, int256 newTotal, uint256 nonce)
+func (_AgentRegistry *AgentRegistryFilterer) WatchScorePosted(opts *bind.WatchOpts, sink chan<- *AgentRegistryScorePosted, agentId []*big.Int, scorer []common.Address) (event.Subscription, error) {
+
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+	var scorerRule []interface{}
+	for _, scorerItem := range scorer {
+		scorerRule = append(scorerRule, scorerItem)
+	}
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "ScorePosted", agentIdRule, scorerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryScorePosted)
+				if err := _AgentRegistry.contract.UnpackLog(event, "ScorePosted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseScorePosted is a log parse operation binding the contract event 0xa19792167f6e5259706dc8bacefe76b932fe47d8538e98761711b78e49129e3a.
+//
+// Solidity: event ScorePosted(uint256 indexed agentId, address indexed scorer, int256 delta, int256 newTotal, uint256 nonce)
+func (_AgentRegistry *AgentRegistryFilterer) ParseScorePosted(log types.Log) (*AgentRegistryScorePosted, error) {
+	event := new(AgentRegistryScorePosted)
+	if err := _AgentRegistry.contract.UnpackLog(event, "ScorePosted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentRegistryUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the AgentRegistry contract.
+type AgentRegistryUnpausedIterator struct {
+	Event *AgentRegistryUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentRegistryUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentRegistryUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentRegistryUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentRegistryUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentRegistryUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentRegistryUnpaused represents a Unpaused event raised by the AgentRegistry contract.
+type AgentRegistryUnpaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_AgentRegistry *AgentRegistryFilterer) FilterUnpaused(opts *bind.FilterOpts) (*AgentRegistryUnpausedIterator, error) {
+
+	logs, sub, err := _AgentRegistry.contract.FilterLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return &AgentRegistryUnpausedIterator{contract: _AgentRegistry.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_AgentRegistry *AgentRegistryFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *AgentRegistryUnpaused) (event.Subscription, error) {
+
+	logs, sub, err := _AgentRegistry.contract.WatchLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentRegistryUnpaused)
+				if err := _AgentRegistry.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_AgentRegistry *AgentRegistryFilterer) ParseUnpaused(log types.Log) (*AgentRegistryUnpaused, error) {
+	event := new(AgentRegistryUnpaused)
+	if err := _AgentRegistry.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_buyback_burner.go
+++ b/services/indexer-go/internal/abi/acp_buyback_burner.go
@@ -1,0 +1,1815 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BuybackBurnerMetaData contains all meta data concerning the BuybackBurner contract.
+var BuybackBurnerMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"admin\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_router\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_paymentToken\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_titu\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_swapPath\",\"type\":\"address[]\",\"internalType\":\"address[]\"},{\"name\":\"_minOutBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"_swapDeadlineBuffer\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"EXECUTOR_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"buybackAndBurn\",\"inputs\":[{\"name\":\"amountIn\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"amountOutMin\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getSwapPath\",\"inputs\":[],\"outputs\":[{\"name\":\"path\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"minOutBps\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"paymentToken\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"rescueTokens\",\"inputs\":[{\"name\":\"tokenAddr\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"router\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIUniswapV2Router02\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"setMinOutBps\",\"inputs\":[{\"name\":\"newBps\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setRouter\",\"inputs\":[{\"name\":\"newRouter\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setSwapPath\",\"inputs\":[{\"name\":\"path\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"swapDeadlineBuffer\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"swapPath\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"titu\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIERC20Burnable\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"BuybackAndBurn\",\"inputs\":[{\"name\":\"executor\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"paymentToken\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amountIn\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"tituBurned\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MinOutBpsUpdated\",\"inputs\":[{\"name\":\"oldBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"newBps\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RouterUpdated\",\"inputs\":[{\"name\":\"oldRouter\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newRouter\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SwapPathUpdated\",\"inputs\":[{\"name\":\"path\",\"type\":\"address[]\",\"indexed\":false,\"internalType\":\"address[]\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"InsufficientAmountOut\",\"inputs\":[{\"name\":\"amountIn\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"minOut\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"actualOut\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidBps\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidSwapPath\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// BuybackBurnerABI is the input ABI used to generate the binding from.
+// Deprecated: Use BuybackBurnerMetaData.ABI instead.
+var BuybackBurnerABI = BuybackBurnerMetaData.ABI
+
+// BuybackBurner is an auto generated Go binding around an Ethereum contract.
+type BuybackBurner struct {
+	BuybackBurnerCaller     // Read-only binding to the contract
+	BuybackBurnerTransactor // Write-only binding to the contract
+	BuybackBurnerFilterer   // Log filterer for contract events
+}
+
+// BuybackBurnerCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BuybackBurnerCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BuybackBurnerTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BuybackBurnerTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BuybackBurnerFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BuybackBurnerFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BuybackBurnerSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BuybackBurnerSession struct {
+	Contract     *BuybackBurner    // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BuybackBurnerCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BuybackBurnerCallerSession struct {
+	Contract *BuybackBurnerCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts        // Call options to use throughout this session
+}
+
+// BuybackBurnerTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BuybackBurnerTransactorSession struct {
+	Contract     *BuybackBurnerTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// BuybackBurnerRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BuybackBurnerRaw struct {
+	Contract *BuybackBurner // Generic contract binding to access the raw methods on
+}
+
+// BuybackBurnerCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BuybackBurnerCallerRaw struct {
+	Contract *BuybackBurnerCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BuybackBurnerTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BuybackBurnerTransactorRaw struct {
+	Contract *BuybackBurnerTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBuybackBurner creates a new instance of BuybackBurner, bound to a specific deployed contract.
+func NewBuybackBurner(address common.Address, backend bind.ContractBackend) (*BuybackBurner, error) {
+	contract, err := bindBuybackBurner(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurner{BuybackBurnerCaller: BuybackBurnerCaller{contract: contract}, BuybackBurnerTransactor: BuybackBurnerTransactor{contract: contract}, BuybackBurnerFilterer: BuybackBurnerFilterer{contract: contract}}, nil
+}
+
+// NewBuybackBurnerCaller creates a new read-only instance of BuybackBurner, bound to a specific deployed contract.
+func NewBuybackBurnerCaller(address common.Address, caller bind.ContractCaller) (*BuybackBurnerCaller, error) {
+	contract, err := bindBuybackBurner(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerCaller{contract: contract}, nil
+}
+
+// NewBuybackBurnerTransactor creates a new write-only instance of BuybackBurner, bound to a specific deployed contract.
+func NewBuybackBurnerTransactor(address common.Address, transactor bind.ContractTransactor) (*BuybackBurnerTransactor, error) {
+	contract, err := bindBuybackBurner(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerTransactor{contract: contract}, nil
+}
+
+// NewBuybackBurnerFilterer creates a new log filterer instance of BuybackBurner, bound to a specific deployed contract.
+func NewBuybackBurnerFilterer(address common.Address, filterer bind.ContractFilterer) (*BuybackBurnerFilterer, error) {
+	contract, err := bindBuybackBurner(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerFilterer{contract: contract}, nil
+}
+
+// bindBuybackBurner binds a generic wrapper to an already deployed contract.
+func bindBuybackBurner(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BuybackBurnerMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BuybackBurner *BuybackBurnerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BuybackBurner.Contract.BuybackBurnerCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BuybackBurner *BuybackBurnerRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.BuybackBurnerTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BuybackBurner *BuybackBurnerRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.BuybackBurnerTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_BuybackBurner *BuybackBurnerCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _BuybackBurner.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_BuybackBurner *BuybackBurnerTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_BuybackBurner *BuybackBurnerTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.contract.Transact(opts, method, params...)
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_BuybackBurner *BuybackBurnerCaller) BPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_BuybackBurner *BuybackBurnerSession) BPS() (*big.Int, error) {
+	return _BuybackBurner.Contract.BPS(&_BuybackBurner.CallOpts)
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_BuybackBurner *BuybackBurnerCallerSession) BPS() (*big.Int, error) {
+	return _BuybackBurner.Contract.BPS(&_BuybackBurner.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BuybackBurner *BuybackBurnerCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BuybackBurner *BuybackBurnerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BuybackBurner.Contract.DEFAULTADMINROLE(&_BuybackBurner.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_BuybackBurner *BuybackBurnerCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _BuybackBurner.Contract.DEFAULTADMINROLE(&_BuybackBurner.CallOpts)
+}
+
+// EXECUTORROLE is a free data retrieval call binding the contract method 0x07bd0265.
+//
+// Solidity: function EXECUTOR_ROLE() view returns(bytes32)
+func (_BuybackBurner *BuybackBurnerCaller) EXECUTORROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "EXECUTOR_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// EXECUTORROLE is a free data retrieval call binding the contract method 0x07bd0265.
+//
+// Solidity: function EXECUTOR_ROLE() view returns(bytes32)
+func (_BuybackBurner *BuybackBurnerSession) EXECUTORROLE() ([32]byte, error) {
+	return _BuybackBurner.Contract.EXECUTORROLE(&_BuybackBurner.CallOpts)
+}
+
+// EXECUTORROLE is a free data retrieval call binding the contract method 0x07bd0265.
+//
+// Solidity: function EXECUTOR_ROLE() view returns(bytes32)
+func (_BuybackBurner *BuybackBurnerCallerSession) EXECUTORROLE() ([32]byte, error) {
+	return _BuybackBurner.Contract.EXECUTORROLE(&_BuybackBurner.CallOpts)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BuybackBurner *BuybackBurnerCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BuybackBurner *BuybackBurnerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BuybackBurner.Contract.GetRoleAdmin(&_BuybackBurner.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_BuybackBurner *BuybackBurnerCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _BuybackBurner.Contract.GetRoleAdmin(&_BuybackBurner.CallOpts, role)
+}
+
+// GetSwapPath is a free data retrieval call binding the contract method 0x8ffb62d2.
+//
+// Solidity: function getSwapPath() view returns(address[] path)
+func (_BuybackBurner *BuybackBurnerCaller) GetSwapPath(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "getSwapPath")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// GetSwapPath is a free data retrieval call binding the contract method 0x8ffb62d2.
+//
+// Solidity: function getSwapPath() view returns(address[] path)
+func (_BuybackBurner *BuybackBurnerSession) GetSwapPath() ([]common.Address, error) {
+	return _BuybackBurner.Contract.GetSwapPath(&_BuybackBurner.CallOpts)
+}
+
+// GetSwapPath is a free data retrieval call binding the contract method 0x8ffb62d2.
+//
+// Solidity: function getSwapPath() view returns(address[] path)
+func (_BuybackBurner *BuybackBurnerCallerSession) GetSwapPath() ([]common.Address, error) {
+	return _BuybackBurner.Contract.GetSwapPath(&_BuybackBurner.CallOpts)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BuybackBurner *BuybackBurnerCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BuybackBurner *BuybackBurnerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BuybackBurner.Contract.HasRole(&_BuybackBurner.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_BuybackBurner *BuybackBurnerCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _BuybackBurner.Contract.HasRole(&_BuybackBurner.CallOpts, role, account)
+}
+
+// MinOutBps is a free data retrieval call binding the contract method 0xa4d9f536.
+//
+// Solidity: function minOutBps() view returns(uint256)
+func (_BuybackBurner *BuybackBurnerCaller) MinOutBps(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "minOutBps")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// MinOutBps is a free data retrieval call binding the contract method 0xa4d9f536.
+//
+// Solidity: function minOutBps() view returns(uint256)
+func (_BuybackBurner *BuybackBurnerSession) MinOutBps() (*big.Int, error) {
+	return _BuybackBurner.Contract.MinOutBps(&_BuybackBurner.CallOpts)
+}
+
+// MinOutBps is a free data retrieval call binding the contract method 0xa4d9f536.
+//
+// Solidity: function minOutBps() view returns(uint256)
+func (_BuybackBurner *BuybackBurnerCallerSession) MinOutBps() (*big.Int, error) {
+	return _BuybackBurner.Contract.MinOutBps(&_BuybackBurner.CallOpts)
+}
+
+// PaymentToken is a free data retrieval call binding the contract method 0x3013ce29.
+//
+// Solidity: function paymentToken() view returns(address)
+func (_BuybackBurner *BuybackBurnerCaller) PaymentToken(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "paymentToken")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// PaymentToken is a free data retrieval call binding the contract method 0x3013ce29.
+//
+// Solidity: function paymentToken() view returns(address)
+func (_BuybackBurner *BuybackBurnerSession) PaymentToken() (common.Address, error) {
+	return _BuybackBurner.Contract.PaymentToken(&_BuybackBurner.CallOpts)
+}
+
+// PaymentToken is a free data retrieval call binding the contract method 0x3013ce29.
+//
+// Solidity: function paymentToken() view returns(address)
+func (_BuybackBurner *BuybackBurnerCallerSession) PaymentToken() (common.Address, error) {
+	return _BuybackBurner.Contract.PaymentToken(&_BuybackBurner.CallOpts)
+}
+
+// Router is a free data retrieval call binding the contract method 0xf887ea40.
+//
+// Solidity: function router() view returns(address)
+func (_BuybackBurner *BuybackBurnerCaller) Router(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "router")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Router is a free data retrieval call binding the contract method 0xf887ea40.
+//
+// Solidity: function router() view returns(address)
+func (_BuybackBurner *BuybackBurnerSession) Router() (common.Address, error) {
+	return _BuybackBurner.Contract.Router(&_BuybackBurner.CallOpts)
+}
+
+// Router is a free data retrieval call binding the contract method 0xf887ea40.
+//
+// Solidity: function router() view returns(address)
+func (_BuybackBurner *BuybackBurnerCallerSession) Router() (common.Address, error) {
+	return _BuybackBurner.Contract.Router(&_BuybackBurner.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BuybackBurner *BuybackBurnerCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BuybackBurner *BuybackBurnerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BuybackBurner.Contract.SupportsInterface(&_BuybackBurner.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_BuybackBurner *BuybackBurnerCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _BuybackBurner.Contract.SupportsInterface(&_BuybackBurner.CallOpts, interfaceId)
+}
+
+// SwapDeadlineBuffer is a free data retrieval call binding the contract method 0xdec8f8c0.
+//
+// Solidity: function swapDeadlineBuffer() view returns(uint256)
+func (_BuybackBurner *BuybackBurnerCaller) SwapDeadlineBuffer(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "swapDeadlineBuffer")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SwapDeadlineBuffer is a free data retrieval call binding the contract method 0xdec8f8c0.
+//
+// Solidity: function swapDeadlineBuffer() view returns(uint256)
+func (_BuybackBurner *BuybackBurnerSession) SwapDeadlineBuffer() (*big.Int, error) {
+	return _BuybackBurner.Contract.SwapDeadlineBuffer(&_BuybackBurner.CallOpts)
+}
+
+// SwapDeadlineBuffer is a free data retrieval call binding the contract method 0xdec8f8c0.
+//
+// Solidity: function swapDeadlineBuffer() view returns(uint256)
+func (_BuybackBurner *BuybackBurnerCallerSession) SwapDeadlineBuffer() (*big.Int, error) {
+	return _BuybackBurner.Contract.SwapDeadlineBuffer(&_BuybackBurner.CallOpts)
+}
+
+// SwapPath is a free data retrieval call binding the contract method 0x24cc0766.
+//
+// Solidity: function swapPath(uint256 ) view returns(address)
+func (_BuybackBurner *BuybackBurnerCaller) SwapPath(opts *bind.CallOpts, arg0 *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "swapPath", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// SwapPath is a free data retrieval call binding the contract method 0x24cc0766.
+//
+// Solidity: function swapPath(uint256 ) view returns(address)
+func (_BuybackBurner *BuybackBurnerSession) SwapPath(arg0 *big.Int) (common.Address, error) {
+	return _BuybackBurner.Contract.SwapPath(&_BuybackBurner.CallOpts, arg0)
+}
+
+// SwapPath is a free data retrieval call binding the contract method 0x24cc0766.
+//
+// Solidity: function swapPath(uint256 ) view returns(address)
+func (_BuybackBurner *BuybackBurnerCallerSession) SwapPath(arg0 *big.Int) (common.Address, error) {
+	return _BuybackBurner.Contract.SwapPath(&_BuybackBurner.CallOpts, arg0)
+}
+
+// Titu is a free data retrieval call binding the contract method 0x33fcb0f6.
+//
+// Solidity: function titu() view returns(address)
+func (_BuybackBurner *BuybackBurnerCaller) Titu(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _BuybackBurner.contract.Call(opts, &out, "titu")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Titu is a free data retrieval call binding the contract method 0x33fcb0f6.
+//
+// Solidity: function titu() view returns(address)
+func (_BuybackBurner *BuybackBurnerSession) Titu() (common.Address, error) {
+	return _BuybackBurner.Contract.Titu(&_BuybackBurner.CallOpts)
+}
+
+// Titu is a free data retrieval call binding the contract method 0x33fcb0f6.
+//
+// Solidity: function titu() view returns(address)
+func (_BuybackBurner *BuybackBurnerCallerSession) Titu() (common.Address, error) {
+	return _BuybackBurner.Contract.Titu(&_BuybackBurner.CallOpts)
+}
+
+// BuybackAndBurn is a paid mutator transaction binding the contract method 0x2238eee5.
+//
+// Solidity: function buybackAndBurn(uint256 amountIn, uint256 amountOutMin) returns()
+func (_BuybackBurner *BuybackBurnerTransactor) BuybackAndBurn(opts *bind.TransactOpts, amountIn *big.Int, amountOutMin *big.Int) (*types.Transaction, error) {
+	return _BuybackBurner.contract.Transact(opts, "buybackAndBurn", amountIn, amountOutMin)
+}
+
+// BuybackAndBurn is a paid mutator transaction binding the contract method 0x2238eee5.
+//
+// Solidity: function buybackAndBurn(uint256 amountIn, uint256 amountOutMin) returns()
+func (_BuybackBurner *BuybackBurnerSession) BuybackAndBurn(amountIn *big.Int, amountOutMin *big.Int) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.BuybackAndBurn(&_BuybackBurner.TransactOpts, amountIn, amountOutMin)
+}
+
+// BuybackAndBurn is a paid mutator transaction binding the contract method 0x2238eee5.
+//
+// Solidity: function buybackAndBurn(uint256 amountIn, uint256 amountOutMin) returns()
+func (_BuybackBurner *BuybackBurnerTransactorSession) BuybackAndBurn(amountIn *big.Int, amountOutMin *big.Int) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.BuybackAndBurn(&_BuybackBurner.TransactOpts, amountIn, amountOutMin)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BuybackBurner *BuybackBurnerTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BuybackBurner *BuybackBurnerSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.GrantRole(&_BuybackBurner.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_BuybackBurner *BuybackBurnerTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.GrantRole(&_BuybackBurner.TransactOpts, role, account)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BuybackBurner *BuybackBurnerTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BuybackBurner *BuybackBurnerSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.RenounceRole(&_BuybackBurner.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_BuybackBurner *BuybackBurnerTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.RenounceRole(&_BuybackBurner.TransactOpts, role, callerConfirmation)
+}
+
+// RescueTokens is a paid mutator transaction binding the contract method 0xcea9d26f.
+//
+// Solidity: function rescueTokens(address tokenAddr, address to, uint256 amount) returns()
+func (_BuybackBurner *BuybackBurnerTransactor) RescueTokens(opts *bind.TransactOpts, tokenAddr common.Address, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BuybackBurner.contract.Transact(opts, "rescueTokens", tokenAddr, to, amount)
+}
+
+// RescueTokens is a paid mutator transaction binding the contract method 0xcea9d26f.
+//
+// Solidity: function rescueTokens(address tokenAddr, address to, uint256 amount) returns()
+func (_BuybackBurner *BuybackBurnerSession) RescueTokens(tokenAddr common.Address, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.RescueTokens(&_BuybackBurner.TransactOpts, tokenAddr, to, amount)
+}
+
+// RescueTokens is a paid mutator transaction binding the contract method 0xcea9d26f.
+//
+// Solidity: function rescueTokens(address tokenAddr, address to, uint256 amount) returns()
+func (_BuybackBurner *BuybackBurnerTransactorSession) RescueTokens(tokenAddr common.Address, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.RescueTokens(&_BuybackBurner.TransactOpts, tokenAddr, to, amount)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BuybackBurner *BuybackBurnerTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BuybackBurner *BuybackBurnerSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.RevokeRole(&_BuybackBurner.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_BuybackBurner *BuybackBurnerTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.RevokeRole(&_BuybackBurner.TransactOpts, role, account)
+}
+
+// SetMinOutBps is a paid mutator transaction binding the contract method 0x17fdef55.
+//
+// Solidity: function setMinOutBps(uint256 newBps) returns()
+func (_BuybackBurner *BuybackBurnerTransactor) SetMinOutBps(opts *bind.TransactOpts, newBps *big.Int) (*types.Transaction, error) {
+	return _BuybackBurner.contract.Transact(opts, "setMinOutBps", newBps)
+}
+
+// SetMinOutBps is a paid mutator transaction binding the contract method 0x17fdef55.
+//
+// Solidity: function setMinOutBps(uint256 newBps) returns()
+func (_BuybackBurner *BuybackBurnerSession) SetMinOutBps(newBps *big.Int) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.SetMinOutBps(&_BuybackBurner.TransactOpts, newBps)
+}
+
+// SetMinOutBps is a paid mutator transaction binding the contract method 0x17fdef55.
+//
+// Solidity: function setMinOutBps(uint256 newBps) returns()
+func (_BuybackBurner *BuybackBurnerTransactorSession) SetMinOutBps(newBps *big.Int) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.SetMinOutBps(&_BuybackBurner.TransactOpts, newBps)
+}
+
+// SetRouter is a paid mutator transaction binding the contract method 0xc0d78655.
+//
+// Solidity: function setRouter(address newRouter) returns()
+func (_BuybackBurner *BuybackBurnerTransactor) SetRouter(opts *bind.TransactOpts, newRouter common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.contract.Transact(opts, "setRouter", newRouter)
+}
+
+// SetRouter is a paid mutator transaction binding the contract method 0xc0d78655.
+//
+// Solidity: function setRouter(address newRouter) returns()
+func (_BuybackBurner *BuybackBurnerSession) SetRouter(newRouter common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.SetRouter(&_BuybackBurner.TransactOpts, newRouter)
+}
+
+// SetRouter is a paid mutator transaction binding the contract method 0xc0d78655.
+//
+// Solidity: function setRouter(address newRouter) returns()
+func (_BuybackBurner *BuybackBurnerTransactorSession) SetRouter(newRouter common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.SetRouter(&_BuybackBurner.TransactOpts, newRouter)
+}
+
+// SetSwapPath is a paid mutator transaction binding the contract method 0x12ddadbc.
+//
+// Solidity: function setSwapPath(address[] path) returns()
+func (_BuybackBurner *BuybackBurnerTransactor) SetSwapPath(opts *bind.TransactOpts, path []common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.contract.Transact(opts, "setSwapPath", path)
+}
+
+// SetSwapPath is a paid mutator transaction binding the contract method 0x12ddadbc.
+//
+// Solidity: function setSwapPath(address[] path) returns()
+func (_BuybackBurner *BuybackBurnerSession) SetSwapPath(path []common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.SetSwapPath(&_BuybackBurner.TransactOpts, path)
+}
+
+// SetSwapPath is a paid mutator transaction binding the contract method 0x12ddadbc.
+//
+// Solidity: function setSwapPath(address[] path) returns()
+func (_BuybackBurner *BuybackBurnerTransactorSession) SetSwapPath(path []common.Address) (*types.Transaction, error) {
+	return _BuybackBurner.Contract.SetSwapPath(&_BuybackBurner.TransactOpts, path)
+}
+
+// BuybackBurnerBuybackAndBurnIterator is returned from FilterBuybackAndBurn and is used to iterate over the raw logs and unpacked data for BuybackAndBurn events raised by the BuybackBurner contract.
+type BuybackBurnerBuybackAndBurnIterator struct {
+	Event *BuybackBurnerBuybackAndBurn // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BuybackBurnerBuybackAndBurnIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BuybackBurnerBuybackAndBurn)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BuybackBurnerBuybackAndBurn)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BuybackBurnerBuybackAndBurnIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BuybackBurnerBuybackAndBurnIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BuybackBurnerBuybackAndBurn represents a BuybackAndBurn event raised by the BuybackBurner contract.
+type BuybackBurnerBuybackAndBurn struct {
+	Executor     common.Address
+	PaymentToken common.Address
+	AmountIn     *big.Int
+	TituBurned   *big.Int
+	Raw          types.Log // Blockchain specific contextual infos
+}
+
+// FilterBuybackAndBurn is a free log retrieval operation binding the contract event 0x0f995e1de8b2d83fb2db107b6a0cb5b3a5bb1cca0d54dbcb01dd63f19ffed3bc.
+//
+// Solidity: event BuybackAndBurn(address indexed executor, address indexed paymentToken, uint256 amountIn, uint256 tituBurned)
+func (_BuybackBurner *BuybackBurnerFilterer) FilterBuybackAndBurn(opts *bind.FilterOpts, executor []common.Address, paymentToken []common.Address) (*BuybackBurnerBuybackAndBurnIterator, error) {
+
+	var executorRule []interface{}
+	for _, executorItem := range executor {
+		executorRule = append(executorRule, executorItem)
+	}
+	var paymentTokenRule []interface{}
+	for _, paymentTokenItem := range paymentToken {
+		paymentTokenRule = append(paymentTokenRule, paymentTokenItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.FilterLogs(opts, "BuybackAndBurn", executorRule, paymentTokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerBuybackAndBurnIterator{contract: _BuybackBurner.contract, event: "BuybackAndBurn", logs: logs, sub: sub}, nil
+}
+
+// WatchBuybackAndBurn is a free log subscription operation binding the contract event 0x0f995e1de8b2d83fb2db107b6a0cb5b3a5bb1cca0d54dbcb01dd63f19ffed3bc.
+//
+// Solidity: event BuybackAndBurn(address indexed executor, address indexed paymentToken, uint256 amountIn, uint256 tituBurned)
+func (_BuybackBurner *BuybackBurnerFilterer) WatchBuybackAndBurn(opts *bind.WatchOpts, sink chan<- *BuybackBurnerBuybackAndBurn, executor []common.Address, paymentToken []common.Address) (event.Subscription, error) {
+
+	var executorRule []interface{}
+	for _, executorItem := range executor {
+		executorRule = append(executorRule, executorItem)
+	}
+	var paymentTokenRule []interface{}
+	for _, paymentTokenItem := range paymentToken {
+		paymentTokenRule = append(paymentTokenRule, paymentTokenItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.WatchLogs(opts, "BuybackAndBurn", executorRule, paymentTokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BuybackBurnerBuybackAndBurn)
+				if err := _BuybackBurner.contract.UnpackLog(event, "BuybackAndBurn", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBuybackAndBurn is a log parse operation binding the contract event 0x0f995e1de8b2d83fb2db107b6a0cb5b3a5bb1cca0d54dbcb01dd63f19ffed3bc.
+//
+// Solidity: event BuybackAndBurn(address indexed executor, address indexed paymentToken, uint256 amountIn, uint256 tituBurned)
+func (_BuybackBurner *BuybackBurnerFilterer) ParseBuybackAndBurn(log types.Log) (*BuybackBurnerBuybackAndBurn, error) {
+	event := new(BuybackBurnerBuybackAndBurn)
+	if err := _BuybackBurner.contract.UnpackLog(event, "BuybackAndBurn", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BuybackBurnerMinOutBpsUpdatedIterator is returned from FilterMinOutBpsUpdated and is used to iterate over the raw logs and unpacked data for MinOutBpsUpdated events raised by the BuybackBurner contract.
+type BuybackBurnerMinOutBpsUpdatedIterator struct {
+	Event *BuybackBurnerMinOutBpsUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BuybackBurnerMinOutBpsUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BuybackBurnerMinOutBpsUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BuybackBurnerMinOutBpsUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BuybackBurnerMinOutBpsUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BuybackBurnerMinOutBpsUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BuybackBurnerMinOutBpsUpdated represents a MinOutBpsUpdated event raised by the BuybackBurner contract.
+type BuybackBurnerMinOutBpsUpdated struct {
+	OldBps *big.Int
+	NewBps *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterMinOutBpsUpdated is a free log retrieval operation binding the contract event 0xbbccd34c6edc4e3f130223b359b3b1012f8c0a25ebf5aa54400f87321df43c32.
+//
+// Solidity: event MinOutBpsUpdated(uint256 oldBps, uint256 newBps)
+func (_BuybackBurner *BuybackBurnerFilterer) FilterMinOutBpsUpdated(opts *bind.FilterOpts) (*BuybackBurnerMinOutBpsUpdatedIterator, error) {
+
+	logs, sub, err := _BuybackBurner.contract.FilterLogs(opts, "MinOutBpsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerMinOutBpsUpdatedIterator{contract: _BuybackBurner.contract, event: "MinOutBpsUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchMinOutBpsUpdated is a free log subscription operation binding the contract event 0xbbccd34c6edc4e3f130223b359b3b1012f8c0a25ebf5aa54400f87321df43c32.
+//
+// Solidity: event MinOutBpsUpdated(uint256 oldBps, uint256 newBps)
+func (_BuybackBurner *BuybackBurnerFilterer) WatchMinOutBpsUpdated(opts *bind.WatchOpts, sink chan<- *BuybackBurnerMinOutBpsUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BuybackBurner.contract.WatchLogs(opts, "MinOutBpsUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BuybackBurnerMinOutBpsUpdated)
+				if err := _BuybackBurner.contract.UnpackLog(event, "MinOutBpsUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMinOutBpsUpdated is a log parse operation binding the contract event 0xbbccd34c6edc4e3f130223b359b3b1012f8c0a25ebf5aa54400f87321df43c32.
+//
+// Solidity: event MinOutBpsUpdated(uint256 oldBps, uint256 newBps)
+func (_BuybackBurner *BuybackBurnerFilterer) ParseMinOutBpsUpdated(log types.Log) (*BuybackBurnerMinOutBpsUpdated, error) {
+	event := new(BuybackBurnerMinOutBpsUpdated)
+	if err := _BuybackBurner.contract.UnpackLog(event, "MinOutBpsUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BuybackBurnerRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the BuybackBurner contract.
+type BuybackBurnerRoleAdminChangedIterator struct {
+	Event *BuybackBurnerRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BuybackBurnerRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BuybackBurnerRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BuybackBurnerRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BuybackBurnerRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BuybackBurnerRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BuybackBurnerRoleAdminChanged represents a RoleAdminChanged event raised by the BuybackBurner contract.
+type BuybackBurnerRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BuybackBurner *BuybackBurnerFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*BuybackBurnerRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerRoleAdminChangedIterator{contract: _BuybackBurner.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BuybackBurner *BuybackBurnerFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *BuybackBurnerRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BuybackBurnerRoleAdminChanged)
+				if err := _BuybackBurner.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_BuybackBurner *BuybackBurnerFilterer) ParseRoleAdminChanged(log types.Log) (*BuybackBurnerRoleAdminChanged, error) {
+	event := new(BuybackBurnerRoleAdminChanged)
+	if err := _BuybackBurner.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BuybackBurnerRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the BuybackBurner contract.
+type BuybackBurnerRoleGrantedIterator struct {
+	Event *BuybackBurnerRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BuybackBurnerRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BuybackBurnerRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BuybackBurnerRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BuybackBurnerRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BuybackBurnerRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BuybackBurnerRoleGranted represents a RoleGranted event raised by the BuybackBurner contract.
+type BuybackBurnerRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BuybackBurner *BuybackBurnerFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BuybackBurnerRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerRoleGrantedIterator{contract: _BuybackBurner.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BuybackBurner *BuybackBurnerFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *BuybackBurnerRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BuybackBurnerRoleGranted)
+				if err := _BuybackBurner.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BuybackBurner *BuybackBurnerFilterer) ParseRoleGranted(log types.Log) (*BuybackBurnerRoleGranted, error) {
+	event := new(BuybackBurnerRoleGranted)
+	if err := _BuybackBurner.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BuybackBurnerRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the BuybackBurner contract.
+type BuybackBurnerRoleRevokedIterator struct {
+	Event *BuybackBurnerRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BuybackBurnerRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BuybackBurnerRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BuybackBurnerRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BuybackBurnerRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BuybackBurnerRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BuybackBurnerRoleRevoked represents a RoleRevoked event raised by the BuybackBurner contract.
+type BuybackBurnerRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BuybackBurner *BuybackBurnerFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*BuybackBurnerRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerRoleRevokedIterator{contract: _BuybackBurner.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BuybackBurner *BuybackBurnerFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *BuybackBurnerRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BuybackBurnerRoleRevoked)
+				if err := _BuybackBurner.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_BuybackBurner *BuybackBurnerFilterer) ParseRoleRevoked(log types.Log) (*BuybackBurnerRoleRevoked, error) {
+	event := new(BuybackBurnerRoleRevoked)
+	if err := _BuybackBurner.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BuybackBurnerRouterUpdatedIterator is returned from FilterRouterUpdated and is used to iterate over the raw logs and unpacked data for RouterUpdated events raised by the BuybackBurner contract.
+type BuybackBurnerRouterUpdatedIterator struct {
+	Event *BuybackBurnerRouterUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BuybackBurnerRouterUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BuybackBurnerRouterUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BuybackBurnerRouterUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BuybackBurnerRouterUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BuybackBurnerRouterUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BuybackBurnerRouterUpdated represents a RouterUpdated event raised by the BuybackBurner contract.
+type BuybackBurnerRouterUpdated struct {
+	OldRouter common.Address
+	NewRouter common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterRouterUpdated is a free log retrieval operation binding the contract event 0x02dc5c233404867c793b749c6d644beb2277536d18a7e7974d3f238e4c6f1684.
+//
+// Solidity: event RouterUpdated(address indexed oldRouter, address indexed newRouter)
+func (_BuybackBurner *BuybackBurnerFilterer) FilterRouterUpdated(opts *bind.FilterOpts, oldRouter []common.Address, newRouter []common.Address) (*BuybackBurnerRouterUpdatedIterator, error) {
+
+	var oldRouterRule []interface{}
+	for _, oldRouterItem := range oldRouter {
+		oldRouterRule = append(oldRouterRule, oldRouterItem)
+	}
+	var newRouterRule []interface{}
+	for _, newRouterItem := range newRouter {
+		newRouterRule = append(newRouterRule, newRouterItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.FilterLogs(opts, "RouterUpdated", oldRouterRule, newRouterRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerRouterUpdatedIterator{contract: _BuybackBurner.contract, event: "RouterUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchRouterUpdated is a free log subscription operation binding the contract event 0x02dc5c233404867c793b749c6d644beb2277536d18a7e7974d3f238e4c6f1684.
+//
+// Solidity: event RouterUpdated(address indexed oldRouter, address indexed newRouter)
+func (_BuybackBurner *BuybackBurnerFilterer) WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *BuybackBurnerRouterUpdated, oldRouter []common.Address, newRouter []common.Address) (event.Subscription, error) {
+
+	var oldRouterRule []interface{}
+	for _, oldRouterItem := range oldRouter {
+		oldRouterRule = append(oldRouterRule, oldRouterItem)
+	}
+	var newRouterRule []interface{}
+	for _, newRouterItem := range newRouter {
+		newRouterRule = append(newRouterRule, newRouterItem)
+	}
+
+	logs, sub, err := _BuybackBurner.contract.WatchLogs(opts, "RouterUpdated", oldRouterRule, newRouterRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BuybackBurnerRouterUpdated)
+				if err := _BuybackBurner.contract.UnpackLog(event, "RouterUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRouterUpdated is a log parse operation binding the contract event 0x02dc5c233404867c793b749c6d644beb2277536d18a7e7974d3f238e4c6f1684.
+//
+// Solidity: event RouterUpdated(address indexed oldRouter, address indexed newRouter)
+func (_BuybackBurner *BuybackBurnerFilterer) ParseRouterUpdated(log types.Log) (*BuybackBurnerRouterUpdated, error) {
+	event := new(BuybackBurnerRouterUpdated)
+	if err := _BuybackBurner.contract.UnpackLog(event, "RouterUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BuybackBurnerSwapPathUpdatedIterator is returned from FilterSwapPathUpdated and is used to iterate over the raw logs and unpacked data for SwapPathUpdated events raised by the BuybackBurner contract.
+type BuybackBurnerSwapPathUpdatedIterator struct {
+	Event *BuybackBurnerSwapPathUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BuybackBurnerSwapPathUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BuybackBurnerSwapPathUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BuybackBurnerSwapPathUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BuybackBurnerSwapPathUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BuybackBurnerSwapPathUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BuybackBurnerSwapPathUpdated represents a SwapPathUpdated event raised by the BuybackBurner contract.
+type BuybackBurnerSwapPathUpdated struct {
+	Path []common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterSwapPathUpdated is a free log retrieval operation binding the contract event 0x6ac8d8fd2cc5d6c950ab25024970e2ab3d81ff6e6e5ebeb21d992ee119b8e6ce.
+//
+// Solidity: event SwapPathUpdated(address[] path)
+func (_BuybackBurner *BuybackBurnerFilterer) FilterSwapPathUpdated(opts *bind.FilterOpts) (*BuybackBurnerSwapPathUpdatedIterator, error) {
+
+	logs, sub, err := _BuybackBurner.contract.FilterLogs(opts, "SwapPathUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &BuybackBurnerSwapPathUpdatedIterator{contract: _BuybackBurner.contract, event: "SwapPathUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchSwapPathUpdated is a free log subscription operation binding the contract event 0x6ac8d8fd2cc5d6c950ab25024970e2ab3d81ff6e6e5ebeb21d992ee119b8e6ce.
+//
+// Solidity: event SwapPathUpdated(address[] path)
+func (_BuybackBurner *BuybackBurnerFilterer) WatchSwapPathUpdated(opts *bind.WatchOpts, sink chan<- *BuybackBurnerSwapPathUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _BuybackBurner.contract.WatchLogs(opts, "SwapPathUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BuybackBurnerSwapPathUpdated)
+				if err := _BuybackBurner.contract.UnpackLog(event, "SwapPathUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSwapPathUpdated is a log parse operation binding the contract event 0x6ac8d8fd2cc5d6c950ab25024970e2ab3d81ff6e6e5ebeb21d992ee119b8e6ce.
+//
+// Solidity: event SwapPathUpdated(address[] path)
+func (_BuybackBurner *BuybackBurnerFilterer) ParseSwapPathUpdated(log types.Log) (*BuybackBurnerSwapPathUpdated, error) {
+	event := new(BuybackBurnerSwapPathUpdated)
+	if err := _BuybackBurner.contract.UnpackLog(event, "SwapPathUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_escrow.go
+++ b/services/indexer-go/internal/abi/acp_escrow.go
@@ -1,0 +1,1571 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// EscrowRecipient is an auto generated low-level Go binding around an user-defined struct.
+type EscrowRecipient struct {
+	To     common.Address
+	Amount *big.Int
+}
+
+// IPermit2PermitTransferFrom is an auto generated low-level Go binding around an user-defined struct.
+type IPermit2PermitTransferFrom struct {
+	Permitted IPermit2TokenPermissions
+	Nonce     *big.Int
+	Deadline  *big.Int
+}
+
+// IPermit2TokenPermissions is an auto generated low-level Go binding around an user-defined struct.
+type IPermit2TokenPermissions struct {
+	Token  common.Address
+	Amount *big.Int
+}
+
+// EscrowMetaData contains all meta data concerning the Escrow contract.
+var EscrowMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"admin\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_permit2\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"RELEASER_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"balances\",\"inputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"fund\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"fundWithPermit2\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"permit\",\"type\":\"tuple\",\"internalType\":\"structIPermit2.PermitTransferFrom\",\"components\":[{\"name\":\"permitted\",\"type\":\"tuple\",\"internalType\":\"structIPermit2.TokenPermissions\",\"components\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"nonce\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deadline\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"name\":\"signature\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getBalance\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"balance\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"permit2\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractIPermit2\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"refund\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"release\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"recipients\",\"type\":\"tuple[]\",\"internalType\":\"structEscrow.Recipient[]\",\"components\":[{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"Funded\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Refunded\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Released\",\"inputs\":[{\"name\":\"depositor\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"EmptyRecipients\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InsufficientBalance\",\"inputs\":[{\"name\":\"have\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"want\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"RecipientZeroAddress\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"RecipientZeroAmount\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"SumExceedsBalance\",\"inputs\":[{\"name\":\"sum\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"balance\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// EscrowABI is the input ABI used to generate the binding from.
+// Deprecated: Use EscrowMetaData.ABI instead.
+var EscrowABI = EscrowMetaData.ABI
+
+// Escrow is an auto generated Go binding around an Ethereum contract.
+type Escrow struct {
+	EscrowCaller     // Read-only binding to the contract
+	EscrowTransactor // Write-only binding to the contract
+	EscrowFilterer   // Log filterer for contract events
+}
+
+// EscrowCaller is an auto generated read-only Go binding around an Ethereum contract.
+type EscrowCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EscrowTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type EscrowTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EscrowFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type EscrowFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// EscrowSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type EscrowSession struct {
+	Contract     *Escrow           // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// EscrowCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type EscrowCallerSession struct {
+	Contract *EscrowCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// EscrowTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type EscrowTransactorSession struct {
+	Contract     *EscrowTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// EscrowRaw is an auto generated low-level Go binding around an Ethereum contract.
+type EscrowRaw struct {
+	Contract *Escrow // Generic contract binding to access the raw methods on
+}
+
+// EscrowCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type EscrowCallerRaw struct {
+	Contract *EscrowCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// EscrowTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type EscrowTransactorRaw struct {
+	Contract *EscrowTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewEscrow creates a new instance of Escrow, bound to a specific deployed contract.
+func NewEscrow(address common.Address, backend bind.ContractBackend) (*Escrow, error) {
+	contract, err := bindEscrow(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Escrow{EscrowCaller: EscrowCaller{contract: contract}, EscrowTransactor: EscrowTransactor{contract: contract}, EscrowFilterer: EscrowFilterer{contract: contract}}, nil
+}
+
+// NewEscrowCaller creates a new read-only instance of Escrow, bound to a specific deployed contract.
+func NewEscrowCaller(address common.Address, caller bind.ContractCaller) (*EscrowCaller, error) {
+	contract, err := bindEscrow(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &EscrowCaller{contract: contract}, nil
+}
+
+// NewEscrowTransactor creates a new write-only instance of Escrow, bound to a specific deployed contract.
+func NewEscrowTransactor(address common.Address, transactor bind.ContractTransactor) (*EscrowTransactor, error) {
+	contract, err := bindEscrow(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &EscrowTransactor{contract: contract}, nil
+}
+
+// NewEscrowFilterer creates a new log filterer instance of Escrow, bound to a specific deployed contract.
+func NewEscrowFilterer(address common.Address, filterer bind.ContractFilterer) (*EscrowFilterer, error) {
+	contract, err := bindEscrow(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &EscrowFilterer{contract: contract}, nil
+}
+
+// bindEscrow binds a generic wrapper to an already deployed contract.
+func bindEscrow(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := EscrowMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Escrow *EscrowRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Escrow.Contract.EscrowCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Escrow *EscrowRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Escrow.Contract.EscrowTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Escrow *EscrowRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Escrow.Contract.EscrowTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Escrow *EscrowCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Escrow.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Escrow *EscrowTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Escrow.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Escrow *EscrowTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Escrow.Contract.contract.Transact(opts, method, params...)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Escrow *EscrowCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Escrow.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Escrow *EscrowSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _Escrow.Contract.DEFAULTADMINROLE(&_Escrow.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_Escrow *EscrowCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _Escrow.Contract.DEFAULTADMINROLE(&_Escrow.CallOpts)
+}
+
+// RELEASERROLE is a free data retrieval call binding the contract method 0xac28af24.
+//
+// Solidity: function RELEASER_ROLE() view returns(bytes32)
+func (_Escrow *EscrowCaller) RELEASERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Escrow.contract.Call(opts, &out, "RELEASER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// RELEASERROLE is a free data retrieval call binding the contract method 0xac28af24.
+//
+// Solidity: function RELEASER_ROLE() view returns(bytes32)
+func (_Escrow *EscrowSession) RELEASERROLE() ([32]byte, error) {
+	return _Escrow.Contract.RELEASERROLE(&_Escrow.CallOpts)
+}
+
+// RELEASERROLE is a free data retrieval call binding the contract method 0xac28af24.
+//
+// Solidity: function RELEASER_ROLE() view returns(bytes32)
+func (_Escrow *EscrowCallerSession) RELEASERROLE() ([32]byte, error) {
+	return _Escrow.Contract.RELEASERROLE(&_Escrow.CallOpts)
+}
+
+// Balances is a free data retrieval call binding the contract method 0xd52dddf4.
+//
+// Solidity: function balances(address , uint256 , address ) view returns(uint256)
+func (_Escrow *EscrowCaller) Balances(opts *bind.CallOpts, arg0 common.Address, arg1 *big.Int, arg2 common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _Escrow.contract.Call(opts, &out, "balances", arg0, arg1, arg2)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Balances is a free data retrieval call binding the contract method 0xd52dddf4.
+//
+// Solidity: function balances(address , uint256 , address ) view returns(uint256)
+func (_Escrow *EscrowSession) Balances(arg0 common.Address, arg1 *big.Int, arg2 common.Address) (*big.Int, error) {
+	return _Escrow.Contract.Balances(&_Escrow.CallOpts, arg0, arg1, arg2)
+}
+
+// Balances is a free data retrieval call binding the contract method 0xd52dddf4.
+//
+// Solidity: function balances(address , uint256 , address ) view returns(uint256)
+func (_Escrow *EscrowCallerSession) Balances(arg0 common.Address, arg1 *big.Int, arg2 common.Address) (*big.Int, error) {
+	return _Escrow.Contract.Balances(&_Escrow.CallOpts, arg0, arg1, arg2)
+}
+
+// GetBalance is a free data retrieval call binding the contract method 0x54ce61b1.
+//
+// Solidity: function getBalance(address depositor, uint256 jobId, address token) view returns(uint256 balance)
+func (_Escrow *EscrowCaller) GetBalance(opts *bind.CallOpts, depositor common.Address, jobId *big.Int, token common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _Escrow.contract.Call(opts, &out, "getBalance", depositor, jobId, token)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetBalance is a free data retrieval call binding the contract method 0x54ce61b1.
+//
+// Solidity: function getBalance(address depositor, uint256 jobId, address token) view returns(uint256 balance)
+func (_Escrow *EscrowSession) GetBalance(depositor common.Address, jobId *big.Int, token common.Address) (*big.Int, error) {
+	return _Escrow.Contract.GetBalance(&_Escrow.CallOpts, depositor, jobId, token)
+}
+
+// GetBalance is a free data retrieval call binding the contract method 0x54ce61b1.
+//
+// Solidity: function getBalance(address depositor, uint256 jobId, address token) view returns(uint256 balance)
+func (_Escrow *EscrowCallerSession) GetBalance(depositor common.Address, jobId *big.Int, token common.Address) (*big.Int, error) {
+	return _Escrow.Contract.GetBalance(&_Escrow.CallOpts, depositor, jobId, token)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Escrow *EscrowCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _Escrow.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Escrow *EscrowSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _Escrow.Contract.GetRoleAdmin(&_Escrow.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_Escrow *EscrowCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _Escrow.Contract.GetRoleAdmin(&_Escrow.CallOpts, role)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Escrow *EscrowCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _Escrow.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Escrow *EscrowSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _Escrow.Contract.HasRole(&_Escrow.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_Escrow *EscrowCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _Escrow.Contract.HasRole(&_Escrow.CallOpts, role, account)
+}
+
+// Permit2 is a free data retrieval call binding the contract method 0x12261ee7.
+//
+// Solidity: function permit2() view returns(address)
+func (_Escrow *EscrowCaller) Permit2(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Escrow.contract.Call(opts, &out, "permit2")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Permit2 is a free data retrieval call binding the contract method 0x12261ee7.
+//
+// Solidity: function permit2() view returns(address)
+func (_Escrow *EscrowSession) Permit2() (common.Address, error) {
+	return _Escrow.Contract.Permit2(&_Escrow.CallOpts)
+}
+
+// Permit2 is a free data retrieval call binding the contract method 0x12261ee7.
+//
+// Solidity: function permit2() view returns(address)
+func (_Escrow *EscrowCallerSession) Permit2() (common.Address, error) {
+	return _Escrow.Contract.Permit2(&_Escrow.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Escrow *EscrowCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _Escrow.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Escrow *EscrowSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _Escrow.Contract.SupportsInterface(&_Escrow.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_Escrow *EscrowCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _Escrow.Contract.SupportsInterface(&_Escrow.CallOpts, interfaceId)
+}
+
+// Fund is a paid mutator transaction binding the contract method 0x4232f95e.
+//
+// Solidity: function fund(address depositor, uint256 jobId, address token, uint256 amount) returns()
+func (_Escrow *EscrowTransactor) Fund(opts *bind.TransactOpts, depositor common.Address, jobId *big.Int, token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Escrow.contract.Transact(opts, "fund", depositor, jobId, token, amount)
+}
+
+// Fund is a paid mutator transaction binding the contract method 0x4232f95e.
+//
+// Solidity: function fund(address depositor, uint256 jobId, address token, uint256 amount) returns()
+func (_Escrow *EscrowSession) Fund(depositor common.Address, jobId *big.Int, token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Escrow.Contract.Fund(&_Escrow.TransactOpts, depositor, jobId, token, amount)
+}
+
+// Fund is a paid mutator transaction binding the contract method 0x4232f95e.
+//
+// Solidity: function fund(address depositor, uint256 jobId, address token, uint256 amount) returns()
+func (_Escrow *EscrowTransactorSession) Fund(depositor common.Address, jobId *big.Int, token common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _Escrow.Contract.Fund(&_Escrow.TransactOpts, depositor, jobId, token, amount)
+}
+
+// FundWithPermit2 is a paid mutator transaction binding the contract method 0xd9f0f6ef.
+//
+// Solidity: function fundWithPermit2(address depositor, uint256 jobId, address token, uint256 amount, ((address,uint256),uint256,uint256) permit, bytes signature) returns()
+func (_Escrow *EscrowTransactor) FundWithPermit2(opts *bind.TransactOpts, depositor common.Address, jobId *big.Int, token common.Address, amount *big.Int, permit IPermit2PermitTransferFrom, signature []byte) (*types.Transaction, error) {
+	return _Escrow.contract.Transact(opts, "fundWithPermit2", depositor, jobId, token, amount, permit, signature)
+}
+
+// FundWithPermit2 is a paid mutator transaction binding the contract method 0xd9f0f6ef.
+//
+// Solidity: function fundWithPermit2(address depositor, uint256 jobId, address token, uint256 amount, ((address,uint256),uint256,uint256) permit, bytes signature) returns()
+func (_Escrow *EscrowSession) FundWithPermit2(depositor common.Address, jobId *big.Int, token common.Address, amount *big.Int, permit IPermit2PermitTransferFrom, signature []byte) (*types.Transaction, error) {
+	return _Escrow.Contract.FundWithPermit2(&_Escrow.TransactOpts, depositor, jobId, token, amount, permit, signature)
+}
+
+// FundWithPermit2 is a paid mutator transaction binding the contract method 0xd9f0f6ef.
+//
+// Solidity: function fundWithPermit2(address depositor, uint256 jobId, address token, uint256 amount, ((address,uint256),uint256,uint256) permit, bytes signature) returns()
+func (_Escrow *EscrowTransactorSession) FundWithPermit2(depositor common.Address, jobId *big.Int, token common.Address, amount *big.Int, permit IPermit2PermitTransferFrom, signature []byte) (*types.Transaction, error) {
+	return _Escrow.Contract.FundWithPermit2(&_Escrow.TransactOpts, depositor, jobId, token, amount, permit, signature)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Escrow *EscrowTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Escrow.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Escrow *EscrowSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Escrow.Contract.GrantRole(&_Escrow.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_Escrow *EscrowTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Escrow.Contract.GrantRole(&_Escrow.TransactOpts, role, account)
+}
+
+// Refund is a paid mutator transaction binding the contract method 0x4154aede.
+//
+// Solidity: function refund(address depositor, uint256 jobId, address token) returns()
+func (_Escrow *EscrowTransactor) Refund(opts *bind.TransactOpts, depositor common.Address, jobId *big.Int, token common.Address) (*types.Transaction, error) {
+	return _Escrow.contract.Transact(opts, "refund", depositor, jobId, token)
+}
+
+// Refund is a paid mutator transaction binding the contract method 0x4154aede.
+//
+// Solidity: function refund(address depositor, uint256 jobId, address token) returns()
+func (_Escrow *EscrowSession) Refund(depositor common.Address, jobId *big.Int, token common.Address) (*types.Transaction, error) {
+	return _Escrow.Contract.Refund(&_Escrow.TransactOpts, depositor, jobId, token)
+}
+
+// Refund is a paid mutator transaction binding the contract method 0x4154aede.
+//
+// Solidity: function refund(address depositor, uint256 jobId, address token) returns()
+func (_Escrow *EscrowTransactorSession) Refund(depositor common.Address, jobId *big.Int, token common.Address) (*types.Transaction, error) {
+	return _Escrow.Contract.Refund(&_Escrow.TransactOpts, depositor, jobId, token)
+}
+
+// Release is a paid mutator transaction binding the contract method 0x929ad5a9.
+//
+// Solidity: function release(address depositor, uint256 jobId, address token, (address,uint256)[] recipients) returns()
+func (_Escrow *EscrowTransactor) Release(opts *bind.TransactOpts, depositor common.Address, jobId *big.Int, token common.Address, recipients []EscrowRecipient) (*types.Transaction, error) {
+	return _Escrow.contract.Transact(opts, "release", depositor, jobId, token, recipients)
+}
+
+// Release is a paid mutator transaction binding the contract method 0x929ad5a9.
+//
+// Solidity: function release(address depositor, uint256 jobId, address token, (address,uint256)[] recipients) returns()
+func (_Escrow *EscrowSession) Release(depositor common.Address, jobId *big.Int, token common.Address, recipients []EscrowRecipient) (*types.Transaction, error) {
+	return _Escrow.Contract.Release(&_Escrow.TransactOpts, depositor, jobId, token, recipients)
+}
+
+// Release is a paid mutator transaction binding the contract method 0x929ad5a9.
+//
+// Solidity: function release(address depositor, uint256 jobId, address token, (address,uint256)[] recipients) returns()
+func (_Escrow *EscrowTransactorSession) Release(depositor common.Address, jobId *big.Int, token common.Address, recipients []EscrowRecipient) (*types.Transaction, error) {
+	return _Escrow.Contract.Release(&_Escrow.TransactOpts, depositor, jobId, token, recipients)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Escrow *EscrowTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Escrow.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Escrow *EscrowSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Escrow.Contract.RenounceRole(&_Escrow.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_Escrow *EscrowTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _Escrow.Contract.RenounceRole(&_Escrow.TransactOpts, role, callerConfirmation)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Escrow *EscrowTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Escrow.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Escrow *EscrowSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Escrow.Contract.RevokeRole(&_Escrow.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_Escrow *EscrowTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _Escrow.Contract.RevokeRole(&_Escrow.TransactOpts, role, account)
+}
+
+// EscrowFundedIterator is returned from FilterFunded and is used to iterate over the raw logs and unpacked data for Funded events raised by the Escrow contract.
+type EscrowFundedIterator struct {
+	Event *EscrowFunded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EscrowFundedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EscrowFunded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EscrowFunded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EscrowFundedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EscrowFundedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EscrowFunded represents a Funded event raised by the Escrow contract.
+type EscrowFunded struct {
+	Depositor common.Address
+	JobId     *big.Int
+	Token     common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterFunded is a free log retrieval operation binding the contract event 0x6c1892d9d3736322680cc71c620c3fa6ef6e4302b30512327d66987eee7a602c.
+//
+// Solidity: event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount)
+func (_Escrow *EscrowFilterer) FilterFunded(opts *bind.FilterOpts, depositor []common.Address, jobId []*big.Int, token []common.Address) (*EscrowFundedIterator, error) {
+
+	var depositorRule []interface{}
+	for _, depositorItem := range depositor {
+		depositorRule = append(depositorRule, depositorItem)
+	}
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	logs, sub, err := _Escrow.contract.FilterLogs(opts, "Funded", depositorRule, jobIdRule, tokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EscrowFundedIterator{contract: _Escrow.contract, event: "Funded", logs: logs, sub: sub}, nil
+}
+
+// WatchFunded is a free log subscription operation binding the contract event 0x6c1892d9d3736322680cc71c620c3fa6ef6e4302b30512327d66987eee7a602c.
+//
+// Solidity: event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount)
+func (_Escrow *EscrowFilterer) WatchFunded(opts *bind.WatchOpts, sink chan<- *EscrowFunded, depositor []common.Address, jobId []*big.Int, token []common.Address) (event.Subscription, error) {
+
+	var depositorRule []interface{}
+	for _, depositorItem := range depositor {
+		depositorRule = append(depositorRule, depositorItem)
+	}
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	logs, sub, err := _Escrow.contract.WatchLogs(opts, "Funded", depositorRule, jobIdRule, tokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EscrowFunded)
+				if err := _Escrow.contract.UnpackLog(event, "Funded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFunded is a log parse operation binding the contract event 0x6c1892d9d3736322680cc71c620c3fa6ef6e4302b30512327d66987eee7a602c.
+//
+// Solidity: event Funded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount)
+func (_Escrow *EscrowFilterer) ParseFunded(log types.Log) (*EscrowFunded, error) {
+	event := new(EscrowFunded)
+	if err := _Escrow.contract.UnpackLog(event, "Funded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EscrowRefundedIterator is returned from FilterRefunded and is used to iterate over the raw logs and unpacked data for Refunded events raised by the Escrow contract.
+type EscrowRefundedIterator struct {
+	Event *EscrowRefunded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EscrowRefundedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EscrowRefunded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EscrowRefunded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EscrowRefundedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EscrowRefundedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EscrowRefunded represents a Refunded event raised by the Escrow contract.
+type EscrowRefunded struct {
+	Depositor common.Address
+	JobId     *big.Int
+	Token     common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterRefunded is a free log retrieval operation binding the contract event 0x45751971a4d14bc4cd653a41eb84cff467a04fd5311450db55257120987005f7.
+//
+// Solidity: event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount)
+func (_Escrow *EscrowFilterer) FilterRefunded(opts *bind.FilterOpts, depositor []common.Address, jobId []*big.Int, token []common.Address) (*EscrowRefundedIterator, error) {
+
+	var depositorRule []interface{}
+	for _, depositorItem := range depositor {
+		depositorRule = append(depositorRule, depositorItem)
+	}
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	logs, sub, err := _Escrow.contract.FilterLogs(opts, "Refunded", depositorRule, jobIdRule, tokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EscrowRefundedIterator{contract: _Escrow.contract, event: "Refunded", logs: logs, sub: sub}, nil
+}
+
+// WatchRefunded is a free log subscription operation binding the contract event 0x45751971a4d14bc4cd653a41eb84cff467a04fd5311450db55257120987005f7.
+//
+// Solidity: event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount)
+func (_Escrow *EscrowFilterer) WatchRefunded(opts *bind.WatchOpts, sink chan<- *EscrowRefunded, depositor []common.Address, jobId []*big.Int, token []common.Address) (event.Subscription, error) {
+
+	var depositorRule []interface{}
+	for _, depositorItem := range depositor {
+		depositorRule = append(depositorRule, depositorItem)
+	}
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	logs, sub, err := _Escrow.contract.WatchLogs(opts, "Refunded", depositorRule, jobIdRule, tokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EscrowRefunded)
+				if err := _Escrow.contract.UnpackLog(event, "Refunded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRefunded is a log parse operation binding the contract event 0x45751971a4d14bc4cd653a41eb84cff467a04fd5311450db55257120987005f7.
+//
+// Solidity: event Refunded(address indexed depositor, uint256 indexed jobId, address indexed token, uint256 amount)
+func (_Escrow *EscrowFilterer) ParseRefunded(log types.Log) (*EscrowRefunded, error) {
+	event := new(EscrowRefunded)
+	if err := _Escrow.contract.UnpackLog(event, "Refunded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EscrowReleasedIterator is returned from FilterReleased and is used to iterate over the raw logs and unpacked data for Released events raised by the Escrow contract.
+type EscrowReleasedIterator struct {
+	Event *EscrowReleased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EscrowReleasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EscrowReleased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EscrowReleased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EscrowReleasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EscrowReleasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EscrowReleased represents a Released event raised by the Escrow contract.
+type EscrowReleased struct {
+	Depositor common.Address
+	JobId     *big.Int
+	Token     common.Address
+	To        common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterReleased is a free log retrieval operation binding the contract event 0xf50168be4db3b63b5055f81fb26a4ca82261896dc1881b27a68920f764e44f0e.
+//
+// Solidity: event Released(address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount)
+func (_Escrow *EscrowFilterer) FilterReleased(opts *bind.FilterOpts, depositor []common.Address, jobId []*big.Int, token []common.Address) (*EscrowReleasedIterator, error) {
+
+	var depositorRule []interface{}
+	for _, depositorItem := range depositor {
+		depositorRule = append(depositorRule, depositorItem)
+	}
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	logs, sub, err := _Escrow.contract.FilterLogs(opts, "Released", depositorRule, jobIdRule, tokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EscrowReleasedIterator{contract: _Escrow.contract, event: "Released", logs: logs, sub: sub}, nil
+}
+
+// WatchReleased is a free log subscription operation binding the contract event 0xf50168be4db3b63b5055f81fb26a4ca82261896dc1881b27a68920f764e44f0e.
+//
+// Solidity: event Released(address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount)
+func (_Escrow *EscrowFilterer) WatchReleased(opts *bind.WatchOpts, sink chan<- *EscrowReleased, depositor []common.Address, jobId []*big.Int, token []common.Address) (event.Subscription, error) {
+
+	var depositorRule []interface{}
+	for _, depositorItem := range depositor {
+		depositorRule = append(depositorRule, depositorItem)
+	}
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	logs, sub, err := _Escrow.contract.WatchLogs(opts, "Released", depositorRule, jobIdRule, tokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EscrowReleased)
+				if err := _Escrow.contract.UnpackLog(event, "Released", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseReleased is a log parse operation binding the contract event 0xf50168be4db3b63b5055f81fb26a4ca82261896dc1881b27a68920f764e44f0e.
+//
+// Solidity: event Released(address indexed depositor, uint256 indexed jobId, address indexed token, address to, uint256 amount)
+func (_Escrow *EscrowFilterer) ParseReleased(log types.Log) (*EscrowReleased, error) {
+	event := new(EscrowReleased)
+	if err := _Escrow.contract.UnpackLog(event, "Released", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EscrowRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the Escrow contract.
+type EscrowRoleAdminChangedIterator struct {
+	Event *EscrowRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EscrowRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EscrowRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EscrowRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EscrowRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EscrowRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EscrowRoleAdminChanged represents a RoleAdminChanged event raised by the Escrow contract.
+type EscrowRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Escrow *EscrowFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*EscrowRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _Escrow.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EscrowRoleAdminChangedIterator{contract: _Escrow.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Escrow *EscrowFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *EscrowRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _Escrow.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EscrowRoleAdminChanged)
+				if err := _Escrow.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_Escrow *EscrowFilterer) ParseRoleAdminChanged(log types.Log) (*EscrowRoleAdminChanged, error) {
+	event := new(EscrowRoleAdminChanged)
+	if err := _Escrow.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EscrowRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the Escrow contract.
+type EscrowRoleGrantedIterator struct {
+	Event *EscrowRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EscrowRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EscrowRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EscrowRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EscrowRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EscrowRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EscrowRoleGranted represents a RoleGranted event raised by the Escrow contract.
+type EscrowRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Escrow *EscrowFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*EscrowRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Escrow.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EscrowRoleGrantedIterator{contract: _Escrow.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Escrow *EscrowFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *EscrowRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Escrow.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EscrowRoleGranted)
+				if err := _Escrow.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Escrow *EscrowFilterer) ParseRoleGranted(log types.Log) (*EscrowRoleGranted, error) {
+	event := new(EscrowRoleGranted)
+	if err := _Escrow.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// EscrowRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the Escrow contract.
+type EscrowRoleRevokedIterator struct {
+	Event *EscrowRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *EscrowRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(EscrowRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(EscrowRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *EscrowRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *EscrowRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// EscrowRoleRevoked represents a RoleRevoked event raised by the Escrow contract.
+type EscrowRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Escrow *EscrowFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*EscrowRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Escrow.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &EscrowRoleRevokedIterator{contract: _Escrow.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Escrow *EscrowFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *EscrowRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _Escrow.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(EscrowRoleRevoked)
+				if err := _Escrow.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_Escrow *EscrowFilterer) ParseRoleRevoked(log types.Log) (*EscrowRoleRevoked, error) {
+	event := new(EscrowRoleRevoked)
+	if err := _Escrow.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_fee_splitter.go
+++ b/services/indexer-go/internal/abi/acp_fee_splitter.go
@@ -1,0 +1,1686 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// FeeSplitterMetaData contains all meta data concerning the FeeSplitter contract.
+var FeeSplitterMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"admin\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_treasury\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_buybackBurner\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"CALLER_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"SCHEDULE_A_BUYBACK_BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"SCHEDULE_A_TREASURY_BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"SCHEDULE_B_BUYBACK_BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"SCHEDULE_B_TREASURY_BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"buybackBurner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"previewSplit\",\"inputs\":[{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"schedule\",\"type\":\"uint8\",\"internalType\":\"enumFeeSplitter.Schedule\"}],\"outputs\":[{\"name\":\"primaryAmt\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"treasuryAmt\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"buybackAmt\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setBuybackBurner\",\"inputs\":[{\"name\":\"newBurner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setTreasury\",\"inputs\":[{\"name\":\"newTreasury\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"split\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"primary\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"schedule\",\"type\":\"uint8\",\"internalType\":\"enumFeeSplitter.Schedule\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"treasury\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"BuybackBurnerUpdated\",\"inputs\":[{\"name\":\"oldBurner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newBurner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"FeeSplit\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"primary\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"schedule\",\"type\":\"uint8\",\"indexed\":true,\"internalType\":\"enumFeeSplitter.Schedule\"},{\"name\":\"primaryAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"treasuryAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"buybackAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TreasuryUpdated\",\"inputs\":[{\"name\":\"oldTreasury\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newTreasury\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// FeeSplitterABI is the input ABI used to generate the binding from.
+// Deprecated: Use FeeSplitterMetaData.ABI instead.
+var FeeSplitterABI = FeeSplitterMetaData.ABI
+
+// FeeSplitter is an auto generated Go binding around an Ethereum contract.
+type FeeSplitter struct {
+	FeeSplitterCaller     // Read-only binding to the contract
+	FeeSplitterTransactor // Write-only binding to the contract
+	FeeSplitterFilterer   // Log filterer for contract events
+}
+
+// FeeSplitterCaller is an auto generated read-only Go binding around an Ethereum contract.
+type FeeSplitterCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeeSplitterTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type FeeSplitterTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeeSplitterFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type FeeSplitterFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FeeSplitterSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type FeeSplitterSession struct {
+	Contract     *FeeSplitter      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// FeeSplitterCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type FeeSplitterCallerSession struct {
+	Contract *FeeSplitterCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// FeeSplitterTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type FeeSplitterTransactorSession struct {
+	Contract     *FeeSplitterTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// FeeSplitterRaw is an auto generated low-level Go binding around an Ethereum contract.
+type FeeSplitterRaw struct {
+	Contract *FeeSplitter // Generic contract binding to access the raw methods on
+}
+
+// FeeSplitterCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type FeeSplitterCallerRaw struct {
+	Contract *FeeSplitterCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// FeeSplitterTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type FeeSplitterTransactorRaw struct {
+	Contract *FeeSplitterTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewFeeSplitter creates a new instance of FeeSplitter, bound to a specific deployed contract.
+func NewFeeSplitter(address common.Address, backend bind.ContractBackend) (*FeeSplitter, error) {
+	contract, err := bindFeeSplitter(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitter{FeeSplitterCaller: FeeSplitterCaller{contract: contract}, FeeSplitterTransactor: FeeSplitterTransactor{contract: contract}, FeeSplitterFilterer: FeeSplitterFilterer{contract: contract}}, nil
+}
+
+// NewFeeSplitterCaller creates a new read-only instance of FeeSplitter, bound to a specific deployed contract.
+func NewFeeSplitterCaller(address common.Address, caller bind.ContractCaller) (*FeeSplitterCaller, error) {
+	contract, err := bindFeeSplitter(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitterCaller{contract: contract}, nil
+}
+
+// NewFeeSplitterTransactor creates a new write-only instance of FeeSplitter, bound to a specific deployed contract.
+func NewFeeSplitterTransactor(address common.Address, transactor bind.ContractTransactor) (*FeeSplitterTransactor, error) {
+	contract, err := bindFeeSplitter(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitterTransactor{contract: contract}, nil
+}
+
+// NewFeeSplitterFilterer creates a new log filterer instance of FeeSplitter, bound to a specific deployed contract.
+func NewFeeSplitterFilterer(address common.Address, filterer bind.ContractFilterer) (*FeeSplitterFilterer, error) {
+	contract, err := bindFeeSplitter(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitterFilterer{contract: contract}, nil
+}
+
+// bindFeeSplitter binds a generic wrapper to an already deployed contract.
+func bindFeeSplitter(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := FeeSplitterMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FeeSplitter *FeeSplitterRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FeeSplitter.Contract.FeeSplitterCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FeeSplitter *FeeSplitterRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.FeeSplitterTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FeeSplitter *FeeSplitterRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.FeeSplitterTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FeeSplitter *FeeSplitterCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FeeSplitter.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FeeSplitter *FeeSplitterTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FeeSplitter *FeeSplitterTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.contract.Transact(opts, method, params...)
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCaller) BPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterSession) BPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.BPS(&_FeeSplitter.CallOpts)
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCallerSession) BPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.BPS(&_FeeSplitter.CallOpts)
+}
+
+// CALLERROLE is a free data retrieval call binding the contract method 0x774237fc.
+//
+// Solidity: function CALLER_ROLE() view returns(bytes32)
+func (_FeeSplitter *FeeSplitterCaller) CALLERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "CALLER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// CALLERROLE is a free data retrieval call binding the contract method 0x774237fc.
+//
+// Solidity: function CALLER_ROLE() view returns(bytes32)
+func (_FeeSplitter *FeeSplitterSession) CALLERROLE() ([32]byte, error) {
+	return _FeeSplitter.Contract.CALLERROLE(&_FeeSplitter.CallOpts)
+}
+
+// CALLERROLE is a free data retrieval call binding the contract method 0x774237fc.
+//
+// Solidity: function CALLER_ROLE() view returns(bytes32)
+func (_FeeSplitter *FeeSplitterCallerSession) CALLERROLE() ([32]byte, error) {
+	return _FeeSplitter.Contract.CALLERROLE(&_FeeSplitter.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_FeeSplitter *FeeSplitterCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_FeeSplitter *FeeSplitterSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _FeeSplitter.Contract.DEFAULTADMINROLE(&_FeeSplitter.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_FeeSplitter *FeeSplitterCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _FeeSplitter.Contract.DEFAULTADMINROLE(&_FeeSplitter.CallOpts)
+}
+
+// SCHEDULEABUYBACKBPS is a free data retrieval call binding the contract method 0x80ca6fd5.
+//
+// Solidity: function SCHEDULE_A_BUYBACK_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCaller) SCHEDULEABUYBACKBPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "SCHEDULE_A_BUYBACK_BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SCHEDULEABUYBACKBPS is a free data retrieval call binding the contract method 0x80ca6fd5.
+//
+// Solidity: function SCHEDULE_A_BUYBACK_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterSession) SCHEDULEABUYBACKBPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.SCHEDULEABUYBACKBPS(&_FeeSplitter.CallOpts)
+}
+
+// SCHEDULEABUYBACKBPS is a free data retrieval call binding the contract method 0x80ca6fd5.
+//
+// Solidity: function SCHEDULE_A_BUYBACK_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCallerSession) SCHEDULEABUYBACKBPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.SCHEDULEABUYBACKBPS(&_FeeSplitter.CallOpts)
+}
+
+// SCHEDULEATREASURYBPS is a free data retrieval call binding the contract method 0x8d623d05.
+//
+// Solidity: function SCHEDULE_A_TREASURY_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCaller) SCHEDULEATREASURYBPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "SCHEDULE_A_TREASURY_BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SCHEDULEATREASURYBPS is a free data retrieval call binding the contract method 0x8d623d05.
+//
+// Solidity: function SCHEDULE_A_TREASURY_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterSession) SCHEDULEATREASURYBPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.SCHEDULEATREASURYBPS(&_FeeSplitter.CallOpts)
+}
+
+// SCHEDULEATREASURYBPS is a free data retrieval call binding the contract method 0x8d623d05.
+//
+// Solidity: function SCHEDULE_A_TREASURY_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCallerSession) SCHEDULEATREASURYBPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.SCHEDULEATREASURYBPS(&_FeeSplitter.CallOpts)
+}
+
+// SCHEDULEBBUYBACKBPS is a free data retrieval call binding the contract method 0x50a43c09.
+//
+// Solidity: function SCHEDULE_B_BUYBACK_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCaller) SCHEDULEBBUYBACKBPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "SCHEDULE_B_BUYBACK_BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SCHEDULEBBUYBACKBPS is a free data retrieval call binding the contract method 0x50a43c09.
+//
+// Solidity: function SCHEDULE_B_BUYBACK_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterSession) SCHEDULEBBUYBACKBPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.SCHEDULEBBUYBACKBPS(&_FeeSplitter.CallOpts)
+}
+
+// SCHEDULEBBUYBACKBPS is a free data retrieval call binding the contract method 0x50a43c09.
+//
+// Solidity: function SCHEDULE_B_BUYBACK_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCallerSession) SCHEDULEBBUYBACKBPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.SCHEDULEBBUYBACKBPS(&_FeeSplitter.CallOpts)
+}
+
+// SCHEDULEBTREASURYBPS is a free data retrieval call binding the contract method 0x011275fd.
+//
+// Solidity: function SCHEDULE_B_TREASURY_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCaller) SCHEDULEBTREASURYBPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "SCHEDULE_B_TREASURY_BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// SCHEDULEBTREASURYBPS is a free data retrieval call binding the contract method 0x011275fd.
+//
+// Solidity: function SCHEDULE_B_TREASURY_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterSession) SCHEDULEBTREASURYBPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.SCHEDULEBTREASURYBPS(&_FeeSplitter.CallOpts)
+}
+
+// SCHEDULEBTREASURYBPS is a free data retrieval call binding the contract method 0x011275fd.
+//
+// Solidity: function SCHEDULE_B_TREASURY_BPS() view returns(uint256)
+func (_FeeSplitter *FeeSplitterCallerSession) SCHEDULEBTREASURYBPS() (*big.Int, error) {
+	return _FeeSplitter.Contract.SCHEDULEBTREASURYBPS(&_FeeSplitter.CallOpts)
+}
+
+// BuybackBurner is a free data retrieval call binding the contract method 0x82d14fd9.
+//
+// Solidity: function buybackBurner() view returns(address)
+func (_FeeSplitter *FeeSplitterCaller) BuybackBurner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "buybackBurner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// BuybackBurner is a free data retrieval call binding the contract method 0x82d14fd9.
+//
+// Solidity: function buybackBurner() view returns(address)
+func (_FeeSplitter *FeeSplitterSession) BuybackBurner() (common.Address, error) {
+	return _FeeSplitter.Contract.BuybackBurner(&_FeeSplitter.CallOpts)
+}
+
+// BuybackBurner is a free data retrieval call binding the contract method 0x82d14fd9.
+//
+// Solidity: function buybackBurner() view returns(address)
+func (_FeeSplitter *FeeSplitterCallerSession) BuybackBurner() (common.Address, error) {
+	return _FeeSplitter.Contract.BuybackBurner(&_FeeSplitter.CallOpts)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_FeeSplitter *FeeSplitterCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_FeeSplitter *FeeSplitterSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _FeeSplitter.Contract.GetRoleAdmin(&_FeeSplitter.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_FeeSplitter *FeeSplitterCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _FeeSplitter.Contract.GetRoleAdmin(&_FeeSplitter.CallOpts, role)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_FeeSplitter *FeeSplitterCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_FeeSplitter *FeeSplitterSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _FeeSplitter.Contract.HasRole(&_FeeSplitter.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_FeeSplitter *FeeSplitterCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _FeeSplitter.Contract.HasRole(&_FeeSplitter.CallOpts, role, account)
+}
+
+// PreviewSplit is a free data retrieval call binding the contract method 0x345290f1.
+//
+// Solidity: function previewSplit(uint256 amount, uint8 schedule) pure returns(uint256 primaryAmt, uint256 treasuryAmt, uint256 buybackAmt)
+func (_FeeSplitter *FeeSplitterCaller) PreviewSplit(opts *bind.CallOpts, amount *big.Int, schedule uint8) (struct {
+	PrimaryAmt  *big.Int
+	TreasuryAmt *big.Int
+	BuybackAmt  *big.Int
+}, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "previewSplit", amount, schedule)
+
+	outstruct := new(struct {
+		PrimaryAmt  *big.Int
+		TreasuryAmt *big.Int
+		BuybackAmt  *big.Int
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.PrimaryAmt = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.TreasuryAmt = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.BuybackAmt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+// PreviewSplit is a free data retrieval call binding the contract method 0x345290f1.
+//
+// Solidity: function previewSplit(uint256 amount, uint8 schedule) pure returns(uint256 primaryAmt, uint256 treasuryAmt, uint256 buybackAmt)
+func (_FeeSplitter *FeeSplitterSession) PreviewSplit(amount *big.Int, schedule uint8) (struct {
+	PrimaryAmt  *big.Int
+	TreasuryAmt *big.Int
+	BuybackAmt  *big.Int
+}, error) {
+	return _FeeSplitter.Contract.PreviewSplit(&_FeeSplitter.CallOpts, amount, schedule)
+}
+
+// PreviewSplit is a free data retrieval call binding the contract method 0x345290f1.
+//
+// Solidity: function previewSplit(uint256 amount, uint8 schedule) pure returns(uint256 primaryAmt, uint256 treasuryAmt, uint256 buybackAmt)
+func (_FeeSplitter *FeeSplitterCallerSession) PreviewSplit(amount *big.Int, schedule uint8) (struct {
+	PrimaryAmt  *big.Int
+	TreasuryAmt *big.Int
+	BuybackAmt  *big.Int
+}, error) {
+	return _FeeSplitter.Contract.PreviewSplit(&_FeeSplitter.CallOpts, amount, schedule)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_FeeSplitter *FeeSplitterCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_FeeSplitter *FeeSplitterSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _FeeSplitter.Contract.SupportsInterface(&_FeeSplitter.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_FeeSplitter *FeeSplitterCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _FeeSplitter.Contract.SupportsInterface(&_FeeSplitter.CallOpts, interfaceId)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_FeeSplitter *FeeSplitterCaller) Treasury(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _FeeSplitter.contract.Call(opts, &out, "treasury")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_FeeSplitter *FeeSplitterSession) Treasury() (common.Address, error) {
+	return _FeeSplitter.Contract.Treasury(&_FeeSplitter.CallOpts)
+}
+
+// Treasury is a free data retrieval call binding the contract method 0x61d027b3.
+//
+// Solidity: function treasury() view returns(address)
+func (_FeeSplitter *FeeSplitterCallerSession) Treasury() (common.Address, error) {
+	return _FeeSplitter.Contract.Treasury(&_FeeSplitter.CallOpts)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_FeeSplitter *FeeSplitterTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_FeeSplitter *FeeSplitterSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.GrantRole(&_FeeSplitter.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_FeeSplitter *FeeSplitterTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.GrantRole(&_FeeSplitter.TransactOpts, role, account)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_FeeSplitter *FeeSplitterTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_FeeSplitter *FeeSplitterSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.RenounceRole(&_FeeSplitter.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_FeeSplitter *FeeSplitterTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.RenounceRole(&_FeeSplitter.TransactOpts, role, callerConfirmation)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_FeeSplitter *FeeSplitterTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_FeeSplitter *FeeSplitterSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.RevokeRole(&_FeeSplitter.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_FeeSplitter *FeeSplitterTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.RevokeRole(&_FeeSplitter.TransactOpts, role, account)
+}
+
+// SetBuybackBurner is a paid mutator transaction binding the contract method 0x344e74b2.
+//
+// Solidity: function setBuybackBurner(address newBurner) returns()
+func (_FeeSplitter *FeeSplitterTransactor) SetBuybackBurner(opts *bind.TransactOpts, newBurner common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.contract.Transact(opts, "setBuybackBurner", newBurner)
+}
+
+// SetBuybackBurner is a paid mutator transaction binding the contract method 0x344e74b2.
+//
+// Solidity: function setBuybackBurner(address newBurner) returns()
+func (_FeeSplitter *FeeSplitterSession) SetBuybackBurner(newBurner common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.SetBuybackBurner(&_FeeSplitter.TransactOpts, newBurner)
+}
+
+// SetBuybackBurner is a paid mutator transaction binding the contract method 0x344e74b2.
+//
+// Solidity: function setBuybackBurner(address newBurner) returns()
+func (_FeeSplitter *FeeSplitterTransactorSession) SetBuybackBurner(newBurner common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.SetBuybackBurner(&_FeeSplitter.TransactOpts, newBurner)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_FeeSplitter *FeeSplitterTransactor) SetTreasury(opts *bind.TransactOpts, newTreasury common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.contract.Transact(opts, "setTreasury", newTreasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_FeeSplitter *FeeSplitterSession) SetTreasury(newTreasury common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.SetTreasury(&_FeeSplitter.TransactOpts, newTreasury)
+}
+
+// SetTreasury is a paid mutator transaction binding the contract method 0xf0f44260.
+//
+// Solidity: function setTreasury(address newTreasury) returns()
+func (_FeeSplitter *FeeSplitterTransactorSession) SetTreasury(newTreasury common.Address) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.SetTreasury(&_FeeSplitter.TransactOpts, newTreasury)
+}
+
+// Split is a paid mutator transaction binding the contract method 0x0f41ff3d.
+//
+// Solidity: function split(address token, uint256 amount, address primary, uint8 schedule) returns()
+func (_FeeSplitter *FeeSplitterTransactor) Split(opts *bind.TransactOpts, token common.Address, amount *big.Int, primary common.Address, schedule uint8) (*types.Transaction, error) {
+	return _FeeSplitter.contract.Transact(opts, "split", token, amount, primary, schedule)
+}
+
+// Split is a paid mutator transaction binding the contract method 0x0f41ff3d.
+//
+// Solidity: function split(address token, uint256 amount, address primary, uint8 schedule) returns()
+func (_FeeSplitter *FeeSplitterSession) Split(token common.Address, amount *big.Int, primary common.Address, schedule uint8) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.Split(&_FeeSplitter.TransactOpts, token, amount, primary, schedule)
+}
+
+// Split is a paid mutator transaction binding the contract method 0x0f41ff3d.
+//
+// Solidity: function split(address token, uint256 amount, address primary, uint8 schedule) returns()
+func (_FeeSplitter *FeeSplitterTransactorSession) Split(token common.Address, amount *big.Int, primary common.Address, schedule uint8) (*types.Transaction, error) {
+	return _FeeSplitter.Contract.Split(&_FeeSplitter.TransactOpts, token, amount, primary, schedule)
+}
+
+// FeeSplitterBuybackBurnerUpdatedIterator is returned from FilterBuybackBurnerUpdated and is used to iterate over the raw logs and unpacked data for BuybackBurnerUpdated events raised by the FeeSplitter contract.
+type FeeSplitterBuybackBurnerUpdatedIterator struct {
+	Event *FeeSplitterBuybackBurnerUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeSplitterBuybackBurnerUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeSplitterBuybackBurnerUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeSplitterBuybackBurnerUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeSplitterBuybackBurnerUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeSplitterBuybackBurnerUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeSplitterBuybackBurnerUpdated represents a BuybackBurnerUpdated event raised by the FeeSplitter contract.
+type FeeSplitterBuybackBurnerUpdated struct {
+	OldBurner common.Address
+	NewBurner common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterBuybackBurnerUpdated is a free log retrieval operation binding the contract event 0x2413e4696976dabb94237cb746c767cd0118c63bef644fdd08141569bee6331c.
+//
+// Solidity: event BuybackBurnerUpdated(address indexed oldBurner, address indexed newBurner)
+func (_FeeSplitter *FeeSplitterFilterer) FilterBuybackBurnerUpdated(opts *bind.FilterOpts, oldBurner []common.Address, newBurner []common.Address) (*FeeSplitterBuybackBurnerUpdatedIterator, error) {
+
+	var oldBurnerRule []interface{}
+	for _, oldBurnerItem := range oldBurner {
+		oldBurnerRule = append(oldBurnerRule, oldBurnerItem)
+	}
+	var newBurnerRule []interface{}
+	for _, newBurnerItem := range newBurner {
+		newBurnerRule = append(newBurnerRule, newBurnerItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.FilterLogs(opts, "BuybackBurnerUpdated", oldBurnerRule, newBurnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitterBuybackBurnerUpdatedIterator{contract: _FeeSplitter.contract, event: "BuybackBurnerUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchBuybackBurnerUpdated is a free log subscription operation binding the contract event 0x2413e4696976dabb94237cb746c767cd0118c63bef644fdd08141569bee6331c.
+//
+// Solidity: event BuybackBurnerUpdated(address indexed oldBurner, address indexed newBurner)
+func (_FeeSplitter *FeeSplitterFilterer) WatchBuybackBurnerUpdated(opts *bind.WatchOpts, sink chan<- *FeeSplitterBuybackBurnerUpdated, oldBurner []common.Address, newBurner []common.Address) (event.Subscription, error) {
+
+	var oldBurnerRule []interface{}
+	for _, oldBurnerItem := range oldBurner {
+		oldBurnerRule = append(oldBurnerRule, oldBurnerItem)
+	}
+	var newBurnerRule []interface{}
+	for _, newBurnerItem := range newBurner {
+		newBurnerRule = append(newBurnerRule, newBurnerItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.WatchLogs(opts, "BuybackBurnerUpdated", oldBurnerRule, newBurnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeSplitterBuybackBurnerUpdated)
+				if err := _FeeSplitter.contract.UnpackLog(event, "BuybackBurnerUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBuybackBurnerUpdated is a log parse operation binding the contract event 0x2413e4696976dabb94237cb746c767cd0118c63bef644fdd08141569bee6331c.
+//
+// Solidity: event BuybackBurnerUpdated(address indexed oldBurner, address indexed newBurner)
+func (_FeeSplitter *FeeSplitterFilterer) ParseBuybackBurnerUpdated(log types.Log) (*FeeSplitterBuybackBurnerUpdated, error) {
+	event := new(FeeSplitterBuybackBurnerUpdated)
+	if err := _FeeSplitter.contract.UnpackLog(event, "BuybackBurnerUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeSplitterFeeSplitIterator is returned from FilterFeeSplit and is used to iterate over the raw logs and unpacked data for FeeSplit events raised by the FeeSplitter contract.
+type FeeSplitterFeeSplitIterator struct {
+	Event *FeeSplitterFeeSplit // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeSplitterFeeSplitIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeSplitterFeeSplit)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeSplitterFeeSplit)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeSplitterFeeSplitIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeSplitterFeeSplitIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeSplitterFeeSplit represents a FeeSplit event raised by the FeeSplitter contract.
+type FeeSplitterFeeSplit struct {
+	Token          common.Address
+	Primary        common.Address
+	Schedule       uint8
+	PrimaryAmount  *big.Int
+	TreasuryAmount *big.Int
+	BuybackAmount  *big.Int
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterFeeSplit is a free log retrieval operation binding the contract event 0x396f3c0c854fc40380f8870c3e6c468a076d3510a63ecbf8c82c38fa647c098c.
+//
+// Solidity: event FeeSplit(address indexed token, address indexed primary, uint8 indexed schedule, uint256 primaryAmount, uint256 treasuryAmount, uint256 buybackAmount)
+func (_FeeSplitter *FeeSplitterFilterer) FilterFeeSplit(opts *bind.FilterOpts, token []common.Address, primary []common.Address, schedule []uint8) (*FeeSplitterFeeSplitIterator, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var primaryRule []interface{}
+	for _, primaryItem := range primary {
+		primaryRule = append(primaryRule, primaryItem)
+	}
+	var scheduleRule []interface{}
+	for _, scheduleItem := range schedule {
+		scheduleRule = append(scheduleRule, scheduleItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.FilterLogs(opts, "FeeSplit", tokenRule, primaryRule, scheduleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitterFeeSplitIterator{contract: _FeeSplitter.contract, event: "FeeSplit", logs: logs, sub: sub}, nil
+}
+
+// WatchFeeSplit is a free log subscription operation binding the contract event 0x396f3c0c854fc40380f8870c3e6c468a076d3510a63ecbf8c82c38fa647c098c.
+//
+// Solidity: event FeeSplit(address indexed token, address indexed primary, uint8 indexed schedule, uint256 primaryAmount, uint256 treasuryAmount, uint256 buybackAmount)
+func (_FeeSplitter *FeeSplitterFilterer) WatchFeeSplit(opts *bind.WatchOpts, sink chan<- *FeeSplitterFeeSplit, token []common.Address, primary []common.Address, schedule []uint8) (event.Subscription, error) {
+
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var primaryRule []interface{}
+	for _, primaryItem := range primary {
+		primaryRule = append(primaryRule, primaryItem)
+	}
+	var scheduleRule []interface{}
+	for _, scheduleItem := range schedule {
+		scheduleRule = append(scheduleRule, scheduleItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.WatchLogs(opts, "FeeSplit", tokenRule, primaryRule, scheduleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeSplitterFeeSplit)
+				if err := _FeeSplitter.contract.UnpackLog(event, "FeeSplit", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFeeSplit is a log parse operation binding the contract event 0x396f3c0c854fc40380f8870c3e6c468a076d3510a63ecbf8c82c38fa647c098c.
+//
+// Solidity: event FeeSplit(address indexed token, address indexed primary, uint8 indexed schedule, uint256 primaryAmount, uint256 treasuryAmount, uint256 buybackAmount)
+func (_FeeSplitter *FeeSplitterFilterer) ParseFeeSplit(log types.Log) (*FeeSplitterFeeSplit, error) {
+	event := new(FeeSplitterFeeSplit)
+	if err := _FeeSplitter.contract.UnpackLog(event, "FeeSplit", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeSplitterRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the FeeSplitter contract.
+type FeeSplitterRoleAdminChangedIterator struct {
+	Event *FeeSplitterRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeSplitterRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeSplitterRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeSplitterRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeSplitterRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeSplitterRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeSplitterRoleAdminChanged represents a RoleAdminChanged event raised by the FeeSplitter contract.
+type FeeSplitterRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_FeeSplitter *FeeSplitterFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*FeeSplitterRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitterRoleAdminChangedIterator{contract: _FeeSplitter.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_FeeSplitter *FeeSplitterFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *FeeSplitterRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeSplitterRoleAdminChanged)
+				if err := _FeeSplitter.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_FeeSplitter *FeeSplitterFilterer) ParseRoleAdminChanged(log types.Log) (*FeeSplitterRoleAdminChanged, error) {
+	event := new(FeeSplitterRoleAdminChanged)
+	if err := _FeeSplitter.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeSplitterRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the FeeSplitter contract.
+type FeeSplitterRoleGrantedIterator struct {
+	Event *FeeSplitterRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeSplitterRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeSplitterRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeSplitterRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeSplitterRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeSplitterRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeSplitterRoleGranted represents a RoleGranted event raised by the FeeSplitter contract.
+type FeeSplitterRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_FeeSplitter *FeeSplitterFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*FeeSplitterRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitterRoleGrantedIterator{contract: _FeeSplitter.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_FeeSplitter *FeeSplitterFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *FeeSplitterRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeSplitterRoleGranted)
+				if err := _FeeSplitter.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_FeeSplitter *FeeSplitterFilterer) ParseRoleGranted(log types.Log) (*FeeSplitterRoleGranted, error) {
+	event := new(FeeSplitterRoleGranted)
+	if err := _FeeSplitter.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeSplitterRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the FeeSplitter contract.
+type FeeSplitterRoleRevokedIterator struct {
+	Event *FeeSplitterRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeSplitterRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeSplitterRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeSplitterRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeSplitterRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeSplitterRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeSplitterRoleRevoked represents a RoleRevoked event raised by the FeeSplitter contract.
+type FeeSplitterRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_FeeSplitter *FeeSplitterFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*FeeSplitterRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitterRoleRevokedIterator{contract: _FeeSplitter.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_FeeSplitter *FeeSplitterFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *FeeSplitterRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeSplitterRoleRevoked)
+				if err := _FeeSplitter.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_FeeSplitter *FeeSplitterFilterer) ParseRoleRevoked(log types.Log) (*FeeSplitterRoleRevoked, error) {
+	event := new(FeeSplitterRoleRevoked)
+	if err := _FeeSplitter.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// FeeSplitterTreasuryUpdatedIterator is returned from FilterTreasuryUpdated and is used to iterate over the raw logs and unpacked data for TreasuryUpdated events raised by the FeeSplitter contract.
+type FeeSplitterTreasuryUpdatedIterator struct {
+	Event *FeeSplitterTreasuryUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FeeSplitterTreasuryUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FeeSplitterTreasuryUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FeeSplitterTreasuryUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FeeSplitterTreasuryUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FeeSplitterTreasuryUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FeeSplitterTreasuryUpdated represents a TreasuryUpdated event raised by the FeeSplitter contract.
+type FeeSplitterTreasuryUpdated struct {
+	OldTreasury common.Address
+	NewTreasury common.Address
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterTreasuryUpdated is a free log retrieval operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury)
+func (_FeeSplitter *FeeSplitterFilterer) FilterTreasuryUpdated(opts *bind.FilterOpts, oldTreasury []common.Address, newTreasury []common.Address) (*FeeSplitterTreasuryUpdatedIterator, error) {
+
+	var oldTreasuryRule []interface{}
+	for _, oldTreasuryItem := range oldTreasury {
+		oldTreasuryRule = append(oldTreasuryRule, oldTreasuryItem)
+	}
+	var newTreasuryRule []interface{}
+	for _, newTreasuryItem := range newTreasury {
+		newTreasuryRule = append(newTreasuryRule, newTreasuryItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.FilterLogs(opts, "TreasuryUpdated", oldTreasuryRule, newTreasuryRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FeeSplitterTreasuryUpdatedIterator{contract: _FeeSplitter.contract, event: "TreasuryUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchTreasuryUpdated is a free log subscription operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury)
+func (_FeeSplitter *FeeSplitterFilterer) WatchTreasuryUpdated(opts *bind.WatchOpts, sink chan<- *FeeSplitterTreasuryUpdated, oldTreasury []common.Address, newTreasury []common.Address) (event.Subscription, error) {
+
+	var oldTreasuryRule []interface{}
+	for _, oldTreasuryItem := range oldTreasury {
+		oldTreasuryRule = append(oldTreasuryRule, oldTreasuryItem)
+	}
+	var newTreasuryRule []interface{}
+	for _, newTreasuryItem := range newTreasury {
+		newTreasuryRule = append(newTreasuryRule, newTreasuryItem)
+	}
+
+	logs, sub, err := _FeeSplitter.contract.WatchLogs(opts, "TreasuryUpdated", oldTreasuryRule, newTreasuryRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FeeSplitterTreasuryUpdated)
+				if err := _FeeSplitter.contract.UnpackLog(event, "TreasuryUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTreasuryUpdated is a log parse operation binding the contract event 0x4ab5be82436d353e61ca18726e984e561f5c1cc7c6d38b29d2553c790434705a.
+//
+// Solidity: event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury)
+func (_FeeSplitter *FeeSplitterFilterer) ParseTreasuryUpdated(log types.Log) (*FeeSplitterTreasuryUpdated, error) {
+	event := new(FeeSplitterTreasuryUpdated)
+	if err := _FeeSplitter.contract.UnpackLog(event, "TreasuryUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_fund_transfer_hook.go
+++ b/services/indexer-go/internal/abi/acp_fund_transfer_hook.go
@@ -1,0 +1,545 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// FundTransferHookMetaData contains all meta data concerning the FundTransferHook contract.
+var FundTransferHookMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"hookName\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onAccept\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onApprove\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"context\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onCancel\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onReject\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onSubmit\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"event\",\"name\":\"FundTransferred\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"agent\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"token\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"agentAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"pnlAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"settlementAddr\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"InvalidBps\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// FundTransferHookABI is the input ABI used to generate the binding from.
+// Deprecated: Use FundTransferHookMetaData.ABI instead.
+var FundTransferHookABI = FundTransferHookMetaData.ABI
+
+// FundTransferHook is an auto generated Go binding around an Ethereum contract.
+type FundTransferHook struct {
+	FundTransferHookCaller     // Read-only binding to the contract
+	FundTransferHookTransactor // Write-only binding to the contract
+	FundTransferHookFilterer   // Log filterer for contract events
+}
+
+// FundTransferHookCaller is an auto generated read-only Go binding around an Ethereum contract.
+type FundTransferHookCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FundTransferHookTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type FundTransferHookTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FundTransferHookFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type FundTransferHookFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// FundTransferHookSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type FundTransferHookSession struct {
+	Contract     *FundTransferHook // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// FundTransferHookCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type FundTransferHookCallerSession struct {
+	Contract *FundTransferHookCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// FundTransferHookTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type FundTransferHookTransactorSession struct {
+	Contract     *FundTransferHookTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// FundTransferHookRaw is an auto generated low-level Go binding around an Ethereum contract.
+type FundTransferHookRaw struct {
+	Contract *FundTransferHook // Generic contract binding to access the raw methods on
+}
+
+// FundTransferHookCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type FundTransferHookCallerRaw struct {
+	Contract *FundTransferHookCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// FundTransferHookTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type FundTransferHookTransactorRaw struct {
+	Contract *FundTransferHookTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewFundTransferHook creates a new instance of FundTransferHook, bound to a specific deployed contract.
+func NewFundTransferHook(address common.Address, backend bind.ContractBackend) (*FundTransferHook, error) {
+	contract, err := bindFundTransferHook(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &FundTransferHook{FundTransferHookCaller: FundTransferHookCaller{contract: contract}, FundTransferHookTransactor: FundTransferHookTransactor{contract: contract}, FundTransferHookFilterer: FundTransferHookFilterer{contract: contract}}, nil
+}
+
+// NewFundTransferHookCaller creates a new read-only instance of FundTransferHook, bound to a specific deployed contract.
+func NewFundTransferHookCaller(address common.Address, caller bind.ContractCaller) (*FundTransferHookCaller, error) {
+	contract, err := bindFundTransferHook(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FundTransferHookCaller{contract: contract}, nil
+}
+
+// NewFundTransferHookTransactor creates a new write-only instance of FundTransferHook, bound to a specific deployed contract.
+func NewFundTransferHookTransactor(address common.Address, transactor bind.ContractTransactor) (*FundTransferHookTransactor, error) {
+	contract, err := bindFundTransferHook(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &FundTransferHookTransactor{contract: contract}, nil
+}
+
+// NewFundTransferHookFilterer creates a new log filterer instance of FundTransferHook, bound to a specific deployed contract.
+func NewFundTransferHookFilterer(address common.Address, filterer bind.ContractFilterer) (*FundTransferHookFilterer, error) {
+	contract, err := bindFundTransferHook(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &FundTransferHookFilterer{contract: contract}, nil
+}
+
+// bindFundTransferHook binds a generic wrapper to an already deployed contract.
+func bindFundTransferHook(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := FundTransferHookMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FundTransferHook *FundTransferHookRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FundTransferHook.Contract.FundTransferHookCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FundTransferHook *FundTransferHookRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FundTransferHook.Contract.FundTransferHookTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FundTransferHook *FundTransferHookRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FundTransferHook.Contract.FundTransferHookTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_FundTransferHook *FundTransferHookCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _FundTransferHook.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_FundTransferHook *FundTransferHookTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _FundTransferHook.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_FundTransferHook *FundTransferHookTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _FundTransferHook.Contract.contract.Transact(opts, method, params...)
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_FundTransferHook *FundTransferHookCaller) BPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _FundTransferHook.contract.Call(opts, &out, "BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_FundTransferHook *FundTransferHookSession) BPS() (*big.Int, error) {
+	return _FundTransferHook.Contract.BPS(&_FundTransferHook.CallOpts)
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_FundTransferHook *FundTransferHookCallerSession) BPS() (*big.Int, error) {
+	return _FundTransferHook.Contract.BPS(&_FundTransferHook.CallOpts)
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_FundTransferHook *FundTransferHookCaller) HookName(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _FundTransferHook.contract.Call(opts, &out, "hookName")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_FundTransferHook *FundTransferHookSession) HookName() (string, error) {
+	return _FundTransferHook.Contract.HookName(&_FundTransferHook.CallOpts)
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_FundTransferHook *FundTransferHookCallerSession) HookName() (string, error) {
+	return _FundTransferHook.Contract.HookName(&_FundTransferHook.CallOpts)
+}
+
+// OnAccept is a free data retrieval call binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookCaller) OnAccept(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _FundTransferHook.contract.Call(opts, &out, "onAccept", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnAccept is a free data retrieval call binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookSession) OnAccept(arg0 *big.Int, arg1 []byte) error {
+	return _FundTransferHook.Contract.OnAccept(&_FundTransferHook.CallOpts, arg0, arg1)
+}
+
+// OnAccept is a free data retrieval call binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookCallerSession) OnAccept(arg0 *big.Int, arg1 []byte) error {
+	return _FundTransferHook.Contract.OnAccept(&_FundTransferHook.CallOpts, arg0, arg1)
+}
+
+// OnCancel is a free data retrieval call binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookCaller) OnCancel(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _FundTransferHook.contract.Call(opts, &out, "onCancel", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnCancel is a free data retrieval call binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookSession) OnCancel(arg0 *big.Int, arg1 []byte) error {
+	return _FundTransferHook.Contract.OnCancel(&_FundTransferHook.CallOpts, arg0, arg1)
+}
+
+// OnCancel is a free data retrieval call binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookCallerSession) OnCancel(arg0 *big.Int, arg1 []byte) error {
+	return _FundTransferHook.Contract.OnCancel(&_FundTransferHook.CallOpts, arg0, arg1)
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookCaller) OnReject(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _FundTransferHook.contract.Call(opts, &out, "onReject", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookSession) OnReject(arg0 *big.Int, arg1 []byte) error {
+	return _FundTransferHook.Contract.OnReject(&_FundTransferHook.CallOpts, arg0, arg1)
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookCallerSession) OnReject(arg0 *big.Int, arg1 []byte) error {
+	return _FundTransferHook.Contract.OnReject(&_FundTransferHook.CallOpts, arg0, arg1)
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookCaller) OnSubmit(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _FundTransferHook.contract.Call(opts, &out, "onSubmit", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookSession) OnSubmit(arg0 *big.Int, arg1 []byte) error {
+	return _FundTransferHook.Contract.OnSubmit(&_FundTransferHook.CallOpts, arg0, arg1)
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_FundTransferHook *FundTransferHookCallerSession) OnSubmit(arg0 *big.Int, arg1 []byte) error {
+	return _FundTransferHook.Contract.OnSubmit(&_FundTransferHook.CallOpts, arg0, arg1)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes context) returns()
+func (_FundTransferHook *FundTransferHookTransactor) OnApprove(opts *bind.TransactOpts, jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _FundTransferHook.contract.Transact(opts, "onApprove", jobId, context)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes context) returns()
+func (_FundTransferHook *FundTransferHookSession) OnApprove(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _FundTransferHook.Contract.OnApprove(&_FundTransferHook.TransactOpts, jobId, context)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes context) returns()
+func (_FundTransferHook *FundTransferHookTransactorSession) OnApprove(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _FundTransferHook.Contract.OnApprove(&_FundTransferHook.TransactOpts, jobId, context)
+}
+
+// FundTransferHookFundTransferredIterator is returned from FilterFundTransferred and is used to iterate over the raw logs and unpacked data for FundTransferred events raised by the FundTransferHook contract.
+type FundTransferHookFundTransferredIterator struct {
+	Event *FundTransferHookFundTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *FundTransferHookFundTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(FundTransferHookFundTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(FundTransferHookFundTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *FundTransferHookFundTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *FundTransferHookFundTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// FundTransferHookFundTransferred represents a FundTransferred event raised by the FundTransferHook contract.
+type FundTransferHookFundTransferred struct {
+	JobId          *big.Int
+	Agent          common.Address
+	Token          common.Address
+	AgentAmount    *big.Int
+	PnlAmount      *big.Int
+	SettlementAddr common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterFundTransferred is a free log retrieval operation binding the contract event 0xa33cd98019ad28fa37fbbc444267ba860abc1c449e0f9bdad074d09cdae5ebb1.
+//
+// Solidity: event FundTransferred(uint256 indexed jobId, address indexed agent, address indexed token, uint256 agentAmount, uint256 pnlAmount, address settlementAddr)
+func (_FundTransferHook *FundTransferHookFilterer) FilterFundTransferred(opts *bind.FilterOpts, jobId []*big.Int, agent []common.Address, token []common.Address) (*FundTransferHookFundTransferredIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var agentRule []interface{}
+	for _, agentItem := range agent {
+		agentRule = append(agentRule, agentItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	logs, sub, err := _FundTransferHook.contract.FilterLogs(opts, "FundTransferred", jobIdRule, agentRule, tokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return &FundTransferHookFundTransferredIterator{contract: _FundTransferHook.contract, event: "FundTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchFundTransferred is a free log subscription operation binding the contract event 0xa33cd98019ad28fa37fbbc444267ba860abc1c449e0f9bdad074d09cdae5ebb1.
+//
+// Solidity: event FundTransferred(uint256 indexed jobId, address indexed agent, address indexed token, uint256 agentAmount, uint256 pnlAmount, address settlementAddr)
+func (_FundTransferHook *FundTransferHookFilterer) WatchFundTransferred(opts *bind.WatchOpts, sink chan<- *FundTransferHookFundTransferred, jobId []*big.Int, agent []common.Address, token []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var agentRule []interface{}
+	for _, agentItem := range agent {
+		agentRule = append(agentRule, agentItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+
+	logs, sub, err := _FundTransferHook.contract.WatchLogs(opts, "FundTransferred", jobIdRule, agentRule, tokenRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(FundTransferHookFundTransferred)
+				if err := _FundTransferHook.contract.UnpackLog(event, "FundTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseFundTransferred is a log parse operation binding the contract event 0xa33cd98019ad28fa37fbbc444267ba860abc1c449e0f9bdad074d09cdae5ebb1.
+//
+// Solidity: event FundTransferred(uint256 indexed jobId, address indexed agent, address indexed token, uint256 agentAmount, uint256 pnlAmount, address settlementAddr)
+func (_FundTransferHook *FundTransferHookFilterer) ParseFundTransferred(log types.Log) (*FundTransferHookFundTransferred, error) {
+	event := new(FundTransferHookFundTransferred)
+	if err := _FundTransferHook.contract.UnpackLog(event, "FundTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_hook_registry.go
+++ b/services/indexer-go/internal/abi/acp_hook_registry.go
@@ -1,0 +1,1284 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// HookRegistryHookInfo is an auto generated low-level Go binding around an user-defined struct.
+type HookRegistryHookInfo struct {
+	Approved bool
+	Name     string
+}
+
+// HookRegistryMetaData contains all meta data concerning the HookRegistry contract.
+var HookRegistryMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"admin\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"allHooks\",\"inputs\":[],\"outputs\":[{\"name\":\"addresses\",\"type\":\"address[]\",\"internalType\":\"address[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"deregisterHook\",\"inputs\":[{\"name\":\"hook\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getHookInfo\",\"inputs\":[{\"name\":\"hook\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"info\",\"type\":\"tuple\",\"internalType\":\"structHookRegistry.HookInfo\",\"components\":[{\"name\":\"approved\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isApproved\",\"inputs\":[{\"name\":\"hook\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"approved\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registerHook\",\"inputs\":[{\"name\":\"hook\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"HookDeregistered\",\"inputs\":[{\"name\":\"hook\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"HookRegistered\",\"inputs\":[{\"name\":\"hook\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"AlreadyRegistered\",\"inputs\":[{\"name\":\"hook\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"NotRegistered\",\"inputs\":[{\"name\":\"hook\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]}]",
+}
+
+// HookRegistryABI is the input ABI used to generate the binding from.
+// Deprecated: Use HookRegistryMetaData.ABI instead.
+var HookRegistryABI = HookRegistryMetaData.ABI
+
+// HookRegistry is an auto generated Go binding around an Ethereum contract.
+type HookRegistry struct {
+	HookRegistryCaller     // Read-only binding to the contract
+	HookRegistryTransactor // Write-only binding to the contract
+	HookRegistryFilterer   // Log filterer for contract events
+}
+
+// HookRegistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type HookRegistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// HookRegistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type HookRegistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// HookRegistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type HookRegistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// HookRegistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type HookRegistrySession struct {
+	Contract     *HookRegistry     // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// HookRegistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type HookRegistryCallerSession struct {
+	Contract *HookRegistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts       // Call options to use throughout this session
+}
+
+// HookRegistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type HookRegistryTransactorSession struct {
+	Contract     *HookRegistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts       // Transaction auth options to use throughout this session
+}
+
+// HookRegistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type HookRegistryRaw struct {
+	Contract *HookRegistry // Generic contract binding to access the raw methods on
+}
+
+// HookRegistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type HookRegistryCallerRaw struct {
+	Contract *HookRegistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// HookRegistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type HookRegistryTransactorRaw struct {
+	Contract *HookRegistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewHookRegistry creates a new instance of HookRegistry, bound to a specific deployed contract.
+func NewHookRegistry(address common.Address, backend bind.ContractBackend) (*HookRegistry, error) {
+	contract, err := bindHookRegistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &HookRegistry{HookRegistryCaller: HookRegistryCaller{contract: contract}, HookRegistryTransactor: HookRegistryTransactor{contract: contract}, HookRegistryFilterer: HookRegistryFilterer{contract: contract}}, nil
+}
+
+// NewHookRegistryCaller creates a new read-only instance of HookRegistry, bound to a specific deployed contract.
+func NewHookRegistryCaller(address common.Address, caller bind.ContractCaller) (*HookRegistryCaller, error) {
+	contract, err := bindHookRegistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &HookRegistryCaller{contract: contract}, nil
+}
+
+// NewHookRegistryTransactor creates a new write-only instance of HookRegistry, bound to a specific deployed contract.
+func NewHookRegistryTransactor(address common.Address, transactor bind.ContractTransactor) (*HookRegistryTransactor, error) {
+	contract, err := bindHookRegistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &HookRegistryTransactor{contract: contract}, nil
+}
+
+// NewHookRegistryFilterer creates a new log filterer instance of HookRegistry, bound to a specific deployed contract.
+func NewHookRegistryFilterer(address common.Address, filterer bind.ContractFilterer) (*HookRegistryFilterer, error) {
+	contract, err := bindHookRegistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &HookRegistryFilterer{contract: contract}, nil
+}
+
+// bindHookRegistry binds a generic wrapper to an already deployed contract.
+func bindHookRegistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := HookRegistryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_HookRegistry *HookRegistryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _HookRegistry.Contract.HookRegistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_HookRegistry *HookRegistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _HookRegistry.Contract.HookRegistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_HookRegistry *HookRegistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _HookRegistry.Contract.HookRegistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_HookRegistry *HookRegistryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _HookRegistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_HookRegistry *HookRegistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _HookRegistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_HookRegistry *HookRegistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _HookRegistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_HookRegistry *HookRegistryCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _HookRegistry.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_HookRegistry *HookRegistrySession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _HookRegistry.Contract.DEFAULTADMINROLE(&_HookRegistry.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_HookRegistry *HookRegistryCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _HookRegistry.Contract.DEFAULTADMINROLE(&_HookRegistry.CallOpts)
+}
+
+// AllHooks is a free data retrieval call binding the contract method 0x3d5522f2.
+//
+// Solidity: function allHooks() view returns(address[] addresses)
+func (_HookRegistry *HookRegistryCaller) AllHooks(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []interface{}
+	err := _HookRegistry.contract.Call(opts, &out, "allHooks")
+
+	if err != nil {
+		return *new([]common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address)
+
+	return out0, err
+
+}
+
+// AllHooks is a free data retrieval call binding the contract method 0x3d5522f2.
+//
+// Solidity: function allHooks() view returns(address[] addresses)
+func (_HookRegistry *HookRegistrySession) AllHooks() ([]common.Address, error) {
+	return _HookRegistry.Contract.AllHooks(&_HookRegistry.CallOpts)
+}
+
+// AllHooks is a free data retrieval call binding the contract method 0x3d5522f2.
+//
+// Solidity: function allHooks() view returns(address[] addresses)
+func (_HookRegistry *HookRegistryCallerSession) AllHooks() ([]common.Address, error) {
+	return _HookRegistry.Contract.AllHooks(&_HookRegistry.CallOpts)
+}
+
+// GetHookInfo is a free data retrieval call binding the contract method 0x25c7f789.
+//
+// Solidity: function getHookInfo(address hook) view returns((bool,string) info)
+func (_HookRegistry *HookRegistryCaller) GetHookInfo(opts *bind.CallOpts, hook common.Address) (HookRegistryHookInfo, error) {
+	var out []interface{}
+	err := _HookRegistry.contract.Call(opts, &out, "getHookInfo", hook)
+
+	if err != nil {
+		return *new(HookRegistryHookInfo), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(HookRegistryHookInfo)).(*HookRegistryHookInfo)
+
+	return out0, err
+
+}
+
+// GetHookInfo is a free data retrieval call binding the contract method 0x25c7f789.
+//
+// Solidity: function getHookInfo(address hook) view returns((bool,string) info)
+func (_HookRegistry *HookRegistrySession) GetHookInfo(hook common.Address) (HookRegistryHookInfo, error) {
+	return _HookRegistry.Contract.GetHookInfo(&_HookRegistry.CallOpts, hook)
+}
+
+// GetHookInfo is a free data retrieval call binding the contract method 0x25c7f789.
+//
+// Solidity: function getHookInfo(address hook) view returns((bool,string) info)
+func (_HookRegistry *HookRegistryCallerSession) GetHookInfo(hook common.Address) (HookRegistryHookInfo, error) {
+	return _HookRegistry.Contract.GetHookInfo(&_HookRegistry.CallOpts, hook)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_HookRegistry *HookRegistryCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _HookRegistry.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_HookRegistry *HookRegistrySession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _HookRegistry.Contract.GetRoleAdmin(&_HookRegistry.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_HookRegistry *HookRegistryCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _HookRegistry.Contract.GetRoleAdmin(&_HookRegistry.CallOpts, role)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_HookRegistry *HookRegistryCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _HookRegistry.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_HookRegistry *HookRegistrySession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _HookRegistry.Contract.HasRole(&_HookRegistry.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_HookRegistry *HookRegistryCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _HookRegistry.Contract.HasRole(&_HookRegistry.CallOpts, role, account)
+}
+
+// IsApproved is a free data retrieval call binding the contract method 0x673448dd.
+//
+// Solidity: function isApproved(address hook) view returns(bool approved)
+func (_HookRegistry *HookRegistryCaller) IsApproved(opts *bind.CallOpts, hook common.Address) (bool, error) {
+	var out []interface{}
+	err := _HookRegistry.contract.Call(opts, &out, "isApproved", hook)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsApproved is a free data retrieval call binding the contract method 0x673448dd.
+//
+// Solidity: function isApproved(address hook) view returns(bool approved)
+func (_HookRegistry *HookRegistrySession) IsApproved(hook common.Address) (bool, error) {
+	return _HookRegistry.Contract.IsApproved(&_HookRegistry.CallOpts, hook)
+}
+
+// IsApproved is a free data retrieval call binding the contract method 0x673448dd.
+//
+// Solidity: function isApproved(address hook) view returns(bool approved)
+func (_HookRegistry *HookRegistryCallerSession) IsApproved(hook common.Address) (bool, error) {
+	return _HookRegistry.Contract.IsApproved(&_HookRegistry.CallOpts, hook)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_HookRegistry *HookRegistryCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _HookRegistry.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_HookRegistry *HookRegistrySession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _HookRegistry.Contract.SupportsInterface(&_HookRegistry.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_HookRegistry *HookRegistryCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _HookRegistry.Contract.SupportsInterface(&_HookRegistry.CallOpts, interfaceId)
+}
+
+// DeregisterHook is a paid mutator transaction binding the contract method 0xc58e9eb0.
+//
+// Solidity: function deregisterHook(address hook) returns()
+func (_HookRegistry *HookRegistryTransactor) DeregisterHook(opts *bind.TransactOpts, hook common.Address) (*types.Transaction, error) {
+	return _HookRegistry.contract.Transact(opts, "deregisterHook", hook)
+}
+
+// DeregisterHook is a paid mutator transaction binding the contract method 0xc58e9eb0.
+//
+// Solidity: function deregisterHook(address hook) returns()
+func (_HookRegistry *HookRegistrySession) DeregisterHook(hook common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.DeregisterHook(&_HookRegistry.TransactOpts, hook)
+}
+
+// DeregisterHook is a paid mutator transaction binding the contract method 0xc58e9eb0.
+//
+// Solidity: function deregisterHook(address hook) returns()
+func (_HookRegistry *HookRegistryTransactorSession) DeregisterHook(hook common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.DeregisterHook(&_HookRegistry.TransactOpts, hook)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_HookRegistry *HookRegistryTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _HookRegistry.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_HookRegistry *HookRegistrySession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.GrantRole(&_HookRegistry.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_HookRegistry *HookRegistryTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.GrantRole(&_HookRegistry.TransactOpts, role, account)
+}
+
+// RegisterHook is a paid mutator transaction binding the contract method 0x6354b661.
+//
+// Solidity: function registerHook(address hook) returns()
+func (_HookRegistry *HookRegistryTransactor) RegisterHook(opts *bind.TransactOpts, hook common.Address) (*types.Transaction, error) {
+	return _HookRegistry.contract.Transact(opts, "registerHook", hook)
+}
+
+// RegisterHook is a paid mutator transaction binding the contract method 0x6354b661.
+//
+// Solidity: function registerHook(address hook) returns()
+func (_HookRegistry *HookRegistrySession) RegisterHook(hook common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.RegisterHook(&_HookRegistry.TransactOpts, hook)
+}
+
+// RegisterHook is a paid mutator transaction binding the contract method 0x6354b661.
+//
+// Solidity: function registerHook(address hook) returns()
+func (_HookRegistry *HookRegistryTransactorSession) RegisterHook(hook common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.RegisterHook(&_HookRegistry.TransactOpts, hook)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_HookRegistry *HookRegistryTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _HookRegistry.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_HookRegistry *HookRegistrySession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.RenounceRole(&_HookRegistry.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_HookRegistry *HookRegistryTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.RenounceRole(&_HookRegistry.TransactOpts, role, callerConfirmation)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_HookRegistry *HookRegistryTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _HookRegistry.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_HookRegistry *HookRegistrySession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.RevokeRole(&_HookRegistry.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_HookRegistry *HookRegistryTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _HookRegistry.Contract.RevokeRole(&_HookRegistry.TransactOpts, role, account)
+}
+
+// HookRegistryHookDeregisteredIterator is returned from FilterHookDeregistered and is used to iterate over the raw logs and unpacked data for HookDeregistered events raised by the HookRegistry contract.
+type HookRegistryHookDeregisteredIterator struct {
+	Event *HookRegistryHookDeregistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *HookRegistryHookDeregisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(HookRegistryHookDeregistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(HookRegistryHookDeregistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *HookRegistryHookDeregisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *HookRegistryHookDeregisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// HookRegistryHookDeregistered represents a HookDeregistered event raised by the HookRegistry contract.
+type HookRegistryHookDeregistered struct {
+	Hook common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookDeregistered is a free log retrieval operation binding the contract event 0x5f04ed00bba892fd984432cd96beabe664a2de332ff480f08ec0c135c0372d55.
+//
+// Solidity: event HookDeregistered(address indexed hook)
+func (_HookRegistry *HookRegistryFilterer) FilterHookDeregistered(opts *bind.FilterOpts, hook []common.Address) (*HookRegistryHookDeregisteredIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.FilterLogs(opts, "HookDeregistered", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &HookRegistryHookDeregisteredIterator{contract: _HookRegistry.contract, event: "HookDeregistered", logs: logs, sub: sub}, nil
+}
+
+// WatchHookDeregistered is a free log subscription operation binding the contract event 0x5f04ed00bba892fd984432cd96beabe664a2de332ff480f08ec0c135c0372d55.
+//
+// Solidity: event HookDeregistered(address indexed hook)
+func (_HookRegistry *HookRegistryFilterer) WatchHookDeregistered(opts *bind.WatchOpts, sink chan<- *HookRegistryHookDeregistered, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.WatchLogs(opts, "HookDeregistered", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(HookRegistryHookDeregistered)
+				if err := _HookRegistry.contract.UnpackLog(event, "HookDeregistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookDeregistered is a log parse operation binding the contract event 0x5f04ed00bba892fd984432cd96beabe664a2de332ff480f08ec0c135c0372d55.
+//
+// Solidity: event HookDeregistered(address indexed hook)
+func (_HookRegistry *HookRegistryFilterer) ParseHookDeregistered(log types.Log) (*HookRegistryHookDeregistered, error) {
+	event := new(HookRegistryHookDeregistered)
+	if err := _HookRegistry.contract.UnpackLog(event, "HookDeregistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// HookRegistryHookRegisteredIterator is returned from FilterHookRegistered and is used to iterate over the raw logs and unpacked data for HookRegistered events raised by the HookRegistry contract.
+type HookRegistryHookRegisteredIterator struct {
+	Event *HookRegistryHookRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *HookRegistryHookRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(HookRegistryHookRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(HookRegistryHookRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *HookRegistryHookRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *HookRegistryHookRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// HookRegistryHookRegistered represents a HookRegistered event raised by the HookRegistry contract.
+type HookRegistryHookRegistered struct {
+	Hook common.Address
+	Name string
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterHookRegistered is a free log retrieval operation binding the contract event 0x8096ae10f94d9c9266fe844741548a8afe2a55900eb4607c7a5c3dd5560651a9.
+//
+// Solidity: event HookRegistered(address indexed hook, string name)
+func (_HookRegistry *HookRegistryFilterer) FilterHookRegistered(opts *bind.FilterOpts, hook []common.Address) (*HookRegistryHookRegisteredIterator, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.FilterLogs(opts, "HookRegistered", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return &HookRegistryHookRegisteredIterator{contract: _HookRegistry.contract, event: "HookRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchHookRegistered is a free log subscription operation binding the contract event 0x8096ae10f94d9c9266fe844741548a8afe2a55900eb4607c7a5c3dd5560651a9.
+//
+// Solidity: event HookRegistered(address indexed hook, string name)
+func (_HookRegistry *HookRegistryFilterer) WatchHookRegistered(opts *bind.WatchOpts, sink chan<- *HookRegistryHookRegistered, hook []common.Address) (event.Subscription, error) {
+
+	var hookRule []interface{}
+	for _, hookItem := range hook {
+		hookRule = append(hookRule, hookItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.WatchLogs(opts, "HookRegistered", hookRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(HookRegistryHookRegistered)
+				if err := _HookRegistry.contract.UnpackLog(event, "HookRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseHookRegistered is a log parse operation binding the contract event 0x8096ae10f94d9c9266fe844741548a8afe2a55900eb4607c7a5c3dd5560651a9.
+//
+// Solidity: event HookRegistered(address indexed hook, string name)
+func (_HookRegistry *HookRegistryFilterer) ParseHookRegistered(log types.Log) (*HookRegistryHookRegistered, error) {
+	event := new(HookRegistryHookRegistered)
+	if err := _HookRegistry.contract.UnpackLog(event, "HookRegistered", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// HookRegistryRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the HookRegistry contract.
+type HookRegistryRoleAdminChangedIterator struct {
+	Event *HookRegistryRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *HookRegistryRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(HookRegistryRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(HookRegistryRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *HookRegistryRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *HookRegistryRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// HookRegistryRoleAdminChanged represents a RoleAdminChanged event raised by the HookRegistry contract.
+type HookRegistryRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_HookRegistry *HookRegistryFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*HookRegistryRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &HookRegistryRoleAdminChangedIterator{contract: _HookRegistry.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_HookRegistry *HookRegistryFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *HookRegistryRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(HookRegistryRoleAdminChanged)
+				if err := _HookRegistry.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_HookRegistry *HookRegistryFilterer) ParseRoleAdminChanged(log types.Log) (*HookRegistryRoleAdminChanged, error) {
+	event := new(HookRegistryRoleAdminChanged)
+	if err := _HookRegistry.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// HookRegistryRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the HookRegistry contract.
+type HookRegistryRoleGrantedIterator struct {
+	Event *HookRegistryRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *HookRegistryRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(HookRegistryRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(HookRegistryRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *HookRegistryRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *HookRegistryRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// HookRegistryRoleGranted represents a RoleGranted event raised by the HookRegistry contract.
+type HookRegistryRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_HookRegistry *HookRegistryFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*HookRegistryRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &HookRegistryRoleGrantedIterator{contract: _HookRegistry.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_HookRegistry *HookRegistryFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *HookRegistryRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(HookRegistryRoleGranted)
+				if err := _HookRegistry.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_HookRegistry *HookRegistryFilterer) ParseRoleGranted(log types.Log) (*HookRegistryRoleGranted, error) {
+	event := new(HookRegistryRoleGranted)
+	if err := _HookRegistry.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// HookRegistryRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the HookRegistry contract.
+type HookRegistryRoleRevokedIterator struct {
+	Event *HookRegistryRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *HookRegistryRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(HookRegistryRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(HookRegistryRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *HookRegistryRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *HookRegistryRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// HookRegistryRoleRevoked represents a RoleRevoked event raised by the HookRegistry contract.
+type HookRegistryRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_HookRegistry *HookRegistryFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*HookRegistryRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &HookRegistryRoleRevokedIterator{contract: _HookRegistry.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_HookRegistry *HookRegistryFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *HookRegistryRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _HookRegistry.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(HookRegistryRoleRevoked)
+				if err := _HookRegistry.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_HookRegistry *HookRegistryFilterer) ParseRoleRevoked(log types.Log) (*HookRegistryRoleRevoked, error) {
+	event := new(HookRegistryRoleRevoked)
+	if err := _HookRegistry.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_job.go
+++ b/services/indexer-go/internal/abi/acp_job.go
@@ -1,0 +1,2654 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// JobInitParams is an auto generated low-level Go binding around an user-defined struct.
+type JobInitParams struct {
+	JobId         *big.Int
+	Principal     common.Address
+	Registry      common.Address
+	TargetAgentId *big.Int
+	Token         common.Address
+	Budget        *big.Int
+	Deadline      uint64
+	JobType       uint8
+	Evaluator     common.Address
+	Arbiter       common.Address
+}
+
+// JobMetaData contains all meta data concerning the Job contract.
+var JobMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"DISPUTE_GRACE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"RELEASE_GRACE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"accept\",\"inputs\":[{\"name\":\"_agentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"agent\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"agentId\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"approveResult\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"arbiter\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"budget\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"cancel\",\"inputs\":[{\"name\":\"reason\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"currentPhase\",\"inputs\":[],\"outputs\":[{\"name\":\"current\",\"type\":\"uint8\",\"internalType\":\"enumIJob.Phase\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"deadline\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"evaluator\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"expireJob\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"p\",\"type\":\"tuple\",\"internalType\":\"structJob.InitParams\",\"components\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"principal\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"registry\",\"type\":\"address\",\"internalType\":\"contractAgentRegistry\"},{\"name\":\"targetAgentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"budget\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deadline\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"jobType\",\"type\":\"uint8\",\"internalType\":\"enumIJob.JobType\"},{\"name\":\"evaluator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"arbiter\",\"type\":\"address\",\"internalType\":\"address\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"jobId\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"jobType\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"enumIJob.JobType\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"phase\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"enumIJob.Phase\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"principal\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"raiseDispute\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractAgentRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"rejectResult\",\"inputs\":[{\"name\":\"reason\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"release\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"resolveDispute\",\"inputs\":[{\"name\":\"agentFavoured\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"resultSubmittedAt\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"resultURI\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"submitResult\",\"inputs\":[{\"name\":\"_resultURI\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"targetAgentId\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"token\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"AgentAccepted\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"agent\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DisputeRaised\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"raisedBy\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"DisputeResolved\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"resolver\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"agentFavoured\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"EvaluatorAssigned\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"evaluator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"JobCancelled\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"cancelledBy\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"reason\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"JobCompleted\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"releasedBy\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"JobInitialised\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"principal\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"agentId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"jobType\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumIJob.JobType\"},{\"name\":\"budget\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"deadline\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ResultApproved\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"evaluator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ResultRejected\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"evaluator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"reason\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ResultSubmitted\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"agent\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"resultURI\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AgentInactive\",\"inputs\":[{\"name\":\"id\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"AgentNotFound\",\"inputs\":[{\"name\":\"id\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"AlreadyInitialized\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"DirectJobNoEvaluator\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"EvaluatorRequired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"GracePeriodActive\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidDeadline\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidJobType\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"JobNotExpired\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotAgent\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotArbiter\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotEvaluator\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotPrincipal\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ReentrancyGuardReentrantCall\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"TokenMismatch\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"WrongPhase\",\"inputs\":[{\"name\":\"current\",\"type\":\"uint8\",\"internalType\":\"enumIJob.Phase\"},{\"name\":\"required\",\"type\":\"uint8\",\"internalType\":\"enumIJob.Phase\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// JobABI is the input ABI used to generate the binding from.
+// Deprecated: Use JobMetaData.ABI instead.
+var JobABI = JobMetaData.ABI
+
+// Job is an auto generated Go binding around an Ethereum contract.
+type Job struct {
+	JobCaller     // Read-only binding to the contract
+	JobTransactor // Write-only binding to the contract
+	JobFilterer   // Log filterer for contract events
+}
+
+// JobCaller is an auto generated read-only Go binding around an Ethereum contract.
+type JobCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// JobTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type JobTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// JobFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type JobFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// JobSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type JobSession struct {
+	Contract     *Job              // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// JobCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type JobCallerSession struct {
+	Contract *JobCaller    // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// JobTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type JobTransactorSession struct {
+	Contract     *JobTransactor    // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// JobRaw is an auto generated low-level Go binding around an Ethereum contract.
+type JobRaw struct {
+	Contract *Job // Generic contract binding to access the raw methods on
+}
+
+// JobCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type JobCallerRaw struct {
+	Contract *JobCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// JobTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type JobTransactorRaw struct {
+	Contract *JobTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewJob creates a new instance of Job, bound to a specific deployed contract.
+func NewJob(address common.Address, backend bind.ContractBackend) (*Job, error) {
+	contract, err := bindJob(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Job{JobCaller: JobCaller{contract: contract}, JobTransactor: JobTransactor{contract: contract}, JobFilterer: JobFilterer{contract: contract}}, nil
+}
+
+// NewJobCaller creates a new read-only instance of Job, bound to a specific deployed contract.
+func NewJobCaller(address common.Address, caller bind.ContractCaller) (*JobCaller, error) {
+	contract, err := bindJob(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &JobCaller{contract: contract}, nil
+}
+
+// NewJobTransactor creates a new write-only instance of Job, bound to a specific deployed contract.
+func NewJobTransactor(address common.Address, transactor bind.ContractTransactor) (*JobTransactor, error) {
+	contract, err := bindJob(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &JobTransactor{contract: contract}, nil
+}
+
+// NewJobFilterer creates a new log filterer instance of Job, bound to a specific deployed contract.
+func NewJobFilterer(address common.Address, filterer bind.ContractFilterer) (*JobFilterer, error) {
+	contract, err := bindJob(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFilterer{contract: contract}, nil
+}
+
+// bindJob binds a generic wrapper to an already deployed contract.
+func bindJob(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := JobMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Job *JobRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Job.Contract.JobCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Job *JobRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Job.Contract.JobTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Job *JobRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Job.Contract.JobTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Job *JobCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Job.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Job *JobTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Job.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Job *JobTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Job.Contract.contract.Transact(opts, method, params...)
+}
+
+// DISPUTEGRACE is a free data retrieval call binding the contract method 0x276a556e.
+//
+// Solidity: function DISPUTE_GRACE() view returns(uint64)
+func (_Job *JobCaller) DISPUTEGRACE(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "DISPUTE_GRACE")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// DISPUTEGRACE is a free data retrieval call binding the contract method 0x276a556e.
+//
+// Solidity: function DISPUTE_GRACE() view returns(uint64)
+func (_Job *JobSession) DISPUTEGRACE() (uint64, error) {
+	return _Job.Contract.DISPUTEGRACE(&_Job.CallOpts)
+}
+
+// DISPUTEGRACE is a free data retrieval call binding the contract method 0x276a556e.
+//
+// Solidity: function DISPUTE_GRACE() view returns(uint64)
+func (_Job *JobCallerSession) DISPUTEGRACE() (uint64, error) {
+	return _Job.Contract.DISPUTEGRACE(&_Job.CallOpts)
+}
+
+// RELEASEGRACE is a free data retrieval call binding the contract method 0xe73ad7c6.
+//
+// Solidity: function RELEASE_GRACE() view returns(uint64)
+func (_Job *JobCaller) RELEASEGRACE(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "RELEASE_GRACE")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// RELEASEGRACE is a free data retrieval call binding the contract method 0xe73ad7c6.
+//
+// Solidity: function RELEASE_GRACE() view returns(uint64)
+func (_Job *JobSession) RELEASEGRACE() (uint64, error) {
+	return _Job.Contract.RELEASEGRACE(&_Job.CallOpts)
+}
+
+// RELEASEGRACE is a free data retrieval call binding the contract method 0xe73ad7c6.
+//
+// Solidity: function RELEASE_GRACE() view returns(uint64)
+func (_Job *JobCallerSession) RELEASEGRACE() (uint64, error) {
+	return _Job.Contract.RELEASEGRACE(&_Job.CallOpts)
+}
+
+// Agent is a free data retrieval call binding the contract method 0xf5ff5c76.
+//
+// Solidity: function agent() view returns(address)
+func (_Job *JobCaller) Agent(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "agent")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Agent is a free data retrieval call binding the contract method 0xf5ff5c76.
+//
+// Solidity: function agent() view returns(address)
+func (_Job *JobSession) Agent() (common.Address, error) {
+	return _Job.Contract.Agent(&_Job.CallOpts)
+}
+
+// Agent is a free data retrieval call binding the contract method 0xf5ff5c76.
+//
+// Solidity: function agent() view returns(address)
+func (_Job *JobCallerSession) Agent() (common.Address, error) {
+	return _Job.Contract.Agent(&_Job.CallOpts)
+}
+
+// AgentId is a free data retrieval call binding the contract method 0xe84f43b7.
+//
+// Solidity: function agentId() view returns(uint256)
+func (_Job *JobCaller) AgentId(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "agentId")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// AgentId is a free data retrieval call binding the contract method 0xe84f43b7.
+//
+// Solidity: function agentId() view returns(uint256)
+func (_Job *JobSession) AgentId() (*big.Int, error) {
+	return _Job.Contract.AgentId(&_Job.CallOpts)
+}
+
+// AgentId is a free data retrieval call binding the contract method 0xe84f43b7.
+//
+// Solidity: function agentId() view returns(uint256)
+func (_Job *JobCallerSession) AgentId() (*big.Int, error) {
+	return _Job.Contract.AgentId(&_Job.CallOpts)
+}
+
+// Arbiter is a free data retrieval call binding the contract method 0xfe25e00a.
+//
+// Solidity: function arbiter() view returns(address)
+func (_Job *JobCaller) Arbiter(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "arbiter")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Arbiter is a free data retrieval call binding the contract method 0xfe25e00a.
+//
+// Solidity: function arbiter() view returns(address)
+func (_Job *JobSession) Arbiter() (common.Address, error) {
+	return _Job.Contract.Arbiter(&_Job.CallOpts)
+}
+
+// Arbiter is a free data retrieval call binding the contract method 0xfe25e00a.
+//
+// Solidity: function arbiter() view returns(address)
+func (_Job *JobCallerSession) Arbiter() (common.Address, error) {
+	return _Job.Contract.Arbiter(&_Job.CallOpts)
+}
+
+// Budget is a free data retrieval call binding the contract method 0xed01bf29.
+//
+// Solidity: function budget() view returns(uint256)
+func (_Job *JobCaller) Budget(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "budget")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Budget is a free data retrieval call binding the contract method 0xed01bf29.
+//
+// Solidity: function budget() view returns(uint256)
+func (_Job *JobSession) Budget() (*big.Int, error) {
+	return _Job.Contract.Budget(&_Job.CallOpts)
+}
+
+// Budget is a free data retrieval call binding the contract method 0xed01bf29.
+//
+// Solidity: function budget() view returns(uint256)
+func (_Job *JobCallerSession) Budget() (*big.Int, error) {
+	return _Job.Contract.Budget(&_Job.CallOpts)
+}
+
+// CurrentPhase is a free data retrieval call binding the contract method 0x055ad42e.
+//
+// Solidity: function currentPhase() view returns(uint8 current)
+func (_Job *JobCaller) CurrentPhase(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "currentPhase")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// CurrentPhase is a free data retrieval call binding the contract method 0x055ad42e.
+//
+// Solidity: function currentPhase() view returns(uint8 current)
+func (_Job *JobSession) CurrentPhase() (uint8, error) {
+	return _Job.Contract.CurrentPhase(&_Job.CallOpts)
+}
+
+// CurrentPhase is a free data retrieval call binding the contract method 0x055ad42e.
+//
+// Solidity: function currentPhase() view returns(uint8 current)
+func (_Job *JobCallerSession) CurrentPhase() (uint8, error) {
+	return _Job.Contract.CurrentPhase(&_Job.CallOpts)
+}
+
+// Deadline is a free data retrieval call binding the contract method 0x29dcb0cf.
+//
+// Solidity: function deadline() view returns(uint64)
+func (_Job *JobCaller) Deadline(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "deadline")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// Deadline is a free data retrieval call binding the contract method 0x29dcb0cf.
+//
+// Solidity: function deadline() view returns(uint64)
+func (_Job *JobSession) Deadline() (uint64, error) {
+	return _Job.Contract.Deadline(&_Job.CallOpts)
+}
+
+// Deadline is a free data retrieval call binding the contract method 0x29dcb0cf.
+//
+// Solidity: function deadline() view returns(uint64)
+func (_Job *JobCallerSession) Deadline() (uint64, error) {
+	return _Job.Contract.Deadline(&_Job.CallOpts)
+}
+
+// Evaluator is a free data retrieval call binding the contract method 0x9cb93dd1.
+//
+// Solidity: function evaluator() view returns(address)
+func (_Job *JobCaller) Evaluator(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "evaluator")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Evaluator is a free data retrieval call binding the contract method 0x9cb93dd1.
+//
+// Solidity: function evaluator() view returns(address)
+func (_Job *JobSession) Evaluator() (common.Address, error) {
+	return _Job.Contract.Evaluator(&_Job.CallOpts)
+}
+
+// Evaluator is a free data retrieval call binding the contract method 0x9cb93dd1.
+//
+// Solidity: function evaluator() view returns(address)
+func (_Job *JobCallerSession) Evaluator() (common.Address, error) {
+	return _Job.Contract.Evaluator(&_Job.CallOpts)
+}
+
+// JobId is a free data retrieval call binding the contract method 0xc2939d97.
+//
+// Solidity: function jobId() view returns(uint256)
+func (_Job *JobCaller) JobId(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "jobId")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// JobId is a free data retrieval call binding the contract method 0xc2939d97.
+//
+// Solidity: function jobId() view returns(uint256)
+func (_Job *JobSession) JobId() (*big.Int, error) {
+	return _Job.Contract.JobId(&_Job.CallOpts)
+}
+
+// JobId is a free data retrieval call binding the contract method 0xc2939d97.
+//
+// Solidity: function jobId() view returns(uint256)
+func (_Job *JobCallerSession) JobId() (*big.Int, error) {
+	return _Job.Contract.JobId(&_Job.CallOpts)
+}
+
+// JobType is a free data retrieval call binding the contract method 0x8080be77.
+//
+// Solidity: function jobType() view returns(uint8)
+func (_Job *JobCaller) JobType(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "jobType")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// JobType is a free data retrieval call binding the contract method 0x8080be77.
+//
+// Solidity: function jobType() view returns(uint8)
+func (_Job *JobSession) JobType() (uint8, error) {
+	return _Job.Contract.JobType(&_Job.CallOpts)
+}
+
+// JobType is a free data retrieval call binding the contract method 0x8080be77.
+//
+// Solidity: function jobType() view returns(uint8)
+func (_Job *JobCallerSession) JobType() (uint8, error) {
+	return _Job.Contract.JobType(&_Job.CallOpts)
+}
+
+// Phase is a free data retrieval call binding the contract method 0xb1c9fe6e.
+//
+// Solidity: function phase() view returns(uint8)
+func (_Job *JobCaller) Phase(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "phase")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// Phase is a free data retrieval call binding the contract method 0xb1c9fe6e.
+//
+// Solidity: function phase() view returns(uint8)
+func (_Job *JobSession) Phase() (uint8, error) {
+	return _Job.Contract.Phase(&_Job.CallOpts)
+}
+
+// Phase is a free data retrieval call binding the contract method 0xb1c9fe6e.
+//
+// Solidity: function phase() view returns(uint8)
+func (_Job *JobCallerSession) Phase() (uint8, error) {
+	return _Job.Contract.Phase(&_Job.CallOpts)
+}
+
+// Principal is a free data retrieval call binding the contract method 0xba5d3078.
+//
+// Solidity: function principal() view returns(address)
+func (_Job *JobCaller) Principal(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "principal")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Principal is a free data retrieval call binding the contract method 0xba5d3078.
+//
+// Solidity: function principal() view returns(address)
+func (_Job *JobSession) Principal() (common.Address, error) {
+	return _Job.Contract.Principal(&_Job.CallOpts)
+}
+
+// Principal is a free data retrieval call binding the contract method 0xba5d3078.
+//
+// Solidity: function principal() view returns(address)
+func (_Job *JobCallerSession) Principal() (common.Address, error) {
+	return _Job.Contract.Principal(&_Job.CallOpts)
+}
+
+// Registry is a free data retrieval call binding the contract method 0x7b103999.
+//
+// Solidity: function registry() view returns(address)
+func (_Job *JobCaller) Registry(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "registry")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Registry is a free data retrieval call binding the contract method 0x7b103999.
+//
+// Solidity: function registry() view returns(address)
+func (_Job *JobSession) Registry() (common.Address, error) {
+	return _Job.Contract.Registry(&_Job.CallOpts)
+}
+
+// Registry is a free data retrieval call binding the contract method 0x7b103999.
+//
+// Solidity: function registry() view returns(address)
+func (_Job *JobCallerSession) Registry() (common.Address, error) {
+	return _Job.Contract.Registry(&_Job.CallOpts)
+}
+
+// ResultSubmittedAt is a free data retrieval call binding the contract method 0xd478f498.
+//
+// Solidity: function resultSubmittedAt() view returns(uint64)
+func (_Job *JobCaller) ResultSubmittedAt(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "resultSubmittedAt")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// ResultSubmittedAt is a free data retrieval call binding the contract method 0xd478f498.
+//
+// Solidity: function resultSubmittedAt() view returns(uint64)
+func (_Job *JobSession) ResultSubmittedAt() (uint64, error) {
+	return _Job.Contract.ResultSubmittedAt(&_Job.CallOpts)
+}
+
+// ResultSubmittedAt is a free data retrieval call binding the contract method 0xd478f498.
+//
+// Solidity: function resultSubmittedAt() view returns(uint64)
+func (_Job *JobCallerSession) ResultSubmittedAt() (uint64, error) {
+	return _Job.Contract.ResultSubmittedAt(&_Job.CallOpts)
+}
+
+// ResultURI is a free data retrieval call binding the contract method 0xb56fd20a.
+//
+// Solidity: function resultURI() view returns(string)
+func (_Job *JobCaller) ResultURI(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "resultURI")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// ResultURI is a free data retrieval call binding the contract method 0xb56fd20a.
+//
+// Solidity: function resultURI() view returns(string)
+func (_Job *JobSession) ResultURI() (string, error) {
+	return _Job.Contract.ResultURI(&_Job.CallOpts)
+}
+
+// ResultURI is a free data retrieval call binding the contract method 0xb56fd20a.
+//
+// Solidity: function resultURI() view returns(string)
+func (_Job *JobCallerSession) ResultURI() (string, error) {
+	return _Job.Contract.ResultURI(&_Job.CallOpts)
+}
+
+// TargetAgentId is a free data retrieval call binding the contract method 0xa63176be.
+//
+// Solidity: function targetAgentId() view returns(uint256)
+func (_Job *JobCaller) TargetAgentId(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "targetAgentId")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TargetAgentId is a free data retrieval call binding the contract method 0xa63176be.
+//
+// Solidity: function targetAgentId() view returns(uint256)
+func (_Job *JobSession) TargetAgentId() (*big.Int, error) {
+	return _Job.Contract.TargetAgentId(&_Job.CallOpts)
+}
+
+// TargetAgentId is a free data retrieval call binding the contract method 0xa63176be.
+//
+// Solidity: function targetAgentId() view returns(uint256)
+func (_Job *JobCallerSession) TargetAgentId() (*big.Int, error) {
+	return _Job.Contract.TargetAgentId(&_Job.CallOpts)
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_Job *JobCaller) Token(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Job.contract.Call(opts, &out, "token")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_Job *JobSession) Token() (common.Address, error) {
+	return _Job.Contract.Token(&_Job.CallOpts)
+}
+
+// Token is a free data retrieval call binding the contract method 0xfc0c546a.
+//
+// Solidity: function token() view returns(address)
+func (_Job *JobCallerSession) Token() (common.Address, error) {
+	return _Job.Contract.Token(&_Job.CallOpts)
+}
+
+// Accept is a paid mutator transaction binding the contract method 0x19b05f49.
+//
+// Solidity: function accept(uint256 _agentId) returns()
+func (_Job *JobTransactor) Accept(opts *bind.TransactOpts, _agentId *big.Int) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "accept", _agentId)
+}
+
+// Accept is a paid mutator transaction binding the contract method 0x19b05f49.
+//
+// Solidity: function accept(uint256 _agentId) returns()
+func (_Job *JobSession) Accept(_agentId *big.Int) (*types.Transaction, error) {
+	return _Job.Contract.Accept(&_Job.TransactOpts, _agentId)
+}
+
+// Accept is a paid mutator transaction binding the contract method 0x19b05f49.
+//
+// Solidity: function accept(uint256 _agentId) returns()
+func (_Job *JobTransactorSession) Accept(_agentId *big.Int) (*types.Transaction, error) {
+	return _Job.Contract.Accept(&_Job.TransactOpts, _agentId)
+}
+
+// ApproveResult is a paid mutator transaction binding the contract method 0xc5ec9b6a.
+//
+// Solidity: function approveResult() returns()
+func (_Job *JobTransactor) ApproveResult(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "approveResult")
+}
+
+// ApproveResult is a paid mutator transaction binding the contract method 0xc5ec9b6a.
+//
+// Solidity: function approveResult() returns()
+func (_Job *JobSession) ApproveResult() (*types.Transaction, error) {
+	return _Job.Contract.ApproveResult(&_Job.TransactOpts)
+}
+
+// ApproveResult is a paid mutator transaction binding the contract method 0xc5ec9b6a.
+//
+// Solidity: function approveResult() returns()
+func (_Job *JobTransactorSession) ApproveResult() (*types.Transaction, error) {
+	return _Job.Contract.ApproveResult(&_Job.TransactOpts)
+}
+
+// Cancel is a paid mutator transaction binding the contract method 0x0b4f3f3d.
+//
+// Solidity: function cancel(string reason) returns()
+func (_Job *JobTransactor) Cancel(opts *bind.TransactOpts, reason string) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "cancel", reason)
+}
+
+// Cancel is a paid mutator transaction binding the contract method 0x0b4f3f3d.
+//
+// Solidity: function cancel(string reason) returns()
+func (_Job *JobSession) Cancel(reason string) (*types.Transaction, error) {
+	return _Job.Contract.Cancel(&_Job.TransactOpts, reason)
+}
+
+// Cancel is a paid mutator transaction binding the contract method 0x0b4f3f3d.
+//
+// Solidity: function cancel(string reason) returns()
+func (_Job *JobTransactorSession) Cancel(reason string) (*types.Transaction, error) {
+	return _Job.Contract.Cancel(&_Job.TransactOpts, reason)
+}
+
+// ExpireJob is a paid mutator transaction binding the contract method 0x7ae6a045.
+//
+// Solidity: function expireJob() returns()
+func (_Job *JobTransactor) ExpireJob(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "expireJob")
+}
+
+// ExpireJob is a paid mutator transaction binding the contract method 0x7ae6a045.
+//
+// Solidity: function expireJob() returns()
+func (_Job *JobSession) ExpireJob() (*types.Transaction, error) {
+	return _Job.Contract.ExpireJob(&_Job.TransactOpts)
+}
+
+// ExpireJob is a paid mutator transaction binding the contract method 0x7ae6a045.
+//
+// Solidity: function expireJob() returns()
+func (_Job *JobTransactorSession) ExpireJob() (*types.Transaction, error) {
+	return _Job.Contract.ExpireJob(&_Job.TransactOpts)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4955ffc.
+//
+// Solidity: function initialize((uint256,address,address,uint256,address,uint256,uint64,uint8,address,address) p) returns()
+func (_Job *JobTransactor) Initialize(opts *bind.TransactOpts, p JobInitParams) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "initialize", p)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4955ffc.
+//
+// Solidity: function initialize((uint256,address,address,uint256,address,uint256,uint64,uint8,address,address) p) returns()
+func (_Job *JobSession) Initialize(p JobInitParams) (*types.Transaction, error) {
+	return _Job.Contract.Initialize(&_Job.TransactOpts, p)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0xc4955ffc.
+//
+// Solidity: function initialize((uint256,address,address,uint256,address,uint256,uint64,uint8,address,address) p) returns()
+func (_Job *JobTransactorSession) Initialize(p JobInitParams) (*types.Transaction, error) {
+	return _Job.Contract.Initialize(&_Job.TransactOpts, p)
+}
+
+// RaiseDispute is a paid mutator transaction binding the contract method 0x6daa2d44.
+//
+// Solidity: function raiseDispute() returns()
+func (_Job *JobTransactor) RaiseDispute(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "raiseDispute")
+}
+
+// RaiseDispute is a paid mutator transaction binding the contract method 0x6daa2d44.
+//
+// Solidity: function raiseDispute() returns()
+func (_Job *JobSession) RaiseDispute() (*types.Transaction, error) {
+	return _Job.Contract.RaiseDispute(&_Job.TransactOpts)
+}
+
+// RaiseDispute is a paid mutator transaction binding the contract method 0x6daa2d44.
+//
+// Solidity: function raiseDispute() returns()
+func (_Job *JobTransactorSession) RaiseDispute() (*types.Transaction, error) {
+	return _Job.Contract.RaiseDispute(&_Job.TransactOpts)
+}
+
+// RejectResult is a paid mutator transaction binding the contract method 0x3868606a.
+//
+// Solidity: function rejectResult(string reason) returns()
+func (_Job *JobTransactor) RejectResult(opts *bind.TransactOpts, reason string) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "rejectResult", reason)
+}
+
+// RejectResult is a paid mutator transaction binding the contract method 0x3868606a.
+//
+// Solidity: function rejectResult(string reason) returns()
+func (_Job *JobSession) RejectResult(reason string) (*types.Transaction, error) {
+	return _Job.Contract.RejectResult(&_Job.TransactOpts, reason)
+}
+
+// RejectResult is a paid mutator transaction binding the contract method 0x3868606a.
+//
+// Solidity: function rejectResult(string reason) returns()
+func (_Job *JobTransactorSession) RejectResult(reason string) (*types.Transaction, error) {
+	return _Job.Contract.RejectResult(&_Job.TransactOpts, reason)
+}
+
+// Release is a paid mutator transaction binding the contract method 0x86d1a69f.
+//
+// Solidity: function release() returns()
+func (_Job *JobTransactor) Release(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "release")
+}
+
+// Release is a paid mutator transaction binding the contract method 0x86d1a69f.
+//
+// Solidity: function release() returns()
+func (_Job *JobSession) Release() (*types.Transaction, error) {
+	return _Job.Contract.Release(&_Job.TransactOpts)
+}
+
+// Release is a paid mutator transaction binding the contract method 0x86d1a69f.
+//
+// Solidity: function release() returns()
+func (_Job *JobTransactorSession) Release() (*types.Transaction, error) {
+	return _Job.Contract.Release(&_Job.TransactOpts)
+}
+
+// ResolveDispute is a paid mutator transaction binding the contract method 0x89e1e82a.
+//
+// Solidity: function resolveDispute(bool agentFavoured) returns()
+func (_Job *JobTransactor) ResolveDispute(opts *bind.TransactOpts, agentFavoured bool) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "resolveDispute", agentFavoured)
+}
+
+// ResolveDispute is a paid mutator transaction binding the contract method 0x89e1e82a.
+//
+// Solidity: function resolveDispute(bool agentFavoured) returns()
+func (_Job *JobSession) ResolveDispute(agentFavoured bool) (*types.Transaction, error) {
+	return _Job.Contract.ResolveDispute(&_Job.TransactOpts, agentFavoured)
+}
+
+// ResolveDispute is a paid mutator transaction binding the contract method 0x89e1e82a.
+//
+// Solidity: function resolveDispute(bool agentFavoured) returns()
+func (_Job *JobTransactorSession) ResolveDispute(agentFavoured bool) (*types.Transaction, error) {
+	return _Job.Contract.ResolveDispute(&_Job.TransactOpts, agentFavoured)
+}
+
+// SubmitResult is a paid mutator transaction binding the contract method 0xec184245.
+//
+// Solidity: function submitResult(string _resultURI) returns()
+func (_Job *JobTransactor) SubmitResult(opts *bind.TransactOpts, _resultURI string) (*types.Transaction, error) {
+	return _Job.contract.Transact(opts, "submitResult", _resultURI)
+}
+
+// SubmitResult is a paid mutator transaction binding the contract method 0xec184245.
+//
+// Solidity: function submitResult(string _resultURI) returns()
+func (_Job *JobSession) SubmitResult(_resultURI string) (*types.Transaction, error) {
+	return _Job.Contract.SubmitResult(&_Job.TransactOpts, _resultURI)
+}
+
+// SubmitResult is a paid mutator transaction binding the contract method 0xec184245.
+//
+// Solidity: function submitResult(string _resultURI) returns()
+func (_Job *JobTransactorSession) SubmitResult(_resultURI string) (*types.Transaction, error) {
+	return _Job.Contract.SubmitResult(&_Job.TransactOpts, _resultURI)
+}
+
+// JobAgentAcceptedIterator is returned from FilterAgentAccepted and is used to iterate over the raw logs and unpacked data for AgentAccepted events raised by the Job contract.
+type JobAgentAcceptedIterator struct {
+	Event *JobAgentAccepted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobAgentAcceptedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobAgentAccepted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobAgentAccepted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobAgentAcceptedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobAgentAcceptedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobAgentAccepted represents a AgentAccepted event raised by the Job contract.
+type JobAgentAccepted struct {
+	JobId   *big.Int
+	Agent   common.Address
+	AgentId *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterAgentAccepted is a free log retrieval operation binding the contract event 0xa08a9d61f61bc14cb9b5ef024d79b5dbbb271dfebaaa5a22ed231c25d5d4ee8e.
+//
+// Solidity: event AgentAccepted(uint256 indexed jobId, address indexed agent, uint256 indexed agentId)
+func (_Job *JobFilterer) FilterAgentAccepted(opts *bind.FilterOpts, jobId []*big.Int, agent []common.Address, agentId []*big.Int) (*JobAgentAcceptedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var agentRule []interface{}
+	for _, agentItem := range agent {
+		agentRule = append(agentRule, agentItem)
+	}
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "AgentAccepted", jobIdRule, agentRule, agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobAgentAcceptedIterator{contract: _Job.contract, event: "AgentAccepted", logs: logs, sub: sub}, nil
+}
+
+// WatchAgentAccepted is a free log subscription operation binding the contract event 0xa08a9d61f61bc14cb9b5ef024d79b5dbbb271dfebaaa5a22ed231c25d5d4ee8e.
+//
+// Solidity: event AgentAccepted(uint256 indexed jobId, address indexed agent, uint256 indexed agentId)
+func (_Job *JobFilterer) WatchAgentAccepted(opts *bind.WatchOpts, sink chan<- *JobAgentAccepted, jobId []*big.Int, agent []common.Address, agentId []*big.Int) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var agentRule []interface{}
+	for _, agentItem := range agent {
+		agentRule = append(agentRule, agentItem)
+	}
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "AgentAccepted", jobIdRule, agentRule, agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobAgentAccepted)
+				if err := _Job.contract.UnpackLog(event, "AgentAccepted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAgentAccepted is a log parse operation binding the contract event 0xa08a9d61f61bc14cb9b5ef024d79b5dbbb271dfebaaa5a22ed231c25d5d4ee8e.
+//
+// Solidity: event AgentAccepted(uint256 indexed jobId, address indexed agent, uint256 indexed agentId)
+func (_Job *JobFilterer) ParseAgentAccepted(log types.Log) (*JobAgentAccepted, error) {
+	event := new(JobAgentAccepted)
+	if err := _Job.contract.UnpackLog(event, "AgentAccepted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobDisputeRaisedIterator is returned from FilterDisputeRaised and is used to iterate over the raw logs and unpacked data for DisputeRaised events raised by the Job contract.
+type JobDisputeRaisedIterator struct {
+	Event *JobDisputeRaised // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobDisputeRaisedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobDisputeRaised)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobDisputeRaised)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobDisputeRaisedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobDisputeRaisedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobDisputeRaised represents a DisputeRaised event raised by the Job contract.
+type JobDisputeRaised struct {
+	JobId    *big.Int
+	RaisedBy common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterDisputeRaised is a free log retrieval operation binding the contract event 0x84a477df8a28a4276ca6dee4458a06c3015f30c477d9c949ede4e13ff8a552b4.
+//
+// Solidity: event DisputeRaised(uint256 indexed jobId, address indexed raisedBy)
+func (_Job *JobFilterer) FilterDisputeRaised(opts *bind.FilterOpts, jobId []*big.Int, raisedBy []common.Address) (*JobDisputeRaisedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var raisedByRule []interface{}
+	for _, raisedByItem := range raisedBy {
+		raisedByRule = append(raisedByRule, raisedByItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "DisputeRaised", jobIdRule, raisedByRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobDisputeRaisedIterator{contract: _Job.contract, event: "DisputeRaised", logs: logs, sub: sub}, nil
+}
+
+// WatchDisputeRaised is a free log subscription operation binding the contract event 0x84a477df8a28a4276ca6dee4458a06c3015f30c477d9c949ede4e13ff8a552b4.
+//
+// Solidity: event DisputeRaised(uint256 indexed jobId, address indexed raisedBy)
+func (_Job *JobFilterer) WatchDisputeRaised(opts *bind.WatchOpts, sink chan<- *JobDisputeRaised, jobId []*big.Int, raisedBy []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var raisedByRule []interface{}
+	for _, raisedByItem := range raisedBy {
+		raisedByRule = append(raisedByRule, raisedByItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "DisputeRaised", jobIdRule, raisedByRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobDisputeRaised)
+				if err := _Job.contract.UnpackLog(event, "DisputeRaised", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDisputeRaised is a log parse operation binding the contract event 0x84a477df8a28a4276ca6dee4458a06c3015f30c477d9c949ede4e13ff8a552b4.
+//
+// Solidity: event DisputeRaised(uint256 indexed jobId, address indexed raisedBy)
+func (_Job *JobFilterer) ParseDisputeRaised(log types.Log) (*JobDisputeRaised, error) {
+	event := new(JobDisputeRaised)
+	if err := _Job.contract.UnpackLog(event, "DisputeRaised", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobDisputeResolvedIterator is returned from FilterDisputeResolved and is used to iterate over the raw logs and unpacked data for DisputeResolved events raised by the Job contract.
+type JobDisputeResolvedIterator struct {
+	Event *JobDisputeResolved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobDisputeResolvedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobDisputeResolved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobDisputeResolved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobDisputeResolvedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobDisputeResolvedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobDisputeResolved represents a DisputeResolved event raised by the Job contract.
+type JobDisputeResolved struct {
+	JobId         *big.Int
+	Resolver      common.Address
+	AgentFavoured bool
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterDisputeResolved is a free log retrieval operation binding the contract event 0x8fdd4548a8481406b6e29c0d6f25e27cd72502f79f4adf409468502e7920dabc.
+//
+// Solidity: event DisputeResolved(uint256 indexed jobId, address indexed resolver, bool agentFavoured)
+func (_Job *JobFilterer) FilterDisputeResolved(opts *bind.FilterOpts, jobId []*big.Int, resolver []common.Address) (*JobDisputeResolvedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var resolverRule []interface{}
+	for _, resolverItem := range resolver {
+		resolverRule = append(resolverRule, resolverItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "DisputeResolved", jobIdRule, resolverRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobDisputeResolvedIterator{contract: _Job.contract, event: "DisputeResolved", logs: logs, sub: sub}, nil
+}
+
+// WatchDisputeResolved is a free log subscription operation binding the contract event 0x8fdd4548a8481406b6e29c0d6f25e27cd72502f79f4adf409468502e7920dabc.
+//
+// Solidity: event DisputeResolved(uint256 indexed jobId, address indexed resolver, bool agentFavoured)
+func (_Job *JobFilterer) WatchDisputeResolved(opts *bind.WatchOpts, sink chan<- *JobDisputeResolved, jobId []*big.Int, resolver []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var resolverRule []interface{}
+	for _, resolverItem := range resolver {
+		resolverRule = append(resolverRule, resolverItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "DisputeResolved", jobIdRule, resolverRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobDisputeResolved)
+				if err := _Job.contract.UnpackLog(event, "DisputeResolved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDisputeResolved is a log parse operation binding the contract event 0x8fdd4548a8481406b6e29c0d6f25e27cd72502f79f4adf409468502e7920dabc.
+//
+// Solidity: event DisputeResolved(uint256 indexed jobId, address indexed resolver, bool agentFavoured)
+func (_Job *JobFilterer) ParseDisputeResolved(log types.Log) (*JobDisputeResolved, error) {
+	event := new(JobDisputeResolved)
+	if err := _Job.contract.UnpackLog(event, "DisputeResolved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobEvaluatorAssignedIterator is returned from FilterEvaluatorAssigned and is used to iterate over the raw logs and unpacked data for EvaluatorAssigned events raised by the Job contract.
+type JobEvaluatorAssignedIterator struct {
+	Event *JobEvaluatorAssigned // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobEvaluatorAssignedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobEvaluatorAssigned)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobEvaluatorAssigned)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobEvaluatorAssignedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobEvaluatorAssignedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobEvaluatorAssigned represents a EvaluatorAssigned event raised by the Job contract.
+type JobEvaluatorAssigned struct {
+	JobId     *big.Int
+	Evaluator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterEvaluatorAssigned is a free log retrieval operation binding the contract event 0x50a93d710505e6f207121334c60e2a4c6312fdbae71f879f5abee6488e20b131.
+//
+// Solidity: event EvaluatorAssigned(uint256 indexed jobId, address indexed evaluator)
+func (_Job *JobFilterer) FilterEvaluatorAssigned(opts *bind.FilterOpts, jobId []*big.Int, evaluator []common.Address) (*JobEvaluatorAssignedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var evaluatorRule []interface{}
+	for _, evaluatorItem := range evaluator {
+		evaluatorRule = append(evaluatorRule, evaluatorItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "EvaluatorAssigned", jobIdRule, evaluatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobEvaluatorAssignedIterator{contract: _Job.contract, event: "EvaluatorAssigned", logs: logs, sub: sub}, nil
+}
+
+// WatchEvaluatorAssigned is a free log subscription operation binding the contract event 0x50a93d710505e6f207121334c60e2a4c6312fdbae71f879f5abee6488e20b131.
+//
+// Solidity: event EvaluatorAssigned(uint256 indexed jobId, address indexed evaluator)
+func (_Job *JobFilterer) WatchEvaluatorAssigned(opts *bind.WatchOpts, sink chan<- *JobEvaluatorAssigned, jobId []*big.Int, evaluator []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var evaluatorRule []interface{}
+	for _, evaluatorItem := range evaluator {
+		evaluatorRule = append(evaluatorRule, evaluatorItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "EvaluatorAssigned", jobIdRule, evaluatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobEvaluatorAssigned)
+				if err := _Job.contract.UnpackLog(event, "EvaluatorAssigned", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseEvaluatorAssigned is a log parse operation binding the contract event 0x50a93d710505e6f207121334c60e2a4c6312fdbae71f879f5abee6488e20b131.
+//
+// Solidity: event EvaluatorAssigned(uint256 indexed jobId, address indexed evaluator)
+func (_Job *JobFilterer) ParseEvaluatorAssigned(log types.Log) (*JobEvaluatorAssigned, error) {
+	event := new(JobEvaluatorAssigned)
+	if err := _Job.contract.UnpackLog(event, "EvaluatorAssigned", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Job contract.
+type JobInitializedIterator struct {
+	Event *JobInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobInitialized represents a Initialized event raised by the Job contract.
+type JobInitialized struct {
+	Version uint64
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Job *JobFilterer) FilterInitialized(opts *bind.FilterOpts) (*JobInitializedIterator, error) {
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &JobInitializedIterator{contract: _Job.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Job *JobFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *JobInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobInitialized)
+				if err := _Job.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0xc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d2.
+//
+// Solidity: event Initialized(uint64 version)
+func (_Job *JobFilterer) ParseInitialized(log types.Log) (*JobInitialized, error) {
+	event := new(JobInitialized)
+	if err := _Job.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobJobCancelledIterator is returned from FilterJobCancelled and is used to iterate over the raw logs and unpacked data for JobCancelled events raised by the Job contract.
+type JobJobCancelledIterator struct {
+	Event *JobJobCancelled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobJobCancelledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobJobCancelled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobJobCancelled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobJobCancelledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobJobCancelledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobJobCancelled represents a JobCancelled event raised by the Job contract.
+type JobJobCancelled struct {
+	JobId       *big.Int
+	CancelledBy common.Address
+	Reason      string
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterJobCancelled is a free log retrieval operation binding the contract event 0x141454c3e63a845c54bcfebc9a4f9843c448cd8c0bb7077e5f70235e4f441356.
+//
+// Solidity: event JobCancelled(uint256 indexed jobId, address indexed cancelledBy, string reason)
+func (_Job *JobFilterer) FilterJobCancelled(opts *bind.FilterOpts, jobId []*big.Int, cancelledBy []common.Address) (*JobJobCancelledIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var cancelledByRule []interface{}
+	for _, cancelledByItem := range cancelledBy {
+		cancelledByRule = append(cancelledByRule, cancelledByItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "JobCancelled", jobIdRule, cancelledByRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobJobCancelledIterator{contract: _Job.contract, event: "JobCancelled", logs: logs, sub: sub}, nil
+}
+
+// WatchJobCancelled is a free log subscription operation binding the contract event 0x141454c3e63a845c54bcfebc9a4f9843c448cd8c0bb7077e5f70235e4f441356.
+//
+// Solidity: event JobCancelled(uint256 indexed jobId, address indexed cancelledBy, string reason)
+func (_Job *JobFilterer) WatchJobCancelled(opts *bind.WatchOpts, sink chan<- *JobJobCancelled, jobId []*big.Int, cancelledBy []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var cancelledByRule []interface{}
+	for _, cancelledByItem := range cancelledBy {
+		cancelledByRule = append(cancelledByRule, cancelledByItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "JobCancelled", jobIdRule, cancelledByRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobJobCancelled)
+				if err := _Job.contract.UnpackLog(event, "JobCancelled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseJobCancelled is a log parse operation binding the contract event 0x141454c3e63a845c54bcfebc9a4f9843c448cd8c0bb7077e5f70235e4f441356.
+//
+// Solidity: event JobCancelled(uint256 indexed jobId, address indexed cancelledBy, string reason)
+func (_Job *JobFilterer) ParseJobCancelled(log types.Log) (*JobJobCancelled, error) {
+	event := new(JobJobCancelled)
+	if err := _Job.contract.UnpackLog(event, "JobCancelled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobJobCompletedIterator is returned from FilterJobCompleted and is used to iterate over the raw logs and unpacked data for JobCompleted events raised by the Job contract.
+type JobJobCompletedIterator struct {
+	Event *JobJobCompleted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobJobCompletedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobJobCompleted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobJobCompleted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobJobCompletedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobJobCompletedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobJobCompleted represents a JobCompleted event raised by the Job contract.
+type JobJobCompleted struct {
+	JobId      *big.Int
+	ReleasedBy common.Address
+	Amount     *big.Int
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterJobCompleted is a free log retrieval operation binding the contract event 0x4dbba472101e9f148a3a5ecbe793f0ee16a7efe4bf3f8cbfab5330e1642ef955.
+//
+// Solidity: event JobCompleted(uint256 indexed jobId, address indexed releasedBy, uint256 amount)
+func (_Job *JobFilterer) FilterJobCompleted(opts *bind.FilterOpts, jobId []*big.Int, releasedBy []common.Address) (*JobJobCompletedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var releasedByRule []interface{}
+	for _, releasedByItem := range releasedBy {
+		releasedByRule = append(releasedByRule, releasedByItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "JobCompleted", jobIdRule, releasedByRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobJobCompletedIterator{contract: _Job.contract, event: "JobCompleted", logs: logs, sub: sub}, nil
+}
+
+// WatchJobCompleted is a free log subscription operation binding the contract event 0x4dbba472101e9f148a3a5ecbe793f0ee16a7efe4bf3f8cbfab5330e1642ef955.
+//
+// Solidity: event JobCompleted(uint256 indexed jobId, address indexed releasedBy, uint256 amount)
+func (_Job *JobFilterer) WatchJobCompleted(opts *bind.WatchOpts, sink chan<- *JobJobCompleted, jobId []*big.Int, releasedBy []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var releasedByRule []interface{}
+	for _, releasedByItem := range releasedBy {
+		releasedByRule = append(releasedByRule, releasedByItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "JobCompleted", jobIdRule, releasedByRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobJobCompleted)
+				if err := _Job.contract.UnpackLog(event, "JobCompleted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseJobCompleted is a log parse operation binding the contract event 0x4dbba472101e9f148a3a5ecbe793f0ee16a7efe4bf3f8cbfab5330e1642ef955.
+//
+// Solidity: event JobCompleted(uint256 indexed jobId, address indexed releasedBy, uint256 amount)
+func (_Job *JobFilterer) ParseJobCompleted(log types.Log) (*JobJobCompleted, error) {
+	event := new(JobJobCompleted)
+	if err := _Job.contract.UnpackLog(event, "JobCompleted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobJobInitialisedIterator is returned from FilterJobInitialised and is used to iterate over the raw logs and unpacked data for JobInitialised events raised by the Job contract.
+type JobJobInitialisedIterator struct {
+	Event *JobJobInitialised // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobJobInitialisedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobJobInitialised)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobJobInitialised)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobJobInitialisedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobJobInitialisedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobJobInitialised represents a JobInitialised event raised by the Job contract.
+type JobJobInitialised struct {
+	JobId     *big.Int
+	Principal common.Address
+	AgentId   *big.Int
+	JobType   uint8
+	Budget    *big.Int
+	Token     common.Address
+	Deadline  uint64
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterJobInitialised is a free log retrieval operation binding the contract event 0x6396f9d24200dbcd88fb1965753f38f76c647a2a0a793a00875957937869ce48.
+//
+// Solidity: event JobInitialised(uint256 indexed jobId, address indexed principal, uint256 indexed agentId, uint8 jobType, uint256 budget, address token, uint64 deadline)
+func (_Job *JobFilterer) FilterJobInitialised(opts *bind.FilterOpts, jobId []*big.Int, principal []common.Address, agentId []*big.Int) (*JobJobInitialisedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var principalRule []interface{}
+	for _, principalItem := range principal {
+		principalRule = append(principalRule, principalItem)
+	}
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "JobInitialised", jobIdRule, principalRule, agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobJobInitialisedIterator{contract: _Job.contract, event: "JobInitialised", logs: logs, sub: sub}, nil
+}
+
+// WatchJobInitialised is a free log subscription operation binding the contract event 0x6396f9d24200dbcd88fb1965753f38f76c647a2a0a793a00875957937869ce48.
+//
+// Solidity: event JobInitialised(uint256 indexed jobId, address indexed principal, uint256 indexed agentId, uint8 jobType, uint256 budget, address token, uint64 deadline)
+func (_Job *JobFilterer) WatchJobInitialised(opts *bind.WatchOpts, sink chan<- *JobJobInitialised, jobId []*big.Int, principal []common.Address, agentId []*big.Int) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var principalRule []interface{}
+	for _, principalItem := range principal {
+		principalRule = append(principalRule, principalItem)
+	}
+	var agentIdRule []interface{}
+	for _, agentIdItem := range agentId {
+		agentIdRule = append(agentIdRule, agentIdItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "JobInitialised", jobIdRule, principalRule, agentIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobJobInitialised)
+				if err := _Job.contract.UnpackLog(event, "JobInitialised", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseJobInitialised is a log parse operation binding the contract event 0x6396f9d24200dbcd88fb1965753f38f76c647a2a0a793a00875957937869ce48.
+//
+// Solidity: event JobInitialised(uint256 indexed jobId, address indexed principal, uint256 indexed agentId, uint8 jobType, uint256 budget, address token, uint64 deadline)
+func (_Job *JobFilterer) ParseJobInitialised(log types.Log) (*JobJobInitialised, error) {
+	event := new(JobJobInitialised)
+	if err := _Job.contract.UnpackLog(event, "JobInitialised", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobResultApprovedIterator is returned from FilterResultApproved and is used to iterate over the raw logs and unpacked data for ResultApproved events raised by the Job contract.
+type JobResultApprovedIterator struct {
+	Event *JobResultApproved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobResultApprovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobResultApproved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobResultApproved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobResultApprovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobResultApprovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobResultApproved represents a ResultApproved event raised by the Job contract.
+type JobResultApproved struct {
+	JobId     *big.Int
+	Evaluator common.Address
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterResultApproved is a free log retrieval operation binding the contract event 0xdfa2a378c6a00b39f4d2b4247ba44e90a894960a78603b2bf5af5de40dbe183d.
+//
+// Solidity: event ResultApproved(uint256 indexed jobId, address indexed evaluator)
+func (_Job *JobFilterer) FilterResultApproved(opts *bind.FilterOpts, jobId []*big.Int, evaluator []common.Address) (*JobResultApprovedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var evaluatorRule []interface{}
+	for _, evaluatorItem := range evaluator {
+		evaluatorRule = append(evaluatorRule, evaluatorItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "ResultApproved", jobIdRule, evaluatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobResultApprovedIterator{contract: _Job.contract, event: "ResultApproved", logs: logs, sub: sub}, nil
+}
+
+// WatchResultApproved is a free log subscription operation binding the contract event 0xdfa2a378c6a00b39f4d2b4247ba44e90a894960a78603b2bf5af5de40dbe183d.
+//
+// Solidity: event ResultApproved(uint256 indexed jobId, address indexed evaluator)
+func (_Job *JobFilterer) WatchResultApproved(opts *bind.WatchOpts, sink chan<- *JobResultApproved, jobId []*big.Int, evaluator []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var evaluatorRule []interface{}
+	for _, evaluatorItem := range evaluator {
+		evaluatorRule = append(evaluatorRule, evaluatorItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "ResultApproved", jobIdRule, evaluatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobResultApproved)
+				if err := _Job.contract.UnpackLog(event, "ResultApproved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseResultApproved is a log parse operation binding the contract event 0xdfa2a378c6a00b39f4d2b4247ba44e90a894960a78603b2bf5af5de40dbe183d.
+//
+// Solidity: event ResultApproved(uint256 indexed jobId, address indexed evaluator)
+func (_Job *JobFilterer) ParseResultApproved(log types.Log) (*JobResultApproved, error) {
+	event := new(JobResultApproved)
+	if err := _Job.contract.UnpackLog(event, "ResultApproved", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobResultRejectedIterator is returned from FilterResultRejected and is used to iterate over the raw logs and unpacked data for ResultRejected events raised by the Job contract.
+type JobResultRejectedIterator struct {
+	Event *JobResultRejected // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobResultRejectedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobResultRejected)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobResultRejected)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobResultRejectedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobResultRejectedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobResultRejected represents a ResultRejected event raised by the Job contract.
+type JobResultRejected struct {
+	JobId     *big.Int
+	Evaluator common.Address
+	Reason    string
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterResultRejected is a free log retrieval operation binding the contract event 0x8e23b50499d65aea2724488d5fbc5924cafc75e6613cea60f4ec898b84123d90.
+//
+// Solidity: event ResultRejected(uint256 indexed jobId, address indexed evaluator, string reason)
+func (_Job *JobFilterer) FilterResultRejected(opts *bind.FilterOpts, jobId []*big.Int, evaluator []common.Address) (*JobResultRejectedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var evaluatorRule []interface{}
+	for _, evaluatorItem := range evaluator {
+		evaluatorRule = append(evaluatorRule, evaluatorItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "ResultRejected", jobIdRule, evaluatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobResultRejectedIterator{contract: _Job.contract, event: "ResultRejected", logs: logs, sub: sub}, nil
+}
+
+// WatchResultRejected is a free log subscription operation binding the contract event 0x8e23b50499d65aea2724488d5fbc5924cafc75e6613cea60f4ec898b84123d90.
+//
+// Solidity: event ResultRejected(uint256 indexed jobId, address indexed evaluator, string reason)
+func (_Job *JobFilterer) WatchResultRejected(opts *bind.WatchOpts, sink chan<- *JobResultRejected, jobId []*big.Int, evaluator []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var evaluatorRule []interface{}
+	for _, evaluatorItem := range evaluator {
+		evaluatorRule = append(evaluatorRule, evaluatorItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "ResultRejected", jobIdRule, evaluatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobResultRejected)
+				if err := _Job.contract.UnpackLog(event, "ResultRejected", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseResultRejected is a log parse operation binding the contract event 0x8e23b50499d65aea2724488d5fbc5924cafc75e6613cea60f4ec898b84123d90.
+//
+// Solidity: event ResultRejected(uint256 indexed jobId, address indexed evaluator, string reason)
+func (_Job *JobFilterer) ParseResultRejected(log types.Log) (*JobResultRejected, error) {
+	event := new(JobResultRejected)
+	if err := _Job.contract.UnpackLog(event, "ResultRejected", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobResultSubmittedIterator is returned from FilterResultSubmitted and is used to iterate over the raw logs and unpacked data for ResultSubmitted events raised by the Job contract.
+type JobResultSubmittedIterator struct {
+	Event *JobResultSubmitted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobResultSubmittedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobResultSubmitted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobResultSubmitted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobResultSubmittedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobResultSubmittedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobResultSubmitted represents a ResultSubmitted event raised by the Job contract.
+type JobResultSubmitted struct {
+	JobId     *big.Int
+	Agent     common.Address
+	ResultURI string
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterResultSubmitted is a free log retrieval operation binding the contract event 0xc06b551d984e333ac851ab20b1454a08d92740468f52ff54c0cd5270817f20a9.
+//
+// Solidity: event ResultSubmitted(uint256 indexed jobId, address indexed agent, string resultURI)
+func (_Job *JobFilterer) FilterResultSubmitted(opts *bind.FilterOpts, jobId []*big.Int, agent []common.Address) (*JobResultSubmittedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var agentRule []interface{}
+	for _, agentItem := range agent {
+		agentRule = append(agentRule, agentItem)
+	}
+
+	logs, sub, err := _Job.contract.FilterLogs(opts, "ResultSubmitted", jobIdRule, agentRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobResultSubmittedIterator{contract: _Job.contract, event: "ResultSubmitted", logs: logs, sub: sub}, nil
+}
+
+// WatchResultSubmitted is a free log subscription operation binding the contract event 0xc06b551d984e333ac851ab20b1454a08d92740468f52ff54c0cd5270817f20a9.
+//
+// Solidity: event ResultSubmitted(uint256 indexed jobId, address indexed agent, string resultURI)
+func (_Job *JobFilterer) WatchResultSubmitted(opts *bind.WatchOpts, sink chan<- *JobResultSubmitted, jobId []*big.Int, agent []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var agentRule []interface{}
+	for _, agentItem := range agent {
+		agentRule = append(agentRule, agentItem)
+	}
+
+	logs, sub, err := _Job.contract.WatchLogs(opts, "ResultSubmitted", jobIdRule, agentRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobResultSubmitted)
+				if err := _Job.contract.UnpackLog(event, "ResultSubmitted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseResultSubmitted is a log parse operation binding the contract event 0xc06b551d984e333ac851ab20b1454a08d92740468f52ff54c0cd5270817f20a9.
+//
+// Solidity: event ResultSubmitted(uint256 indexed jobId, address indexed agent, string resultURI)
+func (_Job *JobFilterer) ParseResultSubmitted(log types.Log) (*JobResultSubmitted, error) {
+	event := new(JobResultSubmitted)
+	if err := _Job.contract.UnpackLog(event, "ResultSubmitted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_job_factory.go
+++ b/services/indexer-go/internal/abi/acp_job_factory.go
@@ -1,0 +1,1977 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// JobFactoryMetaData contains all meta data concerning the JobFactory contract.
+var JobFactoryMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[{\"name\":\"admin\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_jobImpl\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_registry\",\"type\":\"address\",\"internalType\":\"contractAgentRegistry\"},{\"name\":\"_defaultArbiter\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"DEFAULT_ADMIN_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"PAUSER_ROLE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"createJob\",\"inputs\":[{\"name\":\"targetAgentId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"budget\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"deadline\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"jobType\",\"type\":\"uint8\",\"internalType\":\"enumIJob.JobType\"},{\"name\":\"evaluator\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"arbiter\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"clone\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"defaultArbiter\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getJob\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"clone\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getRoleAdmin\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"grantRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"hasRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"jobImplementation\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"jobs\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"jobsByPrincipal\",\"inputs\":[{\"name\":\"principal\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"jobIds\",\"type\":\"uint256[]\",\"internalType\":\"uint256[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registry\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"contractAgentRegistry\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"callerConfirmation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"revokeRole\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setDefaultArbiter\",\"inputs\":[{\"name\":\"newArbiter\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"setJobImplementation\",\"inputs\":[{\"name\":\"newImpl\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalJobs\",\"inputs\":[],\"outputs\":[{\"name\":\"count\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"DefaultArbiterUpdated\",\"inputs\":[{\"name\":\"oldArbiter\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newArbiter\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ImplementationUpdated\",\"inputs\":[{\"name\":\"oldImpl\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newImpl\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"JobCreated\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"clone\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"principal\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"jobType\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumIJob.JobType\"},{\"name\":\"token\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"budget\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleAdminChanged\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"previousAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"newAdminRole\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleGranted\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"RoleRevoked\",\"inputs\":[{\"name\":\"role\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"account\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"sender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AccessControlBadConfirmation\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"AccessControlUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"neededRole\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"EnforcedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ExpectedPause\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FailedDeployment\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InsufficientBalance\",\"inputs\":[{\"name\":\"balance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"needed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidDeadline\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// JobFactoryABI is the input ABI used to generate the binding from.
+// Deprecated: Use JobFactoryMetaData.ABI instead.
+var JobFactoryABI = JobFactoryMetaData.ABI
+
+// JobFactory is an auto generated Go binding around an Ethereum contract.
+type JobFactory struct {
+	JobFactoryCaller     // Read-only binding to the contract
+	JobFactoryTransactor // Write-only binding to the contract
+	JobFactoryFilterer   // Log filterer for contract events
+}
+
+// JobFactoryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type JobFactoryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// JobFactoryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type JobFactoryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// JobFactoryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type JobFactoryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// JobFactorySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type JobFactorySession struct {
+	Contract     *JobFactory       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// JobFactoryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type JobFactoryCallerSession struct {
+	Contract *JobFactoryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// JobFactoryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type JobFactoryTransactorSession struct {
+	Contract     *JobFactoryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// JobFactoryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type JobFactoryRaw struct {
+	Contract *JobFactory // Generic contract binding to access the raw methods on
+}
+
+// JobFactoryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type JobFactoryCallerRaw struct {
+	Contract *JobFactoryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// JobFactoryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type JobFactoryTransactorRaw struct {
+	Contract *JobFactoryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewJobFactory creates a new instance of JobFactory, bound to a specific deployed contract.
+func NewJobFactory(address common.Address, backend bind.ContractBackend) (*JobFactory, error) {
+	contract, err := bindJobFactory(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactory{JobFactoryCaller: JobFactoryCaller{contract: contract}, JobFactoryTransactor: JobFactoryTransactor{contract: contract}, JobFactoryFilterer: JobFactoryFilterer{contract: contract}}, nil
+}
+
+// NewJobFactoryCaller creates a new read-only instance of JobFactory, bound to a specific deployed contract.
+func NewJobFactoryCaller(address common.Address, caller bind.ContractCaller) (*JobFactoryCaller, error) {
+	contract, err := bindJobFactory(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryCaller{contract: contract}, nil
+}
+
+// NewJobFactoryTransactor creates a new write-only instance of JobFactory, bound to a specific deployed contract.
+func NewJobFactoryTransactor(address common.Address, transactor bind.ContractTransactor) (*JobFactoryTransactor, error) {
+	contract, err := bindJobFactory(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryTransactor{contract: contract}, nil
+}
+
+// NewJobFactoryFilterer creates a new log filterer instance of JobFactory, bound to a specific deployed contract.
+func NewJobFactoryFilterer(address common.Address, filterer bind.ContractFilterer) (*JobFactoryFilterer, error) {
+	contract, err := bindJobFactory(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryFilterer{contract: contract}, nil
+}
+
+// bindJobFactory binds a generic wrapper to an already deployed contract.
+func bindJobFactory(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := JobFactoryMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_JobFactory *JobFactoryRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _JobFactory.Contract.JobFactoryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_JobFactory *JobFactoryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _JobFactory.Contract.JobFactoryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_JobFactory *JobFactoryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _JobFactory.Contract.JobFactoryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_JobFactory *JobFactoryCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _JobFactory.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_JobFactory *JobFactoryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _JobFactory.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_JobFactory *JobFactoryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _JobFactory.Contract.contract.Transact(opts, method, params...)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_JobFactory *JobFactoryCaller) DEFAULTADMINROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "DEFAULT_ADMIN_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_JobFactory *JobFactorySession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _JobFactory.Contract.DEFAULTADMINROLE(&_JobFactory.CallOpts)
+}
+
+// DEFAULTADMINROLE is a free data retrieval call binding the contract method 0xa217fddf.
+//
+// Solidity: function DEFAULT_ADMIN_ROLE() view returns(bytes32)
+func (_JobFactory *JobFactoryCallerSession) DEFAULTADMINROLE() ([32]byte, error) {
+	return _JobFactory.Contract.DEFAULTADMINROLE(&_JobFactory.CallOpts)
+}
+
+// PAUSERROLE is a free data retrieval call binding the contract method 0xe63ab1e9.
+//
+// Solidity: function PAUSER_ROLE() view returns(bytes32)
+func (_JobFactory *JobFactoryCaller) PAUSERROLE(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "PAUSER_ROLE")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// PAUSERROLE is a free data retrieval call binding the contract method 0xe63ab1e9.
+//
+// Solidity: function PAUSER_ROLE() view returns(bytes32)
+func (_JobFactory *JobFactorySession) PAUSERROLE() ([32]byte, error) {
+	return _JobFactory.Contract.PAUSERROLE(&_JobFactory.CallOpts)
+}
+
+// PAUSERROLE is a free data retrieval call binding the contract method 0xe63ab1e9.
+//
+// Solidity: function PAUSER_ROLE() view returns(bytes32)
+func (_JobFactory *JobFactoryCallerSession) PAUSERROLE() ([32]byte, error) {
+	return _JobFactory.Contract.PAUSERROLE(&_JobFactory.CallOpts)
+}
+
+// DefaultArbiter is a free data retrieval call binding the contract method 0xb67a2637.
+//
+// Solidity: function defaultArbiter() view returns(address)
+func (_JobFactory *JobFactoryCaller) DefaultArbiter(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "defaultArbiter")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// DefaultArbiter is a free data retrieval call binding the contract method 0xb67a2637.
+//
+// Solidity: function defaultArbiter() view returns(address)
+func (_JobFactory *JobFactorySession) DefaultArbiter() (common.Address, error) {
+	return _JobFactory.Contract.DefaultArbiter(&_JobFactory.CallOpts)
+}
+
+// DefaultArbiter is a free data retrieval call binding the contract method 0xb67a2637.
+//
+// Solidity: function defaultArbiter() view returns(address)
+func (_JobFactory *JobFactoryCallerSession) DefaultArbiter() (common.Address, error) {
+	return _JobFactory.Contract.DefaultArbiter(&_JobFactory.CallOpts)
+}
+
+// GetJob is a free data retrieval call binding the contract method 0xbf22c457.
+//
+// Solidity: function getJob(uint256 jobId) view returns(address clone)
+func (_JobFactory *JobFactoryCaller) GetJob(opts *bind.CallOpts, jobId *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "getJob", jobId)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// GetJob is a free data retrieval call binding the contract method 0xbf22c457.
+//
+// Solidity: function getJob(uint256 jobId) view returns(address clone)
+func (_JobFactory *JobFactorySession) GetJob(jobId *big.Int) (common.Address, error) {
+	return _JobFactory.Contract.GetJob(&_JobFactory.CallOpts, jobId)
+}
+
+// GetJob is a free data retrieval call binding the contract method 0xbf22c457.
+//
+// Solidity: function getJob(uint256 jobId) view returns(address clone)
+func (_JobFactory *JobFactoryCallerSession) GetJob(jobId *big.Int) (common.Address, error) {
+	return _JobFactory.Contract.GetJob(&_JobFactory.CallOpts, jobId)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_JobFactory *JobFactoryCaller) GetRoleAdmin(opts *bind.CallOpts, role [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "getRoleAdmin", role)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_JobFactory *JobFactorySession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _JobFactory.Contract.GetRoleAdmin(&_JobFactory.CallOpts, role)
+}
+
+// GetRoleAdmin is a free data retrieval call binding the contract method 0x248a9ca3.
+//
+// Solidity: function getRoleAdmin(bytes32 role) view returns(bytes32)
+func (_JobFactory *JobFactoryCallerSession) GetRoleAdmin(role [32]byte) ([32]byte, error) {
+	return _JobFactory.Contract.GetRoleAdmin(&_JobFactory.CallOpts, role)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_JobFactory *JobFactoryCaller) HasRole(opts *bind.CallOpts, role [32]byte, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "hasRole", role, account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_JobFactory *JobFactorySession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _JobFactory.Contract.HasRole(&_JobFactory.CallOpts, role, account)
+}
+
+// HasRole is a free data retrieval call binding the contract method 0x91d14854.
+//
+// Solidity: function hasRole(bytes32 role, address account) view returns(bool)
+func (_JobFactory *JobFactoryCallerSession) HasRole(role [32]byte, account common.Address) (bool, error) {
+	return _JobFactory.Contract.HasRole(&_JobFactory.CallOpts, role, account)
+}
+
+// JobImplementation is a free data retrieval call binding the contract method 0x25594a40.
+//
+// Solidity: function jobImplementation() view returns(address)
+func (_JobFactory *JobFactoryCaller) JobImplementation(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "jobImplementation")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// JobImplementation is a free data retrieval call binding the contract method 0x25594a40.
+//
+// Solidity: function jobImplementation() view returns(address)
+func (_JobFactory *JobFactorySession) JobImplementation() (common.Address, error) {
+	return _JobFactory.Contract.JobImplementation(&_JobFactory.CallOpts)
+}
+
+// JobImplementation is a free data retrieval call binding the contract method 0x25594a40.
+//
+// Solidity: function jobImplementation() view returns(address)
+func (_JobFactory *JobFactoryCallerSession) JobImplementation() (common.Address, error) {
+	return _JobFactory.Contract.JobImplementation(&_JobFactory.CallOpts)
+}
+
+// Jobs is a free data retrieval call binding the contract method 0x180aedf3.
+//
+// Solidity: function jobs(uint256 ) view returns(address)
+func (_JobFactory *JobFactoryCaller) Jobs(opts *bind.CallOpts, arg0 *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "jobs", arg0)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Jobs is a free data retrieval call binding the contract method 0x180aedf3.
+//
+// Solidity: function jobs(uint256 ) view returns(address)
+func (_JobFactory *JobFactorySession) Jobs(arg0 *big.Int) (common.Address, error) {
+	return _JobFactory.Contract.Jobs(&_JobFactory.CallOpts, arg0)
+}
+
+// Jobs is a free data retrieval call binding the contract method 0x180aedf3.
+//
+// Solidity: function jobs(uint256 ) view returns(address)
+func (_JobFactory *JobFactoryCallerSession) Jobs(arg0 *big.Int) (common.Address, error) {
+	return _JobFactory.Contract.Jobs(&_JobFactory.CallOpts, arg0)
+}
+
+// JobsByPrincipal is a free data retrieval call binding the contract method 0xa666d299.
+//
+// Solidity: function jobsByPrincipal(address principal) view returns(uint256[] jobIds)
+func (_JobFactory *JobFactoryCaller) JobsByPrincipal(opts *bind.CallOpts, principal common.Address) ([]*big.Int, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "jobsByPrincipal", principal)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// JobsByPrincipal is a free data retrieval call binding the contract method 0xa666d299.
+//
+// Solidity: function jobsByPrincipal(address principal) view returns(uint256[] jobIds)
+func (_JobFactory *JobFactorySession) JobsByPrincipal(principal common.Address) ([]*big.Int, error) {
+	return _JobFactory.Contract.JobsByPrincipal(&_JobFactory.CallOpts, principal)
+}
+
+// JobsByPrincipal is a free data retrieval call binding the contract method 0xa666d299.
+//
+// Solidity: function jobsByPrincipal(address principal) view returns(uint256[] jobIds)
+func (_JobFactory *JobFactoryCallerSession) JobsByPrincipal(principal common.Address) ([]*big.Int, error) {
+	return _JobFactory.Contract.JobsByPrincipal(&_JobFactory.CallOpts, principal)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_JobFactory *JobFactoryCaller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_JobFactory *JobFactorySession) Paused() (bool, error) {
+	return _JobFactory.Contract.Paused(&_JobFactory.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_JobFactory *JobFactoryCallerSession) Paused() (bool, error) {
+	return _JobFactory.Contract.Paused(&_JobFactory.CallOpts)
+}
+
+// Registry is a free data retrieval call binding the contract method 0x7b103999.
+//
+// Solidity: function registry() view returns(address)
+func (_JobFactory *JobFactoryCaller) Registry(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "registry")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Registry is a free data retrieval call binding the contract method 0x7b103999.
+//
+// Solidity: function registry() view returns(address)
+func (_JobFactory *JobFactorySession) Registry() (common.Address, error) {
+	return _JobFactory.Contract.Registry(&_JobFactory.CallOpts)
+}
+
+// Registry is a free data retrieval call binding the contract method 0x7b103999.
+//
+// Solidity: function registry() view returns(address)
+func (_JobFactory *JobFactoryCallerSession) Registry() (common.Address, error) {
+	return _JobFactory.Contract.Registry(&_JobFactory.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_JobFactory *JobFactoryCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_JobFactory *JobFactorySession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _JobFactory.Contract.SupportsInterface(&_JobFactory.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_JobFactory *JobFactoryCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _JobFactory.Contract.SupportsInterface(&_JobFactory.CallOpts, interfaceId)
+}
+
+// TotalJobs is a free data retrieval call binding the contract method 0x1ace87b3.
+//
+// Solidity: function totalJobs() view returns(uint256 count)
+func (_JobFactory *JobFactoryCaller) TotalJobs(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _JobFactory.contract.Call(opts, &out, "totalJobs")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalJobs is a free data retrieval call binding the contract method 0x1ace87b3.
+//
+// Solidity: function totalJobs() view returns(uint256 count)
+func (_JobFactory *JobFactorySession) TotalJobs() (*big.Int, error) {
+	return _JobFactory.Contract.TotalJobs(&_JobFactory.CallOpts)
+}
+
+// TotalJobs is a free data retrieval call binding the contract method 0x1ace87b3.
+//
+// Solidity: function totalJobs() view returns(uint256 count)
+func (_JobFactory *JobFactoryCallerSession) TotalJobs() (*big.Int, error) {
+	return _JobFactory.Contract.TotalJobs(&_JobFactory.CallOpts)
+}
+
+// CreateJob is a paid mutator transaction binding the contract method 0xaa6110ab.
+//
+// Solidity: function createJob(uint256 targetAgentId, address token, uint256 budget, uint64 deadline, uint8 jobType, address evaluator, address arbiter) returns(uint256 jobId, address clone)
+func (_JobFactory *JobFactoryTransactor) CreateJob(opts *bind.TransactOpts, targetAgentId *big.Int, token common.Address, budget *big.Int, deadline uint64, jobType uint8, evaluator common.Address, arbiter common.Address) (*types.Transaction, error) {
+	return _JobFactory.contract.Transact(opts, "createJob", targetAgentId, token, budget, deadline, jobType, evaluator, arbiter)
+}
+
+// CreateJob is a paid mutator transaction binding the contract method 0xaa6110ab.
+//
+// Solidity: function createJob(uint256 targetAgentId, address token, uint256 budget, uint64 deadline, uint8 jobType, address evaluator, address arbiter) returns(uint256 jobId, address clone)
+func (_JobFactory *JobFactorySession) CreateJob(targetAgentId *big.Int, token common.Address, budget *big.Int, deadline uint64, jobType uint8, evaluator common.Address, arbiter common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.CreateJob(&_JobFactory.TransactOpts, targetAgentId, token, budget, deadline, jobType, evaluator, arbiter)
+}
+
+// CreateJob is a paid mutator transaction binding the contract method 0xaa6110ab.
+//
+// Solidity: function createJob(uint256 targetAgentId, address token, uint256 budget, uint64 deadline, uint8 jobType, address evaluator, address arbiter) returns(uint256 jobId, address clone)
+func (_JobFactory *JobFactoryTransactorSession) CreateJob(targetAgentId *big.Int, token common.Address, budget *big.Int, deadline uint64, jobType uint8, evaluator common.Address, arbiter common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.CreateJob(&_JobFactory.TransactOpts, targetAgentId, token, budget, deadline, jobType, evaluator, arbiter)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_JobFactory *JobFactoryTransactor) GrantRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _JobFactory.contract.Transact(opts, "grantRole", role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_JobFactory *JobFactorySession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.GrantRole(&_JobFactory.TransactOpts, role, account)
+}
+
+// GrantRole is a paid mutator transaction binding the contract method 0x2f2ff15d.
+//
+// Solidity: function grantRole(bytes32 role, address account) returns()
+func (_JobFactory *JobFactoryTransactorSession) GrantRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.GrantRole(&_JobFactory.TransactOpts, role, account)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_JobFactory *JobFactoryTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _JobFactory.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_JobFactory *JobFactorySession) Pause() (*types.Transaction, error) {
+	return _JobFactory.Contract.Pause(&_JobFactory.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_JobFactory *JobFactoryTransactorSession) Pause() (*types.Transaction, error) {
+	return _JobFactory.Contract.Pause(&_JobFactory.TransactOpts)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_JobFactory *JobFactoryTransactor) RenounceRole(opts *bind.TransactOpts, role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _JobFactory.contract.Transact(opts, "renounceRole", role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_JobFactory *JobFactorySession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.RenounceRole(&_JobFactory.TransactOpts, role, callerConfirmation)
+}
+
+// RenounceRole is a paid mutator transaction binding the contract method 0x36568abe.
+//
+// Solidity: function renounceRole(bytes32 role, address callerConfirmation) returns()
+func (_JobFactory *JobFactoryTransactorSession) RenounceRole(role [32]byte, callerConfirmation common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.RenounceRole(&_JobFactory.TransactOpts, role, callerConfirmation)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_JobFactory *JobFactoryTransactor) RevokeRole(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _JobFactory.contract.Transact(opts, "revokeRole", role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_JobFactory *JobFactorySession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.RevokeRole(&_JobFactory.TransactOpts, role, account)
+}
+
+// RevokeRole is a paid mutator transaction binding the contract method 0xd547741f.
+//
+// Solidity: function revokeRole(bytes32 role, address account) returns()
+func (_JobFactory *JobFactoryTransactorSession) RevokeRole(role [32]byte, account common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.RevokeRole(&_JobFactory.TransactOpts, role, account)
+}
+
+// SetDefaultArbiter is a paid mutator transaction binding the contract method 0xbbdf7243.
+//
+// Solidity: function setDefaultArbiter(address newArbiter) returns()
+func (_JobFactory *JobFactoryTransactor) SetDefaultArbiter(opts *bind.TransactOpts, newArbiter common.Address) (*types.Transaction, error) {
+	return _JobFactory.contract.Transact(opts, "setDefaultArbiter", newArbiter)
+}
+
+// SetDefaultArbiter is a paid mutator transaction binding the contract method 0xbbdf7243.
+//
+// Solidity: function setDefaultArbiter(address newArbiter) returns()
+func (_JobFactory *JobFactorySession) SetDefaultArbiter(newArbiter common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.SetDefaultArbiter(&_JobFactory.TransactOpts, newArbiter)
+}
+
+// SetDefaultArbiter is a paid mutator transaction binding the contract method 0xbbdf7243.
+//
+// Solidity: function setDefaultArbiter(address newArbiter) returns()
+func (_JobFactory *JobFactoryTransactorSession) SetDefaultArbiter(newArbiter common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.SetDefaultArbiter(&_JobFactory.TransactOpts, newArbiter)
+}
+
+// SetJobImplementation is a paid mutator transaction binding the contract method 0x83c7cfc9.
+//
+// Solidity: function setJobImplementation(address newImpl) returns()
+func (_JobFactory *JobFactoryTransactor) SetJobImplementation(opts *bind.TransactOpts, newImpl common.Address) (*types.Transaction, error) {
+	return _JobFactory.contract.Transact(opts, "setJobImplementation", newImpl)
+}
+
+// SetJobImplementation is a paid mutator transaction binding the contract method 0x83c7cfc9.
+//
+// Solidity: function setJobImplementation(address newImpl) returns()
+func (_JobFactory *JobFactorySession) SetJobImplementation(newImpl common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.SetJobImplementation(&_JobFactory.TransactOpts, newImpl)
+}
+
+// SetJobImplementation is a paid mutator transaction binding the contract method 0x83c7cfc9.
+//
+// Solidity: function setJobImplementation(address newImpl) returns()
+func (_JobFactory *JobFactoryTransactorSession) SetJobImplementation(newImpl common.Address) (*types.Transaction, error) {
+	return _JobFactory.Contract.SetJobImplementation(&_JobFactory.TransactOpts, newImpl)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_JobFactory *JobFactoryTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _JobFactory.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_JobFactory *JobFactorySession) Unpause() (*types.Transaction, error) {
+	return _JobFactory.Contract.Unpause(&_JobFactory.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_JobFactory *JobFactoryTransactorSession) Unpause() (*types.Transaction, error) {
+	return _JobFactory.Contract.Unpause(&_JobFactory.TransactOpts)
+}
+
+// JobFactoryDefaultArbiterUpdatedIterator is returned from FilterDefaultArbiterUpdated and is used to iterate over the raw logs and unpacked data for DefaultArbiterUpdated events raised by the JobFactory contract.
+type JobFactoryDefaultArbiterUpdatedIterator struct {
+	Event *JobFactoryDefaultArbiterUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobFactoryDefaultArbiterUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobFactoryDefaultArbiterUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobFactoryDefaultArbiterUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobFactoryDefaultArbiterUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobFactoryDefaultArbiterUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobFactoryDefaultArbiterUpdated represents a DefaultArbiterUpdated event raised by the JobFactory contract.
+type JobFactoryDefaultArbiterUpdated struct {
+	OldArbiter common.Address
+	NewArbiter common.Address
+	Raw        types.Log // Blockchain specific contextual infos
+}
+
+// FilterDefaultArbiterUpdated is a free log retrieval operation binding the contract event 0x8f4ec914918528531be3ff56f55a057f73eb540484e6fe6f63c7bd02a483a957.
+//
+// Solidity: event DefaultArbiterUpdated(address indexed oldArbiter, address indexed newArbiter)
+func (_JobFactory *JobFactoryFilterer) FilterDefaultArbiterUpdated(opts *bind.FilterOpts, oldArbiter []common.Address, newArbiter []common.Address) (*JobFactoryDefaultArbiterUpdatedIterator, error) {
+
+	var oldArbiterRule []interface{}
+	for _, oldArbiterItem := range oldArbiter {
+		oldArbiterRule = append(oldArbiterRule, oldArbiterItem)
+	}
+	var newArbiterRule []interface{}
+	for _, newArbiterItem := range newArbiter {
+		newArbiterRule = append(newArbiterRule, newArbiterItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.FilterLogs(opts, "DefaultArbiterUpdated", oldArbiterRule, newArbiterRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryDefaultArbiterUpdatedIterator{contract: _JobFactory.contract, event: "DefaultArbiterUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchDefaultArbiterUpdated is a free log subscription operation binding the contract event 0x8f4ec914918528531be3ff56f55a057f73eb540484e6fe6f63c7bd02a483a957.
+//
+// Solidity: event DefaultArbiterUpdated(address indexed oldArbiter, address indexed newArbiter)
+func (_JobFactory *JobFactoryFilterer) WatchDefaultArbiterUpdated(opts *bind.WatchOpts, sink chan<- *JobFactoryDefaultArbiterUpdated, oldArbiter []common.Address, newArbiter []common.Address) (event.Subscription, error) {
+
+	var oldArbiterRule []interface{}
+	for _, oldArbiterItem := range oldArbiter {
+		oldArbiterRule = append(oldArbiterRule, oldArbiterItem)
+	}
+	var newArbiterRule []interface{}
+	for _, newArbiterItem := range newArbiter {
+		newArbiterRule = append(newArbiterRule, newArbiterItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.WatchLogs(opts, "DefaultArbiterUpdated", oldArbiterRule, newArbiterRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobFactoryDefaultArbiterUpdated)
+				if err := _JobFactory.contract.UnpackLog(event, "DefaultArbiterUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDefaultArbiterUpdated is a log parse operation binding the contract event 0x8f4ec914918528531be3ff56f55a057f73eb540484e6fe6f63c7bd02a483a957.
+//
+// Solidity: event DefaultArbiterUpdated(address indexed oldArbiter, address indexed newArbiter)
+func (_JobFactory *JobFactoryFilterer) ParseDefaultArbiterUpdated(log types.Log) (*JobFactoryDefaultArbiterUpdated, error) {
+	event := new(JobFactoryDefaultArbiterUpdated)
+	if err := _JobFactory.contract.UnpackLog(event, "DefaultArbiterUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobFactoryImplementationUpdatedIterator is returned from FilterImplementationUpdated and is used to iterate over the raw logs and unpacked data for ImplementationUpdated events raised by the JobFactory contract.
+type JobFactoryImplementationUpdatedIterator struct {
+	Event *JobFactoryImplementationUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobFactoryImplementationUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobFactoryImplementationUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobFactoryImplementationUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobFactoryImplementationUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobFactoryImplementationUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobFactoryImplementationUpdated represents a ImplementationUpdated event raised by the JobFactory contract.
+type JobFactoryImplementationUpdated struct {
+	OldImpl common.Address
+	NewImpl common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterImplementationUpdated is a free log retrieval operation binding the contract event 0xaa3f731066a578e5f39b4215468d826cdd15373cbc0dfc9cb9bdc649718ef7da.
+//
+// Solidity: event ImplementationUpdated(address indexed oldImpl, address indexed newImpl)
+func (_JobFactory *JobFactoryFilterer) FilterImplementationUpdated(opts *bind.FilterOpts, oldImpl []common.Address, newImpl []common.Address) (*JobFactoryImplementationUpdatedIterator, error) {
+
+	var oldImplRule []interface{}
+	for _, oldImplItem := range oldImpl {
+		oldImplRule = append(oldImplRule, oldImplItem)
+	}
+	var newImplRule []interface{}
+	for _, newImplItem := range newImpl {
+		newImplRule = append(newImplRule, newImplItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.FilterLogs(opts, "ImplementationUpdated", oldImplRule, newImplRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryImplementationUpdatedIterator{contract: _JobFactory.contract, event: "ImplementationUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchImplementationUpdated is a free log subscription operation binding the contract event 0xaa3f731066a578e5f39b4215468d826cdd15373cbc0dfc9cb9bdc649718ef7da.
+//
+// Solidity: event ImplementationUpdated(address indexed oldImpl, address indexed newImpl)
+func (_JobFactory *JobFactoryFilterer) WatchImplementationUpdated(opts *bind.WatchOpts, sink chan<- *JobFactoryImplementationUpdated, oldImpl []common.Address, newImpl []common.Address) (event.Subscription, error) {
+
+	var oldImplRule []interface{}
+	for _, oldImplItem := range oldImpl {
+		oldImplRule = append(oldImplRule, oldImplItem)
+	}
+	var newImplRule []interface{}
+	for _, newImplItem := range newImpl {
+		newImplRule = append(newImplRule, newImplItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.WatchLogs(opts, "ImplementationUpdated", oldImplRule, newImplRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobFactoryImplementationUpdated)
+				if err := _JobFactory.contract.UnpackLog(event, "ImplementationUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseImplementationUpdated is a log parse operation binding the contract event 0xaa3f731066a578e5f39b4215468d826cdd15373cbc0dfc9cb9bdc649718ef7da.
+//
+// Solidity: event ImplementationUpdated(address indexed oldImpl, address indexed newImpl)
+func (_JobFactory *JobFactoryFilterer) ParseImplementationUpdated(log types.Log) (*JobFactoryImplementationUpdated, error) {
+	event := new(JobFactoryImplementationUpdated)
+	if err := _JobFactory.contract.UnpackLog(event, "ImplementationUpdated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobFactoryJobCreatedIterator is returned from FilterJobCreated and is used to iterate over the raw logs and unpacked data for JobCreated events raised by the JobFactory contract.
+type JobFactoryJobCreatedIterator struct {
+	Event *JobFactoryJobCreated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobFactoryJobCreatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobFactoryJobCreated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobFactoryJobCreated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobFactoryJobCreatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobFactoryJobCreatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobFactoryJobCreated represents a JobCreated event raised by the JobFactory contract.
+type JobFactoryJobCreated struct {
+	JobId     *big.Int
+	Clone     common.Address
+	Principal common.Address
+	JobType   uint8
+	Token     common.Address
+	Budget    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterJobCreated is a free log retrieval operation binding the contract event 0xf956496ab0e37cf09cc3df7fd2b643c4a458b72e0d06e6cb9544a68553fabdd5.
+//
+// Solidity: event JobCreated(uint256 indexed jobId, address indexed clone, address indexed principal, uint8 jobType, address token, uint256 budget)
+func (_JobFactory *JobFactoryFilterer) FilterJobCreated(opts *bind.FilterOpts, jobId []*big.Int, clone []common.Address, principal []common.Address) (*JobFactoryJobCreatedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var cloneRule []interface{}
+	for _, cloneItem := range clone {
+		cloneRule = append(cloneRule, cloneItem)
+	}
+	var principalRule []interface{}
+	for _, principalItem := range principal {
+		principalRule = append(principalRule, principalItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.FilterLogs(opts, "JobCreated", jobIdRule, cloneRule, principalRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryJobCreatedIterator{contract: _JobFactory.contract, event: "JobCreated", logs: logs, sub: sub}, nil
+}
+
+// WatchJobCreated is a free log subscription operation binding the contract event 0xf956496ab0e37cf09cc3df7fd2b643c4a458b72e0d06e6cb9544a68553fabdd5.
+//
+// Solidity: event JobCreated(uint256 indexed jobId, address indexed clone, address indexed principal, uint8 jobType, address token, uint256 budget)
+func (_JobFactory *JobFactoryFilterer) WatchJobCreated(opts *bind.WatchOpts, sink chan<- *JobFactoryJobCreated, jobId []*big.Int, clone []common.Address, principal []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var cloneRule []interface{}
+	for _, cloneItem := range clone {
+		cloneRule = append(cloneRule, cloneItem)
+	}
+	var principalRule []interface{}
+	for _, principalItem := range principal {
+		principalRule = append(principalRule, principalItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.WatchLogs(opts, "JobCreated", jobIdRule, cloneRule, principalRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobFactoryJobCreated)
+				if err := _JobFactory.contract.UnpackLog(event, "JobCreated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseJobCreated is a log parse operation binding the contract event 0xf956496ab0e37cf09cc3df7fd2b643c4a458b72e0d06e6cb9544a68553fabdd5.
+//
+// Solidity: event JobCreated(uint256 indexed jobId, address indexed clone, address indexed principal, uint8 jobType, address token, uint256 budget)
+func (_JobFactory *JobFactoryFilterer) ParseJobCreated(log types.Log) (*JobFactoryJobCreated, error) {
+	event := new(JobFactoryJobCreated)
+	if err := _JobFactory.contract.UnpackLog(event, "JobCreated", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobFactoryPausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the JobFactory contract.
+type JobFactoryPausedIterator struct {
+	Event *JobFactoryPaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobFactoryPausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobFactoryPaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobFactoryPaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobFactoryPausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobFactoryPausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobFactoryPaused represents a Paused event raised by the JobFactory contract.
+type JobFactoryPaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_JobFactory *JobFactoryFilterer) FilterPaused(opts *bind.FilterOpts) (*JobFactoryPausedIterator, error) {
+
+	logs, sub, err := _JobFactory.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryPausedIterator{contract: _JobFactory.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_JobFactory *JobFactoryFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *JobFactoryPaused) (event.Subscription, error) {
+
+	logs, sub, err := _JobFactory.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobFactoryPaused)
+				if err := _JobFactory.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_JobFactory *JobFactoryFilterer) ParsePaused(log types.Log) (*JobFactoryPaused, error) {
+	event := new(JobFactoryPaused)
+	if err := _JobFactory.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobFactoryRoleAdminChangedIterator is returned from FilterRoleAdminChanged and is used to iterate over the raw logs and unpacked data for RoleAdminChanged events raised by the JobFactory contract.
+type JobFactoryRoleAdminChangedIterator struct {
+	Event *JobFactoryRoleAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobFactoryRoleAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobFactoryRoleAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobFactoryRoleAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobFactoryRoleAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobFactoryRoleAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobFactoryRoleAdminChanged represents a RoleAdminChanged event raised by the JobFactory contract.
+type JobFactoryRoleAdminChanged struct {
+	Role              [32]byte
+	PreviousAdminRole [32]byte
+	NewAdminRole      [32]byte
+	Raw               types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleAdminChanged is a free log retrieval operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_JobFactory *JobFactoryFilterer) FilterRoleAdminChanged(opts *bind.FilterOpts, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (*JobFactoryRoleAdminChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.FilterLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryRoleAdminChangedIterator{contract: _JobFactory.contract, event: "RoleAdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleAdminChanged is a free log subscription operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_JobFactory *JobFactoryFilterer) WatchRoleAdminChanged(opts *bind.WatchOpts, sink chan<- *JobFactoryRoleAdminChanged, role [][32]byte, previousAdminRole [][32]byte, newAdminRole [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var previousAdminRoleRule []interface{}
+	for _, previousAdminRoleItem := range previousAdminRole {
+		previousAdminRoleRule = append(previousAdminRoleRule, previousAdminRoleItem)
+	}
+	var newAdminRoleRule []interface{}
+	for _, newAdminRoleItem := range newAdminRole {
+		newAdminRoleRule = append(newAdminRoleRule, newAdminRoleItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.WatchLogs(opts, "RoleAdminChanged", roleRule, previousAdminRoleRule, newAdminRoleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobFactoryRoleAdminChanged)
+				if err := _JobFactory.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleAdminChanged is a log parse operation binding the contract event 0xbd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff.
+//
+// Solidity: event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)
+func (_JobFactory *JobFactoryFilterer) ParseRoleAdminChanged(log types.Log) (*JobFactoryRoleAdminChanged, error) {
+	event := new(JobFactoryRoleAdminChanged)
+	if err := _JobFactory.contract.UnpackLog(event, "RoleAdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobFactoryRoleGrantedIterator is returned from FilterRoleGranted and is used to iterate over the raw logs and unpacked data for RoleGranted events raised by the JobFactory contract.
+type JobFactoryRoleGrantedIterator struct {
+	Event *JobFactoryRoleGranted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobFactoryRoleGrantedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobFactoryRoleGranted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobFactoryRoleGranted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobFactoryRoleGrantedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobFactoryRoleGrantedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobFactoryRoleGranted represents a RoleGranted event raised by the JobFactory contract.
+type JobFactoryRoleGranted struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleGranted is a free log retrieval operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_JobFactory *JobFactoryFilterer) FilterRoleGranted(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*JobFactoryRoleGrantedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.FilterLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryRoleGrantedIterator{contract: _JobFactory.contract, event: "RoleGranted", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleGranted is a free log subscription operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_JobFactory *JobFactoryFilterer) WatchRoleGranted(opts *bind.WatchOpts, sink chan<- *JobFactoryRoleGranted, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.WatchLogs(opts, "RoleGranted", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobFactoryRoleGranted)
+				if err := _JobFactory.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleGranted is a log parse operation binding the contract event 0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d.
+//
+// Solidity: event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)
+func (_JobFactory *JobFactoryFilterer) ParseRoleGranted(log types.Log) (*JobFactoryRoleGranted, error) {
+	event := new(JobFactoryRoleGranted)
+	if err := _JobFactory.contract.UnpackLog(event, "RoleGranted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobFactoryRoleRevokedIterator is returned from FilterRoleRevoked and is used to iterate over the raw logs and unpacked data for RoleRevoked events raised by the JobFactory contract.
+type JobFactoryRoleRevokedIterator struct {
+	Event *JobFactoryRoleRevoked // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobFactoryRoleRevokedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobFactoryRoleRevoked)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobFactoryRoleRevoked)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobFactoryRoleRevokedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobFactoryRoleRevokedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobFactoryRoleRevoked represents a RoleRevoked event raised by the JobFactory contract.
+type JobFactoryRoleRevoked struct {
+	Role    [32]byte
+	Account common.Address
+	Sender  common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoleRevoked is a free log retrieval operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_JobFactory *JobFactoryFilterer) FilterRoleRevoked(opts *bind.FilterOpts, role [][32]byte, account []common.Address, sender []common.Address) (*JobFactoryRoleRevokedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.FilterLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryRoleRevokedIterator{contract: _JobFactory.contract, event: "RoleRevoked", logs: logs, sub: sub}, nil
+}
+
+// WatchRoleRevoked is a free log subscription operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_JobFactory *JobFactoryFilterer) WatchRoleRevoked(opts *bind.WatchOpts, sink chan<- *JobFactoryRoleRevoked, role [][32]byte, account []common.Address, sender []common.Address) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+	var accountRule []interface{}
+	for _, accountItem := range account {
+		accountRule = append(accountRule, accountItem)
+	}
+	var senderRule []interface{}
+	for _, senderItem := range sender {
+		senderRule = append(senderRule, senderItem)
+	}
+
+	logs, sub, err := _JobFactory.contract.WatchLogs(opts, "RoleRevoked", roleRule, accountRule, senderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobFactoryRoleRevoked)
+				if err := _JobFactory.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoleRevoked is a log parse operation binding the contract event 0xf6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b.
+//
+// Solidity: event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)
+func (_JobFactory *JobFactoryFilterer) ParseRoleRevoked(log types.Log) (*JobFactoryRoleRevoked, error) {
+	event := new(JobFactoryRoleRevoked)
+	if err := _JobFactory.contract.UnpackLog(event, "RoleRevoked", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// JobFactoryUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the JobFactory contract.
+type JobFactoryUnpausedIterator struct {
+	Event *JobFactoryUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *JobFactoryUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(JobFactoryUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(JobFactoryUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *JobFactoryUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *JobFactoryUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// JobFactoryUnpaused represents a Unpaused event raised by the JobFactory contract.
+type JobFactoryUnpaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_JobFactory *JobFactoryFilterer) FilterUnpaused(opts *bind.FilterOpts) (*JobFactoryUnpausedIterator, error) {
+
+	logs, sub, err := _JobFactory.contract.FilterLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return &JobFactoryUnpausedIterator{contract: _JobFactory.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_JobFactory *JobFactoryFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *JobFactoryUnpaused) (event.Subscription, error) {
+
+	logs, sub, err := _JobFactory.contract.WatchLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(JobFactoryUnpaused)
+				if err := _JobFactory.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_JobFactory *JobFactoryFilterer) ParseUnpaused(log types.Log) (*JobFactoryUnpaused, error) {
+	event := new(JobFactoryUnpaused)
+	if err := _JobFactory.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_milestone_hook.go
+++ b/services/indexer-go/internal/abi/acp_milestone_hook.go
@@ -1,0 +1,704 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// MilestoneHookMetaData contains all meta data concerning the MilestoneHook contract.
+var MilestoneHookMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"hookName\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"milestones\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"agent\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"stageAmount\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"lastStageRemainder\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"totalStages\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"completedStages\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"initialised\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"onAccept\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"context\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onApprove\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onCancel\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onReject\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onSubmit\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"event\",\"name\":\"MilestoneCancelled\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"remainingStages\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MilestoneReleased\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"agent\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"stage\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"},{\"name\":\"totalStages\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"AllStagesComplete\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"InvalidStages\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitialised\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// MilestoneHookABI is the input ABI used to generate the binding from.
+// Deprecated: Use MilestoneHookMetaData.ABI instead.
+var MilestoneHookABI = MilestoneHookMetaData.ABI
+
+// MilestoneHook is an auto generated Go binding around an Ethereum contract.
+type MilestoneHook struct {
+	MilestoneHookCaller     // Read-only binding to the contract
+	MilestoneHookTransactor // Write-only binding to the contract
+	MilestoneHookFilterer   // Log filterer for contract events
+}
+
+// MilestoneHookCaller is an auto generated read-only Go binding around an Ethereum contract.
+type MilestoneHookCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// MilestoneHookTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type MilestoneHookTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// MilestoneHookFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type MilestoneHookFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// MilestoneHookSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type MilestoneHookSession struct {
+	Contract     *MilestoneHook    // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// MilestoneHookCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type MilestoneHookCallerSession struct {
+	Contract *MilestoneHookCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts        // Call options to use throughout this session
+}
+
+// MilestoneHookTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type MilestoneHookTransactorSession struct {
+	Contract     *MilestoneHookTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// MilestoneHookRaw is an auto generated low-level Go binding around an Ethereum contract.
+type MilestoneHookRaw struct {
+	Contract *MilestoneHook // Generic contract binding to access the raw methods on
+}
+
+// MilestoneHookCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type MilestoneHookCallerRaw struct {
+	Contract *MilestoneHookCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// MilestoneHookTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type MilestoneHookTransactorRaw struct {
+	Contract *MilestoneHookTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewMilestoneHook creates a new instance of MilestoneHook, bound to a specific deployed contract.
+func NewMilestoneHook(address common.Address, backend bind.ContractBackend) (*MilestoneHook, error) {
+	contract, err := bindMilestoneHook(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &MilestoneHook{MilestoneHookCaller: MilestoneHookCaller{contract: contract}, MilestoneHookTransactor: MilestoneHookTransactor{contract: contract}, MilestoneHookFilterer: MilestoneHookFilterer{contract: contract}}, nil
+}
+
+// NewMilestoneHookCaller creates a new read-only instance of MilestoneHook, bound to a specific deployed contract.
+func NewMilestoneHookCaller(address common.Address, caller bind.ContractCaller) (*MilestoneHookCaller, error) {
+	contract, err := bindMilestoneHook(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &MilestoneHookCaller{contract: contract}, nil
+}
+
+// NewMilestoneHookTransactor creates a new write-only instance of MilestoneHook, bound to a specific deployed contract.
+func NewMilestoneHookTransactor(address common.Address, transactor bind.ContractTransactor) (*MilestoneHookTransactor, error) {
+	contract, err := bindMilestoneHook(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &MilestoneHookTransactor{contract: contract}, nil
+}
+
+// NewMilestoneHookFilterer creates a new log filterer instance of MilestoneHook, bound to a specific deployed contract.
+func NewMilestoneHookFilterer(address common.Address, filterer bind.ContractFilterer) (*MilestoneHookFilterer, error) {
+	contract, err := bindMilestoneHook(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &MilestoneHookFilterer{contract: contract}, nil
+}
+
+// bindMilestoneHook binds a generic wrapper to an already deployed contract.
+func bindMilestoneHook(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := MilestoneHookMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_MilestoneHook *MilestoneHookRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _MilestoneHook.Contract.MilestoneHookCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_MilestoneHook *MilestoneHookRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.MilestoneHookTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_MilestoneHook *MilestoneHookRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.MilestoneHookTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_MilestoneHook *MilestoneHookCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _MilestoneHook.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_MilestoneHook *MilestoneHookTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_MilestoneHook *MilestoneHookTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.contract.Transact(opts, method, params...)
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_MilestoneHook *MilestoneHookCaller) HookName(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _MilestoneHook.contract.Call(opts, &out, "hookName")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_MilestoneHook *MilestoneHookSession) HookName() (string, error) {
+	return _MilestoneHook.Contract.HookName(&_MilestoneHook.CallOpts)
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_MilestoneHook *MilestoneHookCallerSession) HookName() (string, error) {
+	return _MilestoneHook.Contract.HookName(&_MilestoneHook.CallOpts)
+}
+
+// Milestones is a free data retrieval call binding the contract method 0xe89e4ed6.
+//
+// Solidity: function milestones(uint256 ) view returns(address agent, address token, uint256 stageAmount, uint256 lastStageRemainder, uint8 totalStages, uint8 completedStages, bool initialised)
+func (_MilestoneHook *MilestoneHookCaller) Milestones(opts *bind.CallOpts, arg0 *big.Int) (struct {
+	Agent              common.Address
+	Token              common.Address
+	StageAmount        *big.Int
+	LastStageRemainder *big.Int
+	TotalStages        uint8
+	CompletedStages    uint8
+	Initialised        bool
+}, error) {
+	var out []interface{}
+	err := _MilestoneHook.contract.Call(opts, &out, "milestones", arg0)
+
+	outstruct := new(struct {
+		Agent              common.Address
+		Token              common.Address
+		StageAmount        *big.Int
+		LastStageRemainder *big.Int
+		TotalStages        uint8
+		CompletedStages    uint8
+		Initialised        bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Agent = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.Token = *abi.ConvertType(out[1], new(common.Address)).(*common.Address)
+	outstruct.StageAmount = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.LastStageRemainder = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.TotalStages = *abi.ConvertType(out[4], new(uint8)).(*uint8)
+	outstruct.CompletedStages = *abi.ConvertType(out[5], new(uint8)).(*uint8)
+	outstruct.Initialised = *abi.ConvertType(out[6], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// Milestones is a free data retrieval call binding the contract method 0xe89e4ed6.
+//
+// Solidity: function milestones(uint256 ) view returns(address agent, address token, uint256 stageAmount, uint256 lastStageRemainder, uint8 totalStages, uint8 completedStages, bool initialised)
+func (_MilestoneHook *MilestoneHookSession) Milestones(arg0 *big.Int) (struct {
+	Agent              common.Address
+	Token              common.Address
+	StageAmount        *big.Int
+	LastStageRemainder *big.Int
+	TotalStages        uint8
+	CompletedStages    uint8
+	Initialised        bool
+}, error) {
+	return _MilestoneHook.Contract.Milestones(&_MilestoneHook.CallOpts, arg0)
+}
+
+// Milestones is a free data retrieval call binding the contract method 0xe89e4ed6.
+//
+// Solidity: function milestones(uint256 ) view returns(address agent, address token, uint256 stageAmount, uint256 lastStageRemainder, uint8 totalStages, uint8 completedStages, bool initialised)
+func (_MilestoneHook *MilestoneHookCallerSession) Milestones(arg0 *big.Int) (struct {
+	Agent              common.Address
+	Token              common.Address
+	StageAmount        *big.Int
+	LastStageRemainder *big.Int
+	TotalStages        uint8
+	CompletedStages    uint8
+	Initialised        bool
+}, error) {
+	return _MilestoneHook.Contract.Milestones(&_MilestoneHook.CallOpts, arg0)
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_MilestoneHook *MilestoneHookCaller) OnReject(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _MilestoneHook.contract.Call(opts, &out, "onReject", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_MilestoneHook *MilestoneHookSession) OnReject(arg0 *big.Int, arg1 []byte) error {
+	return _MilestoneHook.Contract.OnReject(&_MilestoneHook.CallOpts, arg0, arg1)
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_MilestoneHook *MilestoneHookCallerSession) OnReject(arg0 *big.Int, arg1 []byte) error {
+	return _MilestoneHook.Contract.OnReject(&_MilestoneHook.CallOpts, arg0, arg1)
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_MilestoneHook *MilestoneHookCaller) OnSubmit(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _MilestoneHook.contract.Call(opts, &out, "onSubmit", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_MilestoneHook *MilestoneHookSession) OnSubmit(arg0 *big.Int, arg1 []byte) error {
+	return _MilestoneHook.Contract.OnSubmit(&_MilestoneHook.CallOpts, arg0, arg1)
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_MilestoneHook *MilestoneHookCallerSession) OnSubmit(arg0 *big.Int, arg1 []byte) error {
+	return _MilestoneHook.Contract.OnSubmit(&_MilestoneHook.CallOpts, arg0, arg1)
+}
+
+// OnAccept is a paid mutator transaction binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 jobId, bytes context) returns()
+func (_MilestoneHook *MilestoneHookTransactor) OnAccept(opts *bind.TransactOpts, jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _MilestoneHook.contract.Transact(opts, "onAccept", jobId, context)
+}
+
+// OnAccept is a paid mutator transaction binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 jobId, bytes context) returns()
+func (_MilestoneHook *MilestoneHookSession) OnAccept(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.OnAccept(&_MilestoneHook.TransactOpts, jobId, context)
+}
+
+// OnAccept is a paid mutator transaction binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 jobId, bytes context) returns()
+func (_MilestoneHook *MilestoneHookTransactorSession) OnAccept(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.OnAccept(&_MilestoneHook.TransactOpts, jobId, context)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes ) returns()
+func (_MilestoneHook *MilestoneHookTransactor) OnApprove(opts *bind.TransactOpts, jobId *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _MilestoneHook.contract.Transact(opts, "onApprove", jobId, arg1)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes ) returns()
+func (_MilestoneHook *MilestoneHookSession) OnApprove(jobId *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.OnApprove(&_MilestoneHook.TransactOpts, jobId, arg1)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes ) returns()
+func (_MilestoneHook *MilestoneHookTransactorSession) OnApprove(jobId *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.OnApprove(&_MilestoneHook.TransactOpts, jobId, arg1)
+}
+
+// OnCancel is a paid mutator transaction binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 jobId, bytes ) returns()
+func (_MilestoneHook *MilestoneHookTransactor) OnCancel(opts *bind.TransactOpts, jobId *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _MilestoneHook.contract.Transact(opts, "onCancel", jobId, arg1)
+}
+
+// OnCancel is a paid mutator transaction binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 jobId, bytes ) returns()
+func (_MilestoneHook *MilestoneHookSession) OnCancel(jobId *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.OnCancel(&_MilestoneHook.TransactOpts, jobId, arg1)
+}
+
+// OnCancel is a paid mutator transaction binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 jobId, bytes ) returns()
+func (_MilestoneHook *MilestoneHookTransactorSession) OnCancel(jobId *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _MilestoneHook.Contract.OnCancel(&_MilestoneHook.TransactOpts, jobId, arg1)
+}
+
+// MilestoneHookMilestoneCancelledIterator is returned from FilterMilestoneCancelled and is used to iterate over the raw logs and unpacked data for MilestoneCancelled events raised by the MilestoneHook contract.
+type MilestoneHookMilestoneCancelledIterator struct {
+	Event *MilestoneHookMilestoneCancelled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MilestoneHookMilestoneCancelledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MilestoneHookMilestoneCancelled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MilestoneHookMilestoneCancelled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MilestoneHookMilestoneCancelledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MilestoneHookMilestoneCancelledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MilestoneHookMilestoneCancelled represents a MilestoneCancelled event raised by the MilestoneHook contract.
+type MilestoneHookMilestoneCancelled struct {
+	JobId           *big.Int
+	RemainingStages uint8
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterMilestoneCancelled is a free log retrieval operation binding the contract event 0x1a0b394b2791bb8cb3c7490e14c4a3617f85d3c9b0bcf966fc8154c0618cfaef.
+//
+// Solidity: event MilestoneCancelled(uint256 indexed jobId, uint8 remainingStages)
+func (_MilestoneHook *MilestoneHookFilterer) FilterMilestoneCancelled(opts *bind.FilterOpts, jobId []*big.Int) (*MilestoneHookMilestoneCancelledIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+
+	logs, sub, err := _MilestoneHook.contract.FilterLogs(opts, "MilestoneCancelled", jobIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &MilestoneHookMilestoneCancelledIterator{contract: _MilestoneHook.contract, event: "MilestoneCancelled", logs: logs, sub: sub}, nil
+}
+
+// WatchMilestoneCancelled is a free log subscription operation binding the contract event 0x1a0b394b2791bb8cb3c7490e14c4a3617f85d3c9b0bcf966fc8154c0618cfaef.
+//
+// Solidity: event MilestoneCancelled(uint256 indexed jobId, uint8 remainingStages)
+func (_MilestoneHook *MilestoneHookFilterer) WatchMilestoneCancelled(opts *bind.WatchOpts, sink chan<- *MilestoneHookMilestoneCancelled, jobId []*big.Int) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+
+	logs, sub, err := _MilestoneHook.contract.WatchLogs(opts, "MilestoneCancelled", jobIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MilestoneHookMilestoneCancelled)
+				if err := _MilestoneHook.contract.UnpackLog(event, "MilestoneCancelled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMilestoneCancelled is a log parse operation binding the contract event 0x1a0b394b2791bb8cb3c7490e14c4a3617f85d3c9b0bcf966fc8154c0618cfaef.
+//
+// Solidity: event MilestoneCancelled(uint256 indexed jobId, uint8 remainingStages)
+func (_MilestoneHook *MilestoneHookFilterer) ParseMilestoneCancelled(log types.Log) (*MilestoneHookMilestoneCancelled, error) {
+	event := new(MilestoneHookMilestoneCancelled)
+	if err := _MilestoneHook.contract.UnpackLog(event, "MilestoneCancelled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// MilestoneHookMilestoneReleasedIterator is returned from FilterMilestoneReleased and is used to iterate over the raw logs and unpacked data for MilestoneReleased events raised by the MilestoneHook contract.
+type MilestoneHookMilestoneReleasedIterator struct {
+	Event *MilestoneHookMilestoneReleased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *MilestoneHookMilestoneReleasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(MilestoneHookMilestoneReleased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(MilestoneHookMilestoneReleased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *MilestoneHookMilestoneReleasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *MilestoneHookMilestoneReleasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// MilestoneHookMilestoneReleased represents a MilestoneReleased event raised by the MilestoneHook contract.
+type MilestoneHookMilestoneReleased struct {
+	JobId       *big.Int
+	Agent       common.Address
+	Stage       uint8
+	TotalStages uint8
+	Amount      *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterMilestoneReleased is a free log retrieval operation binding the contract event 0xd25357de9f9b59472a26c94ce8935500c7af97338a72f82d8c0d5ea5dde3f27d.
+//
+// Solidity: event MilestoneReleased(uint256 indexed jobId, address indexed agent, uint8 stage, uint8 totalStages, uint256 amount)
+func (_MilestoneHook *MilestoneHookFilterer) FilterMilestoneReleased(opts *bind.FilterOpts, jobId []*big.Int, agent []common.Address) (*MilestoneHookMilestoneReleasedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var agentRule []interface{}
+	for _, agentItem := range agent {
+		agentRule = append(agentRule, agentItem)
+	}
+
+	logs, sub, err := _MilestoneHook.contract.FilterLogs(opts, "MilestoneReleased", jobIdRule, agentRule)
+	if err != nil {
+		return nil, err
+	}
+	return &MilestoneHookMilestoneReleasedIterator{contract: _MilestoneHook.contract, event: "MilestoneReleased", logs: logs, sub: sub}, nil
+}
+
+// WatchMilestoneReleased is a free log subscription operation binding the contract event 0xd25357de9f9b59472a26c94ce8935500c7af97338a72f82d8c0d5ea5dde3f27d.
+//
+// Solidity: event MilestoneReleased(uint256 indexed jobId, address indexed agent, uint8 stage, uint8 totalStages, uint256 amount)
+func (_MilestoneHook *MilestoneHookFilterer) WatchMilestoneReleased(opts *bind.WatchOpts, sink chan<- *MilestoneHookMilestoneReleased, jobId []*big.Int, agent []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var agentRule []interface{}
+	for _, agentItem := range agent {
+		agentRule = append(agentRule, agentItem)
+	}
+
+	logs, sub, err := _MilestoneHook.contract.WatchLogs(opts, "MilestoneReleased", jobIdRule, agentRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(MilestoneHookMilestoneReleased)
+				if err := _MilestoneHook.contract.UnpackLog(event, "MilestoneReleased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMilestoneReleased is a log parse operation binding the contract event 0xd25357de9f9b59472a26c94ce8935500c7af97338a72f82d8c0d5ea5dde3f27d.
+//
+// Solidity: event MilestoneReleased(uint256 indexed jobId, address indexed agent, uint8 stage, uint8 totalStages, uint256 amount)
+func (_MilestoneHook *MilestoneHookFilterer) ParseMilestoneReleased(log types.Log) (*MilestoneHookMilestoneReleased, error) {
+	event := new(MilestoneHookMilestoneReleased)
+	if err := _MilestoneHook.contract.UnpackLog(event, "MilestoneReleased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_royalty_hook.go
+++ b/services/indexer-go/internal/abi/acp_royalty_hook.go
@@ -1,0 +1,543 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// RoyaltyHookMetaData contains all meta data concerning the RoyaltyHook contract.
+var RoyaltyHookMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"hookName\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onAccept\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onApprove\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"context\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onCancel\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onReject\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onSubmit\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"event\",\"name\":\"RoyaltyPaid\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"token\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"recipient\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"NoRecipients\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RecipientZeroAddress\",\"inputs\":[{\"name\":\"index\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ShareSumMismatch\",\"inputs\":[{\"name\":\"sum\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// RoyaltyHookABI is the input ABI used to generate the binding from.
+// Deprecated: Use RoyaltyHookMetaData.ABI instead.
+var RoyaltyHookABI = RoyaltyHookMetaData.ABI
+
+// RoyaltyHook is an auto generated Go binding around an Ethereum contract.
+type RoyaltyHook struct {
+	RoyaltyHookCaller     // Read-only binding to the contract
+	RoyaltyHookTransactor // Write-only binding to the contract
+	RoyaltyHookFilterer   // Log filterer for contract events
+}
+
+// RoyaltyHookCaller is an auto generated read-only Go binding around an Ethereum contract.
+type RoyaltyHookCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RoyaltyHookTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type RoyaltyHookTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RoyaltyHookFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type RoyaltyHookFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RoyaltyHookSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type RoyaltyHookSession struct {
+	Contract     *RoyaltyHook      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// RoyaltyHookCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type RoyaltyHookCallerSession struct {
+	Contract *RoyaltyHookCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// RoyaltyHookTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type RoyaltyHookTransactorSession struct {
+	Contract     *RoyaltyHookTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// RoyaltyHookRaw is an auto generated low-level Go binding around an Ethereum contract.
+type RoyaltyHookRaw struct {
+	Contract *RoyaltyHook // Generic contract binding to access the raw methods on
+}
+
+// RoyaltyHookCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type RoyaltyHookCallerRaw struct {
+	Contract *RoyaltyHookCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// RoyaltyHookTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type RoyaltyHookTransactorRaw struct {
+	Contract *RoyaltyHookTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewRoyaltyHook creates a new instance of RoyaltyHook, bound to a specific deployed contract.
+func NewRoyaltyHook(address common.Address, backend bind.ContractBackend) (*RoyaltyHook, error) {
+	contract, err := bindRoyaltyHook(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &RoyaltyHook{RoyaltyHookCaller: RoyaltyHookCaller{contract: contract}, RoyaltyHookTransactor: RoyaltyHookTransactor{contract: contract}, RoyaltyHookFilterer: RoyaltyHookFilterer{contract: contract}}, nil
+}
+
+// NewRoyaltyHookCaller creates a new read-only instance of RoyaltyHook, bound to a specific deployed contract.
+func NewRoyaltyHookCaller(address common.Address, caller bind.ContractCaller) (*RoyaltyHookCaller, error) {
+	contract, err := bindRoyaltyHook(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RoyaltyHookCaller{contract: contract}, nil
+}
+
+// NewRoyaltyHookTransactor creates a new write-only instance of RoyaltyHook, bound to a specific deployed contract.
+func NewRoyaltyHookTransactor(address common.Address, transactor bind.ContractTransactor) (*RoyaltyHookTransactor, error) {
+	contract, err := bindRoyaltyHook(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RoyaltyHookTransactor{contract: contract}, nil
+}
+
+// NewRoyaltyHookFilterer creates a new log filterer instance of RoyaltyHook, bound to a specific deployed contract.
+func NewRoyaltyHookFilterer(address common.Address, filterer bind.ContractFilterer) (*RoyaltyHookFilterer, error) {
+	contract, err := bindRoyaltyHook(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &RoyaltyHookFilterer{contract: contract}, nil
+}
+
+// bindRoyaltyHook binds a generic wrapper to an already deployed contract.
+func bindRoyaltyHook(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := RoyaltyHookMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_RoyaltyHook *RoyaltyHookRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _RoyaltyHook.Contract.RoyaltyHookCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_RoyaltyHook *RoyaltyHookRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _RoyaltyHook.Contract.RoyaltyHookTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_RoyaltyHook *RoyaltyHookRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _RoyaltyHook.Contract.RoyaltyHookTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_RoyaltyHook *RoyaltyHookCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _RoyaltyHook.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_RoyaltyHook *RoyaltyHookTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _RoyaltyHook.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_RoyaltyHook *RoyaltyHookTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _RoyaltyHook.Contract.contract.Transact(opts, method, params...)
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_RoyaltyHook *RoyaltyHookCaller) BPS(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _RoyaltyHook.contract.Call(opts, &out, "BPS")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_RoyaltyHook *RoyaltyHookSession) BPS() (*big.Int, error) {
+	return _RoyaltyHook.Contract.BPS(&_RoyaltyHook.CallOpts)
+}
+
+// BPS is a free data retrieval call binding the contract method 0x249d39e9.
+//
+// Solidity: function BPS() view returns(uint256)
+func (_RoyaltyHook *RoyaltyHookCallerSession) BPS() (*big.Int, error) {
+	return _RoyaltyHook.Contract.BPS(&_RoyaltyHook.CallOpts)
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_RoyaltyHook *RoyaltyHookCaller) HookName(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _RoyaltyHook.contract.Call(opts, &out, "hookName")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_RoyaltyHook *RoyaltyHookSession) HookName() (string, error) {
+	return _RoyaltyHook.Contract.HookName(&_RoyaltyHook.CallOpts)
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_RoyaltyHook *RoyaltyHookCallerSession) HookName() (string, error) {
+	return _RoyaltyHook.Contract.HookName(&_RoyaltyHook.CallOpts)
+}
+
+// OnAccept is a free data retrieval call binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookCaller) OnAccept(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _RoyaltyHook.contract.Call(opts, &out, "onAccept", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnAccept is a free data retrieval call binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookSession) OnAccept(arg0 *big.Int, arg1 []byte) error {
+	return _RoyaltyHook.Contract.OnAccept(&_RoyaltyHook.CallOpts, arg0, arg1)
+}
+
+// OnAccept is a free data retrieval call binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookCallerSession) OnAccept(arg0 *big.Int, arg1 []byte) error {
+	return _RoyaltyHook.Contract.OnAccept(&_RoyaltyHook.CallOpts, arg0, arg1)
+}
+
+// OnCancel is a free data retrieval call binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookCaller) OnCancel(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _RoyaltyHook.contract.Call(opts, &out, "onCancel", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnCancel is a free data retrieval call binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookSession) OnCancel(arg0 *big.Int, arg1 []byte) error {
+	return _RoyaltyHook.Contract.OnCancel(&_RoyaltyHook.CallOpts, arg0, arg1)
+}
+
+// OnCancel is a free data retrieval call binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookCallerSession) OnCancel(arg0 *big.Int, arg1 []byte) error {
+	return _RoyaltyHook.Contract.OnCancel(&_RoyaltyHook.CallOpts, arg0, arg1)
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookCaller) OnReject(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _RoyaltyHook.contract.Call(opts, &out, "onReject", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookSession) OnReject(arg0 *big.Int, arg1 []byte) error {
+	return _RoyaltyHook.Contract.OnReject(&_RoyaltyHook.CallOpts, arg0, arg1)
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookCallerSession) OnReject(arg0 *big.Int, arg1 []byte) error {
+	return _RoyaltyHook.Contract.OnReject(&_RoyaltyHook.CallOpts, arg0, arg1)
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookCaller) OnSubmit(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _RoyaltyHook.contract.Call(opts, &out, "onSubmit", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookSession) OnSubmit(arg0 *big.Int, arg1 []byte) error {
+	return _RoyaltyHook.Contract.OnSubmit(&_RoyaltyHook.CallOpts, arg0, arg1)
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_RoyaltyHook *RoyaltyHookCallerSession) OnSubmit(arg0 *big.Int, arg1 []byte) error {
+	return _RoyaltyHook.Contract.OnSubmit(&_RoyaltyHook.CallOpts, arg0, arg1)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes context) returns()
+func (_RoyaltyHook *RoyaltyHookTransactor) OnApprove(opts *bind.TransactOpts, jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _RoyaltyHook.contract.Transact(opts, "onApprove", jobId, context)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes context) returns()
+func (_RoyaltyHook *RoyaltyHookSession) OnApprove(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _RoyaltyHook.Contract.OnApprove(&_RoyaltyHook.TransactOpts, jobId, context)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes context) returns()
+func (_RoyaltyHook *RoyaltyHookTransactorSession) OnApprove(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _RoyaltyHook.Contract.OnApprove(&_RoyaltyHook.TransactOpts, jobId, context)
+}
+
+// RoyaltyHookRoyaltyPaidIterator is returned from FilterRoyaltyPaid and is used to iterate over the raw logs and unpacked data for RoyaltyPaid events raised by the RoyaltyHook contract.
+type RoyaltyHookRoyaltyPaidIterator struct {
+	Event *RoyaltyHookRoyaltyPaid // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RoyaltyHookRoyaltyPaidIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RoyaltyHookRoyaltyPaid)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RoyaltyHookRoyaltyPaid)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RoyaltyHookRoyaltyPaidIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RoyaltyHookRoyaltyPaidIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RoyaltyHookRoyaltyPaid represents a RoyaltyPaid event raised by the RoyaltyHook contract.
+type RoyaltyHookRoyaltyPaid struct {
+	JobId     *big.Int
+	Token     common.Address
+	Recipient common.Address
+	Amount    *big.Int
+	Raw       types.Log // Blockchain specific contextual infos
+}
+
+// FilterRoyaltyPaid is a free log retrieval operation binding the contract event 0xf3f83c9d88dc83497cc705129934b4aa146d32ecd677e6ed32c57009a077067e.
+//
+// Solidity: event RoyaltyPaid(uint256 indexed jobId, address indexed token, address indexed recipient, uint256 amount)
+func (_RoyaltyHook *RoyaltyHookFilterer) FilterRoyaltyPaid(opts *bind.FilterOpts, jobId []*big.Int, token []common.Address, recipient []common.Address) (*RoyaltyHookRoyaltyPaidIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _RoyaltyHook.contract.FilterLogs(opts, "RoyaltyPaid", jobIdRule, tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RoyaltyHookRoyaltyPaidIterator{contract: _RoyaltyHook.contract, event: "RoyaltyPaid", logs: logs, sub: sub}, nil
+}
+
+// WatchRoyaltyPaid is a free log subscription operation binding the contract event 0xf3f83c9d88dc83497cc705129934b4aa146d32ecd677e6ed32c57009a077067e.
+//
+// Solidity: event RoyaltyPaid(uint256 indexed jobId, address indexed token, address indexed recipient, uint256 amount)
+func (_RoyaltyHook *RoyaltyHookFilterer) WatchRoyaltyPaid(opts *bind.WatchOpts, sink chan<- *RoyaltyHookRoyaltyPaid, jobId []*big.Int, token []common.Address, recipient []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var tokenRule []interface{}
+	for _, tokenItem := range token {
+		tokenRule = append(tokenRule, tokenItem)
+	}
+	var recipientRule []interface{}
+	for _, recipientItem := range recipient {
+		recipientRule = append(recipientRule, recipientItem)
+	}
+
+	logs, sub, err := _RoyaltyHook.contract.WatchLogs(opts, "RoyaltyPaid", jobIdRule, tokenRule, recipientRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RoyaltyHookRoyaltyPaid)
+				if err := _RoyaltyHook.contract.UnpackLog(event, "RoyaltyPaid", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRoyaltyPaid is a log parse operation binding the contract event 0xf3f83c9d88dc83497cc705129934b4aa146d32ecd677e6ed32c57009a077067e.
+//
+// Solidity: event RoyaltyPaid(uint256 indexed jobId, address indexed token, address indexed recipient, uint256 amount)
+func (_RoyaltyHook *RoyaltyHookFilterer) ParseRoyaltyPaid(log types.Log) (*RoyaltyHookRoyaltyPaid, error) {
+	event := new(RoyaltyHookRoyaltyPaid)
+	if err := _RoyaltyHook.contract.UnpackLog(event, "RoyaltyPaid", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/acp_subscription_hook.go
+++ b/services/indexer-go/internal/abi/acp_subscription_hook.go
@@ -1,0 +1,686 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package abi
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// SubscriptionHookMetaData contains all meta data concerning the SubscriptionHook contract.
+var SubscriptionHookMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"hookName\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onAccept\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"context\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onApprove\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"context\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onCancel\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"onReject\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"onSubmit\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"subscriptions\",\"inputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"nextRenewalAt\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"active\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"SubscriptionCancelled\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"SubscriptionRenewed\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"indexed\":true,\"internalType\":\"uint256\"},{\"name\":\"subscriber\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"provider\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"nextRenewalAt\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"InvalidDuration\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"SafeERC20FailedOperation\",\"inputs\":[{\"name\":\"token\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"SubscriptionNotActive\",\"inputs\":[{\"name\":\"jobId\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZeroAmount\",\"inputs\":[]}]",
+}
+
+// SubscriptionHookABI is the input ABI used to generate the binding from.
+// Deprecated: Use SubscriptionHookMetaData.ABI instead.
+var SubscriptionHookABI = SubscriptionHookMetaData.ABI
+
+// SubscriptionHook is an auto generated Go binding around an Ethereum contract.
+type SubscriptionHook struct {
+	SubscriptionHookCaller     // Read-only binding to the contract
+	SubscriptionHookTransactor // Write-only binding to the contract
+	SubscriptionHookFilterer   // Log filterer for contract events
+}
+
+// SubscriptionHookCaller is an auto generated read-only Go binding around an Ethereum contract.
+type SubscriptionHookCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SubscriptionHookTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type SubscriptionHookTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SubscriptionHookFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type SubscriptionHookFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// SubscriptionHookSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type SubscriptionHookSession struct {
+	Contract     *SubscriptionHook // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// SubscriptionHookCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type SubscriptionHookCallerSession struct {
+	Contract *SubscriptionHookCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// SubscriptionHookTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type SubscriptionHookTransactorSession struct {
+	Contract     *SubscriptionHookTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// SubscriptionHookRaw is an auto generated low-level Go binding around an Ethereum contract.
+type SubscriptionHookRaw struct {
+	Contract *SubscriptionHook // Generic contract binding to access the raw methods on
+}
+
+// SubscriptionHookCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type SubscriptionHookCallerRaw struct {
+	Contract *SubscriptionHookCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// SubscriptionHookTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type SubscriptionHookTransactorRaw struct {
+	Contract *SubscriptionHookTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewSubscriptionHook creates a new instance of SubscriptionHook, bound to a specific deployed contract.
+func NewSubscriptionHook(address common.Address, backend bind.ContractBackend) (*SubscriptionHook, error) {
+	contract, err := bindSubscriptionHook(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &SubscriptionHook{SubscriptionHookCaller: SubscriptionHookCaller{contract: contract}, SubscriptionHookTransactor: SubscriptionHookTransactor{contract: contract}, SubscriptionHookFilterer: SubscriptionHookFilterer{contract: contract}}, nil
+}
+
+// NewSubscriptionHookCaller creates a new read-only instance of SubscriptionHook, bound to a specific deployed contract.
+func NewSubscriptionHookCaller(address common.Address, caller bind.ContractCaller) (*SubscriptionHookCaller, error) {
+	contract, err := bindSubscriptionHook(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SubscriptionHookCaller{contract: contract}, nil
+}
+
+// NewSubscriptionHookTransactor creates a new write-only instance of SubscriptionHook, bound to a specific deployed contract.
+func NewSubscriptionHookTransactor(address common.Address, transactor bind.ContractTransactor) (*SubscriptionHookTransactor, error) {
+	contract, err := bindSubscriptionHook(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &SubscriptionHookTransactor{contract: contract}, nil
+}
+
+// NewSubscriptionHookFilterer creates a new log filterer instance of SubscriptionHook, bound to a specific deployed contract.
+func NewSubscriptionHookFilterer(address common.Address, filterer bind.ContractFilterer) (*SubscriptionHookFilterer, error) {
+	contract, err := bindSubscriptionHook(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &SubscriptionHookFilterer{contract: contract}, nil
+}
+
+// bindSubscriptionHook binds a generic wrapper to an already deployed contract.
+func bindSubscriptionHook(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := SubscriptionHookMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SubscriptionHook *SubscriptionHookRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SubscriptionHook.Contract.SubscriptionHookCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SubscriptionHook *SubscriptionHookRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.SubscriptionHookTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SubscriptionHook *SubscriptionHookRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.SubscriptionHookTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_SubscriptionHook *SubscriptionHookCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _SubscriptionHook.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_SubscriptionHook *SubscriptionHookTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_SubscriptionHook *SubscriptionHookTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.contract.Transact(opts, method, params...)
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_SubscriptionHook *SubscriptionHookCaller) HookName(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _SubscriptionHook.contract.Call(opts, &out, "hookName")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_SubscriptionHook *SubscriptionHookSession) HookName() (string, error) {
+	return _SubscriptionHook.Contract.HookName(&_SubscriptionHook.CallOpts)
+}
+
+// HookName is a free data retrieval call binding the contract method 0x144a07c0.
+//
+// Solidity: function hookName() pure returns(string)
+func (_SubscriptionHook *SubscriptionHookCallerSession) HookName() (string, error) {
+	return _SubscriptionHook.Contract.HookName(&_SubscriptionHook.CallOpts)
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_SubscriptionHook *SubscriptionHookCaller) OnReject(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _SubscriptionHook.contract.Call(opts, &out, "onReject", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_SubscriptionHook *SubscriptionHookSession) OnReject(arg0 *big.Int, arg1 []byte) error {
+	return _SubscriptionHook.Contract.OnReject(&_SubscriptionHook.CallOpts, arg0, arg1)
+}
+
+// OnReject is a free data retrieval call binding the contract method 0x87e477dd.
+//
+// Solidity: function onReject(uint256 , bytes ) pure returns()
+func (_SubscriptionHook *SubscriptionHookCallerSession) OnReject(arg0 *big.Int, arg1 []byte) error {
+	return _SubscriptionHook.Contract.OnReject(&_SubscriptionHook.CallOpts, arg0, arg1)
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_SubscriptionHook *SubscriptionHookCaller) OnSubmit(opts *bind.CallOpts, arg0 *big.Int, arg1 []byte) error {
+	var out []interface{}
+	err := _SubscriptionHook.contract.Call(opts, &out, "onSubmit", arg0, arg1)
+
+	if err != nil {
+		return err
+	}
+
+	return err
+
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_SubscriptionHook *SubscriptionHookSession) OnSubmit(arg0 *big.Int, arg1 []byte) error {
+	return _SubscriptionHook.Contract.OnSubmit(&_SubscriptionHook.CallOpts, arg0, arg1)
+}
+
+// OnSubmit is a free data retrieval call binding the contract method 0x25f0968e.
+//
+// Solidity: function onSubmit(uint256 , bytes ) pure returns()
+func (_SubscriptionHook *SubscriptionHookCallerSession) OnSubmit(arg0 *big.Int, arg1 []byte) error {
+	return _SubscriptionHook.Contract.OnSubmit(&_SubscriptionHook.CallOpts, arg0, arg1)
+}
+
+// Subscriptions is a free data retrieval call binding the contract method 0x2d5bbf60.
+//
+// Solidity: function subscriptions(uint256 ) view returns(uint64 nextRenewalAt, bool active)
+func (_SubscriptionHook *SubscriptionHookCaller) Subscriptions(opts *bind.CallOpts, arg0 *big.Int) (struct {
+	NextRenewalAt uint64
+	Active        bool
+}, error) {
+	var out []interface{}
+	err := _SubscriptionHook.contract.Call(opts, &out, "subscriptions", arg0)
+
+	outstruct := new(struct {
+		NextRenewalAt uint64
+		Active        bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.NextRenewalAt = *abi.ConvertType(out[0], new(uint64)).(*uint64)
+	outstruct.Active = *abi.ConvertType(out[1], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// Subscriptions is a free data retrieval call binding the contract method 0x2d5bbf60.
+//
+// Solidity: function subscriptions(uint256 ) view returns(uint64 nextRenewalAt, bool active)
+func (_SubscriptionHook *SubscriptionHookSession) Subscriptions(arg0 *big.Int) (struct {
+	NextRenewalAt uint64
+	Active        bool
+}, error) {
+	return _SubscriptionHook.Contract.Subscriptions(&_SubscriptionHook.CallOpts, arg0)
+}
+
+// Subscriptions is a free data retrieval call binding the contract method 0x2d5bbf60.
+//
+// Solidity: function subscriptions(uint256 ) view returns(uint64 nextRenewalAt, bool active)
+func (_SubscriptionHook *SubscriptionHookCallerSession) Subscriptions(arg0 *big.Int) (struct {
+	NextRenewalAt uint64
+	Active        bool
+}, error) {
+	return _SubscriptionHook.Contract.Subscriptions(&_SubscriptionHook.CallOpts, arg0)
+}
+
+// OnAccept is a paid mutator transaction binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 jobId, bytes context) returns()
+func (_SubscriptionHook *SubscriptionHookTransactor) OnAccept(opts *bind.TransactOpts, jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _SubscriptionHook.contract.Transact(opts, "onAccept", jobId, context)
+}
+
+// OnAccept is a paid mutator transaction binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 jobId, bytes context) returns()
+func (_SubscriptionHook *SubscriptionHookSession) OnAccept(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.OnAccept(&_SubscriptionHook.TransactOpts, jobId, context)
+}
+
+// OnAccept is a paid mutator transaction binding the contract method 0xabe7b240.
+//
+// Solidity: function onAccept(uint256 jobId, bytes context) returns()
+func (_SubscriptionHook *SubscriptionHookTransactorSession) OnAccept(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.OnAccept(&_SubscriptionHook.TransactOpts, jobId, context)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes context) returns()
+func (_SubscriptionHook *SubscriptionHookTransactor) OnApprove(opts *bind.TransactOpts, jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _SubscriptionHook.contract.Transact(opts, "onApprove", jobId, context)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes context) returns()
+func (_SubscriptionHook *SubscriptionHookSession) OnApprove(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.OnApprove(&_SubscriptionHook.TransactOpts, jobId, context)
+}
+
+// OnApprove is a paid mutator transaction binding the contract method 0x0657118e.
+//
+// Solidity: function onApprove(uint256 jobId, bytes context) returns()
+func (_SubscriptionHook *SubscriptionHookTransactorSession) OnApprove(jobId *big.Int, context []byte) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.OnApprove(&_SubscriptionHook.TransactOpts, jobId, context)
+}
+
+// OnCancel is a paid mutator transaction binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 jobId, bytes ) returns()
+func (_SubscriptionHook *SubscriptionHookTransactor) OnCancel(opts *bind.TransactOpts, jobId *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _SubscriptionHook.contract.Transact(opts, "onCancel", jobId, arg1)
+}
+
+// OnCancel is a paid mutator transaction binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 jobId, bytes ) returns()
+func (_SubscriptionHook *SubscriptionHookSession) OnCancel(jobId *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.OnCancel(&_SubscriptionHook.TransactOpts, jobId, arg1)
+}
+
+// OnCancel is a paid mutator transaction binding the contract method 0x5b6d048f.
+//
+// Solidity: function onCancel(uint256 jobId, bytes ) returns()
+func (_SubscriptionHook *SubscriptionHookTransactorSession) OnCancel(jobId *big.Int, arg1 []byte) (*types.Transaction, error) {
+	return _SubscriptionHook.Contract.OnCancel(&_SubscriptionHook.TransactOpts, jobId, arg1)
+}
+
+// SubscriptionHookSubscriptionCancelledIterator is returned from FilterSubscriptionCancelled and is used to iterate over the raw logs and unpacked data for SubscriptionCancelled events raised by the SubscriptionHook contract.
+type SubscriptionHookSubscriptionCancelledIterator struct {
+	Event *SubscriptionHookSubscriptionCancelled // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SubscriptionHookSubscriptionCancelledIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SubscriptionHookSubscriptionCancelled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SubscriptionHookSubscriptionCancelled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SubscriptionHookSubscriptionCancelledIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SubscriptionHookSubscriptionCancelledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SubscriptionHookSubscriptionCancelled represents a SubscriptionCancelled event raised by the SubscriptionHook contract.
+type SubscriptionHookSubscriptionCancelled struct {
+	JobId *big.Int
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterSubscriptionCancelled is a free log retrieval operation binding the contract event 0xbd2bcea75d16a85f005cd83447e0de57341bf926fe7419e6d553663e91ab4da7.
+//
+// Solidity: event SubscriptionCancelled(uint256 indexed jobId)
+func (_SubscriptionHook *SubscriptionHookFilterer) FilterSubscriptionCancelled(opts *bind.FilterOpts, jobId []*big.Int) (*SubscriptionHookSubscriptionCancelledIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+
+	logs, sub, err := _SubscriptionHook.contract.FilterLogs(opts, "SubscriptionCancelled", jobIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SubscriptionHookSubscriptionCancelledIterator{contract: _SubscriptionHook.contract, event: "SubscriptionCancelled", logs: logs, sub: sub}, nil
+}
+
+// WatchSubscriptionCancelled is a free log subscription operation binding the contract event 0xbd2bcea75d16a85f005cd83447e0de57341bf926fe7419e6d553663e91ab4da7.
+//
+// Solidity: event SubscriptionCancelled(uint256 indexed jobId)
+func (_SubscriptionHook *SubscriptionHookFilterer) WatchSubscriptionCancelled(opts *bind.WatchOpts, sink chan<- *SubscriptionHookSubscriptionCancelled, jobId []*big.Int) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+
+	logs, sub, err := _SubscriptionHook.contract.WatchLogs(opts, "SubscriptionCancelled", jobIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SubscriptionHookSubscriptionCancelled)
+				if err := _SubscriptionHook.contract.UnpackLog(event, "SubscriptionCancelled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSubscriptionCancelled is a log parse operation binding the contract event 0xbd2bcea75d16a85f005cd83447e0de57341bf926fe7419e6d553663e91ab4da7.
+//
+// Solidity: event SubscriptionCancelled(uint256 indexed jobId)
+func (_SubscriptionHook *SubscriptionHookFilterer) ParseSubscriptionCancelled(log types.Log) (*SubscriptionHookSubscriptionCancelled, error) {
+	event := new(SubscriptionHookSubscriptionCancelled)
+	if err := _SubscriptionHook.contract.UnpackLog(event, "SubscriptionCancelled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// SubscriptionHookSubscriptionRenewedIterator is returned from FilterSubscriptionRenewed and is used to iterate over the raw logs and unpacked data for SubscriptionRenewed events raised by the SubscriptionHook contract.
+type SubscriptionHookSubscriptionRenewedIterator struct {
+	Event *SubscriptionHookSubscriptionRenewed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *SubscriptionHookSubscriptionRenewedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(SubscriptionHookSubscriptionRenewed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(SubscriptionHookSubscriptionRenewed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *SubscriptionHookSubscriptionRenewedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *SubscriptionHookSubscriptionRenewedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// SubscriptionHookSubscriptionRenewed represents a SubscriptionRenewed event raised by the SubscriptionHook contract.
+type SubscriptionHookSubscriptionRenewed struct {
+	JobId         *big.Int
+	Subscriber    common.Address
+	Provider      common.Address
+	Amount        *big.Int
+	NextRenewalAt uint64
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterSubscriptionRenewed is a free log retrieval operation binding the contract event 0x4a40031fc0683564de624c4cee39202baa4d6ebe5d29b6c82b11e5b6cf185ef3.
+//
+// Solidity: event SubscriptionRenewed(uint256 indexed jobId, address indexed subscriber, address indexed provider, uint256 amount, uint64 nextRenewalAt)
+func (_SubscriptionHook *SubscriptionHookFilterer) FilterSubscriptionRenewed(opts *bind.FilterOpts, jobId []*big.Int, subscriber []common.Address, provider []common.Address) (*SubscriptionHookSubscriptionRenewedIterator, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var subscriberRule []interface{}
+	for _, subscriberItem := range subscriber {
+		subscriberRule = append(subscriberRule, subscriberItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _SubscriptionHook.contract.FilterLogs(opts, "SubscriptionRenewed", jobIdRule, subscriberRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &SubscriptionHookSubscriptionRenewedIterator{contract: _SubscriptionHook.contract, event: "SubscriptionRenewed", logs: logs, sub: sub}, nil
+}
+
+// WatchSubscriptionRenewed is a free log subscription operation binding the contract event 0x4a40031fc0683564de624c4cee39202baa4d6ebe5d29b6c82b11e5b6cf185ef3.
+//
+// Solidity: event SubscriptionRenewed(uint256 indexed jobId, address indexed subscriber, address indexed provider, uint256 amount, uint64 nextRenewalAt)
+func (_SubscriptionHook *SubscriptionHookFilterer) WatchSubscriptionRenewed(opts *bind.WatchOpts, sink chan<- *SubscriptionHookSubscriptionRenewed, jobId []*big.Int, subscriber []common.Address, provider []common.Address) (event.Subscription, error) {
+
+	var jobIdRule []interface{}
+	for _, jobIdItem := range jobId {
+		jobIdRule = append(jobIdRule, jobIdItem)
+	}
+	var subscriberRule []interface{}
+	for _, subscriberItem := range subscriber {
+		subscriberRule = append(subscriberRule, subscriberItem)
+	}
+	var providerRule []interface{}
+	for _, providerItem := range provider {
+		providerRule = append(providerRule, providerItem)
+	}
+
+	logs, sub, err := _SubscriptionHook.contract.WatchLogs(opts, "SubscriptionRenewed", jobIdRule, subscriberRule, providerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(SubscriptionHookSubscriptionRenewed)
+				if err := _SubscriptionHook.contract.UnpackLog(event, "SubscriptionRenewed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSubscriptionRenewed is a log parse operation binding the contract event 0x4a40031fc0683564de624c4cee39202baa4d6ebe5d29b6c82b11e5b6cf185ef3.
+//
+// Solidity: event SubscriptionRenewed(uint256 indexed jobId, address indexed subscriber, address indexed provider, uint256 amount, uint64 nextRenewalAt)
+func (_SubscriptionHook *SubscriptionHookFilterer) ParseSubscriptionRenewed(log types.Log) (*SubscriptionHookSubscriptionRenewed, error) {
+	event := new(SubscriptionHookSubscriptionRenewed)
+	if err := _SubscriptionHook.contract.UnpackLog(event, "SubscriptionRenewed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/services/indexer-go/internal/abi/agent_token.go
+++ b/services/indexer-go/internal/abi/agent_token.go
@@ -31,7 +31,7 @@ var (
 
 // AgentTokenMetaData contains all meta data concerning the AgentToken contract.
 var AgentTokenMetaData = &bind.MetaData{
-	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BPS_DENOMINATOR\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"TOTAL_SUPPLY\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"TRADE_TAX_BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"allowance\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"approve\",\"inputs\":[{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"balanceOf\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"bondingCurve\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"creator\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"decimals\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"feeRouter\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"name_\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"symbol_\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"creator_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"feeRouter_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"bondingCurve_\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"name\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"symbol\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalSupply\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transfer\",\"inputs\":[{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFrom\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"AgentTokenInitialized\",\"inputs\":[{\"name\":\"creator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"feeRouter\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"bondingCurve\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"symbol\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Approval\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"spender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TaxCollected\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"taxAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Transfer\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"ERC20InsufficientAllowance\",\"inputs\":[{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"allowance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"needed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC20InsufficientBalance\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"balance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"needed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidApprover\",\"inputs\":[{\"name\":\"approver\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidReceiver\",\"inputs\":[{\"name\":\"receiver\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidSender\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidSpender\",\"inputs\":[{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"EmptyMetadata\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]}]",
+	ABI: "[{\"type\":\"constructor\",\"inputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"BPS_DENOMINATOR\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"TOTAL_SUPPLY\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"TRADE_TAX_BPS\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint16\",\"internalType\":\"uint16\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"allowance\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"approve\",\"inputs\":[{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"balanceOf\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"bondingCurve\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"creator\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"decimals\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint8\",\"internalType\":\"uint8\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"feeRouter\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"initialize\",\"inputs\":[{\"name\":\"name_\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"symbol_\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"creator_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"feeRouter_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"bondingCurve_\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"graduator_\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"name\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"symbol\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"string\",\"internalType\":\"string\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"taxExempt\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"exempt\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"totalSupply\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transfer\",\"inputs\":[{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferFrom\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"AgentTokenInitialized\",\"inputs\":[{\"name\":\"creator\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"feeRouter\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"bondingCurve\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"name\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"},{\"name\":\"symbol\",\"type\":\"string\",\"indexed\":false,\"internalType\":\"string\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Approval\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"spender\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint64\",\"indexed\":false,\"internalType\":\"uint64\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TaxCollected\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"taxAmount\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"TaxExemptSet\",\"inputs\":[{\"name\":\"addr\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"exempt\",\"type\":\"bool\",\"indexed\":false,\"internalType\":\"bool\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Transfer\",\"inputs\":[{\"name\":\"from\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"ERC20InsufficientAllowance\",\"inputs\":[{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"allowance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"needed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC20InsufficientBalance\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"balance\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"needed\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidApprover\",\"inputs\":[{\"name\":\"approver\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidReceiver\",\"inputs\":[{\"name\":\"receiver\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidSender\",\"inputs\":[{\"name\":\"sender\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ERC20InvalidSpender\",\"inputs\":[{\"name\":\"spender\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"EmptyMetadata\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"InvalidInitialization\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"NotInitializing\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"OwnableInvalidOwner\",\"inputs\":[{\"name\":\"owner\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"OwnableUnauthorizedAccount\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"internalType\":\"address\"}]},{\"type\":\"error\",\"name\":\"ZeroAddress\",\"inputs\":[]}]",
 }
 
 // AgentTokenABI is the input ABI used to generate the binding from.
@@ -552,6 +552,37 @@ func (_AgentToken *AgentTokenCallerSession) Symbol() (string, error) {
 	return _AgentToken.Contract.Symbol(&_AgentToken.CallOpts)
 }
 
+// TaxExempt is a free data retrieval call binding the contract method 0xd1ecfc68.
+//
+// Solidity: function taxExempt(address account) view returns(bool exempt)
+func (_AgentToken *AgentTokenCaller) TaxExempt(opts *bind.CallOpts, account common.Address) (bool, error) {
+	var out []interface{}
+	err := _AgentToken.contract.Call(opts, &out, "taxExempt", account)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// TaxExempt is a free data retrieval call binding the contract method 0xd1ecfc68.
+//
+// Solidity: function taxExempt(address account) view returns(bool exempt)
+func (_AgentToken *AgentTokenSession) TaxExempt(account common.Address) (bool, error) {
+	return _AgentToken.Contract.TaxExempt(&_AgentToken.CallOpts, account)
+}
+
+// TaxExempt is a free data retrieval call binding the contract method 0xd1ecfc68.
+//
+// Solidity: function taxExempt(address account) view returns(bool exempt)
+func (_AgentToken *AgentTokenCallerSession) TaxExempt(account common.Address) (bool, error) {
+	return _AgentToken.Contract.TaxExempt(&_AgentToken.CallOpts, account)
+}
+
 // TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
 //
 // Solidity: function totalSupply() view returns(uint256)
@@ -604,25 +635,25 @@ func (_AgentToken *AgentTokenTransactorSession) Approve(spender common.Address, 
 	return _AgentToken.Contract.Approve(&_AgentToken.TransactOpts, spender, value)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xdb0ed6a0.
+// Initialize is a paid mutator transaction binding the contract method 0xe56f2fe4.
 //
-// Solidity: function initialize(string name_, string symbol_, address creator_, address feeRouter_, address bondingCurve_) returns()
-func (_AgentToken *AgentTokenTransactor) Initialize(opts *bind.TransactOpts, name_ string, symbol_ string, creator_ common.Address, feeRouter_ common.Address, bondingCurve_ common.Address) (*types.Transaction, error) {
-	return _AgentToken.contract.Transact(opts, "initialize", name_, symbol_, creator_, feeRouter_, bondingCurve_)
+// Solidity: function initialize(string name_, string symbol_, address creator_, address feeRouter_, address bondingCurve_, address graduator_) returns()
+func (_AgentToken *AgentTokenTransactor) Initialize(opts *bind.TransactOpts, name_ string, symbol_ string, creator_ common.Address, feeRouter_ common.Address, bondingCurve_ common.Address, graduator_ common.Address) (*types.Transaction, error) {
+	return _AgentToken.contract.Transact(opts, "initialize", name_, symbol_, creator_, feeRouter_, bondingCurve_, graduator_)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xdb0ed6a0.
+// Initialize is a paid mutator transaction binding the contract method 0xe56f2fe4.
 //
-// Solidity: function initialize(string name_, string symbol_, address creator_, address feeRouter_, address bondingCurve_) returns()
-func (_AgentToken *AgentTokenSession) Initialize(name_ string, symbol_ string, creator_ common.Address, feeRouter_ common.Address, bondingCurve_ common.Address) (*types.Transaction, error) {
-	return _AgentToken.Contract.Initialize(&_AgentToken.TransactOpts, name_, symbol_, creator_, feeRouter_, bondingCurve_)
+// Solidity: function initialize(string name_, string symbol_, address creator_, address feeRouter_, address bondingCurve_, address graduator_) returns()
+func (_AgentToken *AgentTokenSession) Initialize(name_ string, symbol_ string, creator_ common.Address, feeRouter_ common.Address, bondingCurve_ common.Address, graduator_ common.Address) (*types.Transaction, error) {
+	return _AgentToken.Contract.Initialize(&_AgentToken.TransactOpts, name_, symbol_, creator_, feeRouter_, bondingCurve_, graduator_)
 }
 
-// Initialize is a paid mutator transaction binding the contract method 0xdb0ed6a0.
+// Initialize is a paid mutator transaction binding the contract method 0xe56f2fe4.
 //
-// Solidity: function initialize(string name_, string symbol_, address creator_, address feeRouter_, address bondingCurve_) returns()
-func (_AgentToken *AgentTokenTransactorSession) Initialize(name_ string, symbol_ string, creator_ common.Address, feeRouter_ common.Address, bondingCurve_ common.Address) (*types.Transaction, error) {
-	return _AgentToken.Contract.Initialize(&_AgentToken.TransactOpts, name_, symbol_, creator_, feeRouter_, bondingCurve_)
+// Solidity: function initialize(string name_, string symbol_, address creator_, address feeRouter_, address bondingCurve_, address graduator_) returns()
+func (_AgentToken *AgentTokenTransactorSession) Initialize(name_ string, symbol_ string, creator_ common.Address, feeRouter_ common.Address, bondingCurve_ common.Address, graduator_ common.Address) (*types.Transaction, error) {
+	return _AgentToken.Contract.Initialize(&_AgentToken.TransactOpts, name_, symbol_, creator_, feeRouter_, bondingCurve_, graduator_)
 }
 
 // RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
@@ -1462,6 +1493,151 @@ func (_AgentToken *AgentTokenFilterer) WatchTaxCollected(opts *bind.WatchOpts, s
 func (_AgentToken *AgentTokenFilterer) ParseTaxCollected(log types.Log) (*AgentTokenTaxCollected, error) {
 	event := new(AgentTokenTaxCollected)
 	if err := _AgentToken.contract.UnpackLog(event, "TaxCollected", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// AgentTokenTaxExemptSetIterator is returned from FilterTaxExemptSet and is used to iterate over the raw logs and unpacked data for TaxExemptSet events raised by the AgentToken contract.
+type AgentTokenTaxExemptSetIterator struct {
+	Event *AgentTokenTaxExemptSet // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *AgentTokenTaxExemptSetIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(AgentTokenTaxExemptSet)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(AgentTokenTaxExemptSet)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *AgentTokenTaxExemptSetIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *AgentTokenTaxExemptSetIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// AgentTokenTaxExemptSet represents a TaxExemptSet event raised by the AgentToken contract.
+type AgentTokenTaxExemptSet struct {
+	Addr   common.Address
+	Exempt bool
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterTaxExemptSet is a free log retrieval operation binding the contract event 0x8af52ca6865dd040a1247f4d247e92db436b658abb69ed82e9efa8a7de0602e9.
+//
+// Solidity: event TaxExemptSet(address indexed addr, bool exempt)
+func (_AgentToken *AgentTokenFilterer) FilterTaxExemptSet(opts *bind.FilterOpts, addr []common.Address) (*AgentTokenTaxExemptSetIterator, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _AgentToken.contract.FilterLogs(opts, "TaxExemptSet", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return &AgentTokenTaxExemptSetIterator{contract: _AgentToken.contract, event: "TaxExemptSet", logs: logs, sub: sub}, nil
+}
+
+// WatchTaxExemptSet is a free log subscription operation binding the contract event 0x8af52ca6865dd040a1247f4d247e92db436b658abb69ed82e9efa8a7de0602e9.
+//
+// Solidity: event TaxExemptSet(address indexed addr, bool exempt)
+func (_AgentToken *AgentTokenFilterer) WatchTaxExemptSet(opts *bind.WatchOpts, sink chan<- *AgentTokenTaxExemptSet, addr []common.Address) (event.Subscription, error) {
+
+	var addrRule []interface{}
+	for _, addrItem := range addr {
+		addrRule = append(addrRule, addrItem)
+	}
+
+	logs, sub, err := _AgentToken.contract.WatchLogs(opts, "TaxExemptSet", addrRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(AgentTokenTaxExemptSet)
+				if err := _AgentToken.contract.UnpackLog(event, "TaxExemptSet", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTaxExemptSet is a log parse operation binding the contract event 0x8af52ca6865dd040a1247f4d247e92db436b658abb69ed82e9efa8a7de0602e9.
+//
+// Solidity: event TaxExemptSet(address indexed addr, bool exempt)
+func (_AgentToken *AgentTokenFilterer) ParseTaxExemptSet(log types.Log) (*AgentTokenTaxExemptSet, error) {
+	event := new(AgentTokenTaxExemptSet)
+	if err := _AgentToken.contract.UnpackLog(event, "TaxExemptSet", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/services/indexer-go/internal/handlers/acp.go
+++ b/services/indexer-go/internal/handlers/acp.go
@@ -1,0 +1,475 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	contractabi "github.com/0xDevNinja/titular/services/indexer-go/internal/abi"
+)
+
+// All ACP handlers follow the same three-step pattern:
+//  1. Idempotency guard via IsLogProcessed.
+//  2. Parse the raw log using the generated abigen filterer (no RPC needed).
+//  3. Persist via the Store interface.
+
+// HandleACPAgentRegistered decodes an AgentRegistry.AgentRegistered log and
+// persists an ACP agent identity record. Idempotent on (txHash, logIndex).
+func HandleACPAgentRegistered(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentRegistered: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewAgentRegistryFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentRegistered: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseAgentRegistered(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentRegistered: parse: %w", err)
+	}
+
+	rec := ACPAgentRegisteredRecord{
+		AgentID:      ev.AgentId,
+		Controller:   ev.Controller,
+		MetadataURI:  ev.MetadataURI,
+		Capabilities: ev.Capabilities,
+		BlockNum:     log.BlockNumber,
+		TxHash:       log.TxHash,
+		LogIndex:     log.Index,
+	}
+
+	if err := store.UpsertACPAgent(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentRegistered: upsert: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPScorePosted decodes an AgentRegistry.ScorePosted log and persists
+// the reputation delta. Idempotent on (txHash, logIndex).
+func HandleACPScorePosted(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPScorePosted: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewAgentRegistryFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPScorePosted: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseScorePosted(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPScorePosted: parse: %w", err)
+	}
+
+	rec := ACPScorePostedRecord{
+		AgentID:  ev.AgentId,
+		Scorer:   ev.Scorer,
+		Delta:    ev.Delta,
+		NewTotal: ev.NewTotal,
+		Nonce:    ev.Nonce,
+		BlockNum: log.BlockNumber,
+		TxHash:   log.TxHash,
+		LogIndex: log.Index,
+	}
+
+	if err := store.InsertACPScore(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPScorePosted: insert: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPControllerTransferAccepted decodes an
+// AgentRegistry.ControllerTransferAccepted log and persists the ownership
+// change. Idempotent on (txHash, logIndex).
+func HandleACPControllerTransferAccepted(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPControllerTransferAccepted: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewAgentRegistryFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPControllerTransferAccepted: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseControllerTransferAccepted(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPControllerTransferAccepted: parse: %w", err)
+	}
+
+	rec := ACPControllerTransferRecord{
+		AgentID:       ev.AgentId,
+		OldController: ev.OldController,
+		NewController: ev.NewController,
+		BlockNum:      log.BlockNumber,
+		TxHash:        log.TxHash,
+		LogIndex:      log.Index,
+	}
+
+	if err := store.UpdateACPController(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPControllerTransferAccepted: update: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPJobInitialised decodes a Job.JobInitialised log and persists the
+// initial job record. Idempotent on (txHash, logIndex).
+func HandleACPJobInitialised(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobInitialised: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewJobFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobInitialised: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseJobInitialised(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobInitialised: parse: %w", err)
+	}
+
+	rec := ACPJobRecord{
+		JobID:     ev.JobId,
+		Principal: ev.Principal,
+		AgentID:   ev.AgentId,
+		JobType:   ev.JobType,
+		Budget:    ev.Budget,
+		Token:     ev.Token,
+		Deadline:  ev.Deadline,
+		BlockNum:  log.BlockNumber,
+		TxHash:    log.TxHash,
+		LogIndex:  log.Index,
+	}
+
+	if err := store.UpsertACPJob(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPJobInitialised: upsert: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPAgentAccepted decodes a Job.AgentAccepted log and records the agent
+// assignment. Idempotent on (txHash, logIndex).
+func HandleACPAgentAccepted(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentAccepted: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewJobFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentAccepted: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseAgentAccepted(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentAccepted: parse: %w", err)
+	}
+
+	rec := ACPJobAcceptedRecord{
+		JobID:    ev.JobId,
+		Agent:    ev.Agent,
+		AgentID:  ev.AgentId,
+		BlockNum: log.BlockNumber,
+		TxHash:   log.TxHash,
+		LogIndex: log.Index,
+	}
+
+	if err := store.UpdateACPJobAccepted(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentAccepted: update: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPResultSubmitted decodes a Job.ResultSubmitted log and records the
+// result URI. Idempotent on (txHash, logIndex).
+func HandleACPResultSubmitted(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPResultSubmitted: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewJobFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPResultSubmitted: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseResultSubmitted(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPResultSubmitted: parse: %w", err)
+	}
+
+	rec := ACPResultSubmittedRecord{
+		JobID:     ev.JobId,
+		Agent:     ev.Agent,
+		ResultURI: ev.ResultURI,
+		BlockNum:  log.BlockNumber,
+		TxHash:    log.TxHash,
+		LogIndex:  log.Index,
+	}
+
+	if err := store.UpdateACPResultSubmitted(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPResultSubmitted: update: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPJobCompleted decodes a Job.JobCompleted log and marks the job
+// terminal-completed. Idempotent on (txHash, logIndex).
+func HandleACPJobCompleted(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCompleted: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewJobFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCompleted: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseJobCompleted(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCompleted: parse: %w", err)
+	}
+
+	rec := ACPJobCompletedRecord{
+		JobID:      ev.JobId,
+		ReleasedBy: ev.ReleasedBy,
+		Amount:     ev.Amount,
+		BlockNum:   log.BlockNumber,
+		TxHash:     log.TxHash,
+		LogIndex:   log.Index,
+	}
+
+	if err := store.UpdateACPJobCompleted(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCompleted: update: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPJobCancelled decodes a Job.JobCancelled log and marks the job
+// terminal-cancelled. Idempotent on (txHash, logIndex).
+func HandleACPJobCancelled(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCancelled: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewJobFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCancelled: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseJobCancelled(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCancelled: parse: %w", err)
+	}
+
+	rec := ACPJobCancelledRecord{
+		JobID:       ev.JobId,
+		CancelledBy: ev.CancelledBy,
+		Reason:      ev.Reason,
+		BlockNum:    log.BlockNumber,
+		TxHash:      log.TxHash,
+		LogIndex:    log.Index,
+	}
+
+	if err := store.UpdateACPJobCancelled(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCancelled: update: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPJobCreated decodes a JobFactory.JobCreated log and persists the
+// factory-level record (clone address, principal). Idempotent on (txHash, logIndex).
+func HandleACPJobCreated(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCreated: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewJobFactoryFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCreated: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseJobCreated(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCreated: parse: %w", err)
+	}
+
+	rec := ACPJobCreatedRecord{
+		JobID:     ev.JobId,
+		Clone:     ev.Clone,
+		Principal: ev.Principal,
+		JobType:   ev.JobType,
+		Token:     ev.Token,
+		Budget:    ev.Budget,
+		BlockNum:  log.BlockNumber,
+		TxHash:    log.TxHash,
+		LogIndex:  log.Index,
+	}
+
+	if err := store.InsertACPJobCreated(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCreated: insert: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPEscrowFunded decodes an Escrow.Funded log and persists the deposit.
+// Idempotent on (txHash, logIndex).
+func HandleACPEscrowFunded(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowFunded: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewEscrowFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowFunded: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseFunded(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowFunded: parse: %w", err)
+	}
+
+	rec := ACPEscrowFundedRecord{
+		Depositor: ev.Depositor,
+		JobID:     ev.JobId,
+		Token:     ev.Token,
+		Amount:    ev.Amount,
+		BlockNum:  log.BlockNumber,
+		TxHash:    log.TxHash,
+		LogIndex:  log.Index,
+	}
+
+	if err := store.InsertACPEscrowFunded(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowFunded: insert: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPEscrowReleased decodes an Escrow.Released log and persists the
+// per-recipient release entry. Idempotent on (txHash, logIndex).
+func HandleACPEscrowReleased(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowReleased: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewEscrowFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowReleased: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseReleased(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowReleased: parse: %w", err)
+	}
+
+	rec := ACPEscrowReleasedRecord{
+		Depositor: ev.Depositor,
+		JobID:     ev.JobId,
+		Token:     ev.Token,
+		To:        ev.To,
+		Amount:    ev.Amount,
+		BlockNum:  log.BlockNumber,
+		TxHash:    log.TxHash,
+		LogIndex:  log.Index,
+	}
+
+	if err := store.InsertACPEscrowReleased(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowReleased: insert: %w", err)
+	}
+
+	return nil
+}
+
+// HandleACPEscrowRefunded decodes an Escrow.Refunded log and persists the
+// refund entry. Idempotent on (txHash, logIndex).
+func HandleACPEscrowRefunded(ctx context.Context, log types.Log, store Store) error {
+	already, err := store.IsLogProcessed(ctx, log.TxHash, log.Index)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowRefunded: check processed: %w", err)
+	}
+	if already {
+		return nil
+	}
+
+	f, err := contractabi.NewEscrowFilterer(common.Address{}, nil)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowRefunded: new filterer: %w", err)
+	}
+
+	ev, err := f.ParseRefunded(log)
+	if err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowRefunded: parse: %w", err)
+	}
+
+	rec := ACPEscrowRefundedRecord{
+		Depositor: ev.Depositor,
+		JobID:     ev.JobId,
+		Token:     ev.Token,
+		Amount:    ev.Amount,
+		BlockNum:  log.BlockNumber,
+		TxHash:    log.TxHash,
+		LogIndex:  log.Index,
+	}
+
+	if err := store.InsertACPEscrowRefunded(ctx, rec); err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowRefunded: insert: %w", err)
+	}
+
+	return nil
+}

--- a/services/indexer-go/internal/handlers/acp_test.go
+++ b/services/indexer-go/internal/handlers/acp_test.go
@@ -1,0 +1,973 @@
+package handlers_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	contractabi "github.com/0xDevNinja/titular/services/indexer-go/internal/abi"
+	"github.com/0xDevNinja/titular/services/indexer-go/internal/handlers"
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// In-memory ACP store (extends the base memStore via composition)
+// ──────────────────────────────────────────────────────────────────────────────
+
+type acpMemStore struct {
+	*memStore
+	acpAgents     []handlers.ACPAgentRegisteredRecord
+	acpScores     []handlers.ACPScorePostedRecord
+	acpTransfers  []handlers.ACPControllerTransferRecord
+	acpJobs       []handlers.ACPJobRecord
+	acpAccepted   []handlers.ACPJobAcceptedRecord
+	acpResults    []handlers.ACPResultSubmittedRecord
+	acpCompleted  []handlers.ACPJobCompletedRecord
+	acpCancelled  []handlers.ACPJobCancelledRecord
+	acpJobCreated []handlers.ACPJobCreatedRecord
+	acpFunded     []handlers.ACPEscrowFundedRecord
+	acpReleased   []handlers.ACPEscrowReleasedRecord
+	acpRefunded   []handlers.ACPEscrowRefundedRecord
+}
+
+func newACPMemStore() *acpMemStore {
+	return &acpMemStore{memStore: newMemStore()}
+}
+
+func (s *acpMemStore) UpsertACPAgent(_ context.Context, rec handlers.ACPAgentRegisteredRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpAgents = append(s.acpAgents, rec)
+	return nil
+}
+
+func (s *acpMemStore) InsertACPScore(_ context.Context, rec handlers.ACPScorePostedRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpScores = append(s.acpScores, rec)
+	return nil
+}
+
+func (s *acpMemStore) UpdateACPController(_ context.Context, rec handlers.ACPControllerTransferRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpTransfers = append(s.acpTransfers, rec)
+	return nil
+}
+
+func (s *acpMemStore) UpsertACPJob(_ context.Context, rec handlers.ACPJobRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpJobs = append(s.acpJobs, rec)
+	return nil
+}
+
+func (s *acpMemStore) UpdateACPJobAccepted(_ context.Context, rec handlers.ACPJobAcceptedRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpAccepted = append(s.acpAccepted, rec)
+	return nil
+}
+
+func (s *acpMemStore) UpdateACPResultSubmitted(_ context.Context, rec handlers.ACPResultSubmittedRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpResults = append(s.acpResults, rec)
+	return nil
+}
+
+func (s *acpMemStore) UpdateACPJobCompleted(_ context.Context, rec handlers.ACPJobCompletedRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpCompleted = append(s.acpCompleted, rec)
+	return nil
+}
+
+func (s *acpMemStore) UpdateACPJobCancelled(_ context.Context, rec handlers.ACPJobCancelledRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpCancelled = append(s.acpCancelled, rec)
+	return nil
+}
+
+func (s *acpMemStore) InsertACPJobCreated(_ context.Context, rec handlers.ACPJobCreatedRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpJobCreated = append(s.acpJobCreated, rec)
+	return nil
+}
+
+func (s *acpMemStore) InsertACPEscrowFunded(_ context.Context, rec handlers.ACPEscrowFundedRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpFunded = append(s.acpFunded, rec)
+	return nil
+}
+
+func (s *acpMemStore) InsertACPEscrowReleased(_ context.Context, rec handlers.ACPEscrowReleasedRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpReleased = append(s.acpReleased, rec)
+	return nil
+}
+
+func (s *acpMemStore) InsertACPEscrowRefunded(_ context.Context, rec handlers.ACPEscrowRefundedRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
+	s.acpRefunded = append(s.acpRefunded, rec)
+	return nil
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers (ABI-level)
+// ──────────────────────────────────────────────────────────────────────────────
+
+func mustGetACPABI(t *testing.T, meta *bind.MetaData) abi.ABI {
+	t.Helper()
+	parsed, err := meta.GetAbi()
+	if err != nil {
+		t.Fatalf("GetAbi: %v", err)
+	}
+	return *parsed
+}
+
+// int256Topic converts a signed *big.Int to a log topic (two's complement, 32 bytes).
+func int256Topic(n *big.Int) common.Hash {
+	return common.BigToHash(n)
+}
+
+// uint64Topic converts a uint64 to a log topic.
+func uint64Topic(v uint64) common.Hash {
+	return common.BigToHash(new(big.Int).SetUint64(v))
+}
+
+// uint8Topic converts a uint8 to a log topic.
+func uint8Topic(v uint8) common.Hash {
+	return common.BigToHash(new(big.Int).SetUint64(uint64(v)))
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPAgentRegistered
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPAgentRegistered(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.AgentRegistryMetaData)
+	eventID := parsed.Events["AgentRegistered"].ID
+
+	agentID := big.NewInt(7)
+	controller := common.HexToAddress("0xAAAA000000000000000000000000000000000001")
+	capabilities := big.NewInt(0xFF)
+	const metadataURI = "ipfs://bafybeifoo"
+
+	data := encodeData(t, parsed, "AgentRegistered", metadataURI, capabilities)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		BlockNumber: 1000,
+		TxHash:      fixedTxHash(0x10),
+		Index:       0,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(agentID),
+			addrTopic(controller),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	// First call — should persist.
+	if err := handlers.HandleACPAgentRegistered(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpAgents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(store.acpAgents))
+	}
+	got := store.acpAgents[0]
+	if got.AgentID.Cmp(agentID) != 0 {
+		t.Errorf("AgentID: got %s, want %s", got.AgentID, agentID)
+	}
+	if got.Controller != controller {
+		t.Errorf("Controller: got %s, want %s", got.Controller, controller)
+	}
+	if got.MetadataURI != metadataURI {
+		t.Errorf("MetadataURI: got %q, want %q", got.MetadataURI, metadataURI)
+	}
+	if got.Capabilities.Cmp(capabilities) != 0 {
+		t.Errorf("Capabilities: got %s, want %s", got.Capabilities, capabilities)
+	}
+	if got.BlockNum != 1000 {
+		t.Errorf("BlockNum: got %d, want 1000", got.BlockNum)
+	}
+
+	// Second call — duplicate, must be skipped.
+	if err := handlers.HandleACPAgentRegistered(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpAgents) != 1 {
+		t.Errorf("duplicate: expected 1 agent, got %d", len(store.acpAgents))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPScorePosted
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPScorePosted(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.AgentRegistryMetaData)
+	eventID := parsed.Events["ScorePosted"].ID
+
+	agentID := big.NewInt(3)
+	scorer := common.HexToAddress("0xBBBB000000000000000000000000000000000002")
+	delta := big.NewInt(-10)
+	newTotal := big.NewInt(90)
+	nonce := big.NewInt(1)
+
+	data := encodeData(t, parsed, "ScorePosted", delta, newTotal, nonce)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		BlockNumber: 2000,
+		TxHash:      fixedTxHash(0x11),
+		Index:       1,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(agentID),
+			addrTopic(scorer),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPScorePosted(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpScores) != 1 {
+		t.Fatalf("expected 1 score, got %d", len(store.acpScores))
+	}
+	got := store.acpScores[0]
+	if got.AgentID.Cmp(agentID) != 0 {
+		t.Errorf("AgentID: got %s, want %s", got.AgentID, agentID)
+	}
+	if got.Scorer != scorer {
+		t.Errorf("Scorer: got %s, want %s", got.Scorer, scorer)
+	}
+	if got.Delta.Cmp(delta) != 0 {
+		t.Errorf("Delta: got %s, want %s", got.Delta, delta)
+	}
+	if got.NewTotal.Cmp(newTotal) != 0 {
+		t.Errorf("NewTotal: got %s, want %s", got.NewTotal, newTotal)
+	}
+	if got.Nonce.Cmp(nonce) != 0 {
+		t.Errorf("Nonce: got %s, want %s", got.Nonce, nonce)
+	}
+
+	// Duplicate is skipped.
+	if err := handlers.HandleACPScorePosted(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpScores) != 1 {
+		t.Errorf("duplicate: expected 1 score, got %d", len(store.acpScores))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPControllerTransferAccepted
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPControllerTransferAccepted(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.AgentRegistryMetaData)
+	eventID := parsed.Events["ControllerTransferAccepted"].ID
+
+	agentID := big.NewInt(5)
+	oldCtrl := common.HexToAddress("0xCCCC000000000000000000000000000000000003")
+	newCtrl := common.HexToAddress("0xDDDD000000000000000000000000000000000004")
+
+	// ControllerTransferAccepted has all three fields indexed — no non-indexed data.
+	log := types.Log{
+		Address:     common.HexToAddress("0x3333333333333333333333333333333333333333"),
+		BlockNumber: 3000,
+		TxHash:      fixedTxHash(0x12),
+		Index:       2,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(agentID),
+			addrTopic(oldCtrl),
+			addrTopic(newCtrl),
+		},
+		Data: []byte{},
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPControllerTransferAccepted(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpTransfers) != 1 {
+		t.Fatalf("expected 1 transfer, got %d", len(store.acpTransfers))
+	}
+	got := store.acpTransfers[0]
+	if got.AgentID.Cmp(agentID) != 0 {
+		t.Errorf("AgentID: got %s, want %s", got.AgentID, agentID)
+	}
+	if got.OldController != oldCtrl {
+		t.Errorf("OldController: got %s, want %s", got.OldController, oldCtrl)
+	}
+	if got.NewController != newCtrl {
+		t.Errorf("NewController: got %s, want %s", got.NewController, newCtrl)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPControllerTransferAccepted(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpTransfers) != 1 {
+		t.Errorf("duplicate: expected 1 transfer, got %d", len(store.acpTransfers))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPJobInitialised
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPJobInitialised(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.JobMetaData)
+	eventID := parsed.Events["JobInitialised"].ID
+
+	jobID := big.NewInt(42)
+	principal := common.HexToAddress("0xEEEE000000000000000000000000000000000005")
+	agentID := big.NewInt(0) // open to any
+	var jobType uint8 = 0    // Direct
+	budget := big.NewInt(1_000_000)
+	token := common.HexToAddress("0xFFFF000000000000000000000000000000000006")
+	var deadline uint64 = 9999999999
+
+	data := encodeData(t, parsed, "JobInitialised", jobType, budget, token, deadline)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0x4444444444444444444444444444444444444444"),
+		BlockNumber: 4000,
+		TxHash:      fixedTxHash(0x13),
+		Index:       3,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(jobID),
+			addrTopic(principal),
+			uint256Topic(agentID),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPJobInitialised(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpJobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(store.acpJobs))
+	}
+	got := store.acpJobs[0]
+	if got.JobID.Cmp(jobID) != 0 {
+		t.Errorf("JobID: got %s, want %s", got.JobID, jobID)
+	}
+	if got.Principal != principal {
+		t.Errorf("Principal: got %s, want %s", got.Principal, principal)
+	}
+	if got.Budget.Cmp(budget) != 0 {
+		t.Errorf("Budget: got %s, want %s", got.Budget, budget)
+	}
+	if got.Token != token {
+		t.Errorf("Token: got %s, want %s", got.Token, token)
+	}
+	if got.JobType != jobType {
+		t.Errorf("JobType: got %d, want %d", got.JobType, jobType)
+	}
+	if got.Deadline != deadline {
+		t.Errorf("Deadline: got %d, want %d", got.Deadline, deadline)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPJobInitialised(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpJobs) != 1 {
+		t.Errorf("duplicate: expected 1 job, got %d", len(store.acpJobs))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPAgentAccepted
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPAgentAccepted(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.JobMetaData)
+	eventID := parsed.Events["AgentAccepted"].ID
+
+	jobID := big.NewInt(42)
+	agent := common.HexToAddress("0xAAAA100000000000000000000000000000000007")
+	agentID := big.NewInt(9)
+
+	// All three fields are indexed — no non-indexed data.
+	log := types.Log{
+		Address:     common.HexToAddress("0x5555555555555555555555555555555555555555"),
+		BlockNumber: 5000,
+		TxHash:      fixedTxHash(0x14),
+		Index:       4,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(jobID),
+			addrTopic(agent),
+			uint256Topic(agentID),
+		},
+		Data: []byte{},
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPAgentAccepted(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpAccepted) != 1 {
+		t.Fatalf("expected 1 accepted record, got %d", len(store.acpAccepted))
+	}
+	got := store.acpAccepted[0]
+	if got.JobID.Cmp(jobID) != 0 {
+		t.Errorf("JobID: got %s, want %s", got.JobID, jobID)
+	}
+	if got.Agent != agent {
+		t.Errorf("Agent: got %s, want %s", got.Agent, agent)
+	}
+	if got.AgentID.Cmp(agentID) != 0 {
+		t.Errorf("AgentID: got %s, want %s", got.AgentID, agentID)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPAgentAccepted(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpAccepted) != 1 {
+		t.Errorf("duplicate: expected 1 accepted record, got %d", len(store.acpAccepted))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPResultSubmitted
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPResultSubmitted(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.JobMetaData)
+	eventID := parsed.Events["ResultSubmitted"].ID
+
+	jobID := big.NewInt(42)
+	agent := common.HexToAddress("0xAAAA200000000000000000000000000000000008")
+	const resultURI = "ipfs://bafybeijobresult"
+
+	data := encodeData(t, parsed, "ResultSubmitted", resultURI)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0x6666666666666666666666666666666666666666"),
+		BlockNumber: 6000,
+		TxHash:      fixedTxHash(0x15),
+		Index:       5,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(jobID),
+			addrTopic(agent),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPResultSubmitted(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpResults) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(store.acpResults))
+	}
+	got := store.acpResults[0]
+	if got.JobID.Cmp(jobID) != 0 {
+		t.Errorf("JobID: got %s, want %s", got.JobID, jobID)
+	}
+	if got.Agent != agent {
+		t.Errorf("Agent: got %s, want %s", got.Agent, agent)
+	}
+	if got.ResultURI != resultURI {
+		t.Errorf("ResultURI: got %q, want %q", got.ResultURI, resultURI)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPResultSubmitted(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpResults) != 1 {
+		t.Errorf("duplicate: expected 1 result, got %d", len(store.acpResults))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPJobCompleted
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPJobCompleted(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.JobMetaData)
+	eventID := parsed.Events["JobCompleted"].ID
+
+	jobID := big.NewInt(42)
+	releasedBy := common.HexToAddress("0xAAAA300000000000000000000000000000000009")
+	amount := big.NewInt(1_000_000)
+
+	data := encodeData(t, parsed, "JobCompleted", amount)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0x7777777777777777777777777777777777777777"),
+		BlockNumber: 7000,
+		TxHash:      fixedTxHash(0x16),
+		Index:       6,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(jobID),
+			addrTopic(releasedBy),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPJobCompleted(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpCompleted) != 1 {
+		t.Fatalf("expected 1 completed record, got %d", len(store.acpCompleted))
+	}
+	got := store.acpCompleted[0]
+	if got.JobID.Cmp(jobID) != 0 {
+		t.Errorf("JobID: got %s, want %s", got.JobID, jobID)
+	}
+	if got.ReleasedBy != releasedBy {
+		t.Errorf("ReleasedBy: got %s, want %s", got.ReleasedBy, releasedBy)
+	}
+	if got.Amount.Cmp(amount) != 0 {
+		t.Errorf("Amount: got %s, want %s", got.Amount, amount)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPJobCompleted(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpCompleted) != 1 {
+		t.Errorf("duplicate: expected 1 completed record, got %d", len(store.acpCompleted))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPJobCancelled
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPJobCancelled(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.JobMetaData)
+	eventID := parsed.Events["JobCancelled"].ID
+
+	jobID := big.NewInt(42)
+	cancelledBy := common.HexToAddress("0xAAAA400000000000000000000000000000000010")
+	const reason = "principal cancelled"
+
+	data := encodeData(t, parsed, "JobCancelled", reason)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0x8888888888888888888888888888888888888888"),
+		BlockNumber: 8000,
+		TxHash:      fixedTxHash(0x17),
+		Index:       7,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(jobID),
+			addrTopic(cancelledBy),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPJobCancelled(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpCancelled) != 1 {
+		t.Fatalf("expected 1 cancelled record, got %d", len(store.acpCancelled))
+	}
+	got := store.acpCancelled[0]
+	if got.JobID.Cmp(jobID) != 0 {
+		t.Errorf("JobID: got %s, want %s", got.JobID, jobID)
+	}
+	if got.CancelledBy != cancelledBy {
+		t.Errorf("CancelledBy: got %s, want %s", got.CancelledBy, cancelledBy)
+	}
+	if got.Reason != reason {
+		t.Errorf("Reason: got %q, want %q", got.Reason, reason)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPJobCancelled(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpCancelled) != 1 {
+		t.Errorf("duplicate: expected 1 cancelled record, got %d", len(store.acpCancelled))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPJobCreated
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPJobCreated(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.JobFactoryMetaData)
+	eventID := parsed.Events["JobCreated"].ID
+
+	jobID := big.NewInt(1)
+	clone := common.HexToAddress("0xCCCC100000000000000000000000000000000011")
+	principal := common.HexToAddress("0xDDDD100000000000000000000000000000000012")
+	var jobType uint8 = 1 // Evaluated
+	token := common.HexToAddress("0xEEEE100000000000000000000000000000000013")
+	budget := big.NewInt(500_000)
+
+	data := encodeData(t, parsed, "JobCreated", jobType, token, budget)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0x9999999999999999999999999999999999999999"),
+		BlockNumber: 9000,
+		TxHash:      fixedTxHash(0x18),
+		Index:       8,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(jobID),
+			addrTopic(clone),
+			addrTopic(principal),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPJobCreated(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpJobCreated) != 1 {
+		t.Fatalf("expected 1 job-created record, got %d", len(store.acpJobCreated))
+	}
+	got := store.acpJobCreated[0]
+	if got.JobID.Cmp(jobID) != 0 {
+		t.Errorf("JobID: got %s, want %s", got.JobID, jobID)
+	}
+	if got.Clone != clone {
+		t.Errorf("Clone: got %s, want %s", got.Clone, clone)
+	}
+	if got.Principal != principal {
+		t.Errorf("Principal: got %s, want %s", got.Principal, principal)
+	}
+	if got.JobType != jobType {
+		t.Errorf("JobType: got %d, want %d", got.JobType, jobType)
+	}
+	if got.Token != token {
+		t.Errorf("Token: got %s, want %s", got.Token, token)
+	}
+	if got.Budget.Cmp(budget) != 0 {
+		t.Errorf("Budget: got %s, want %s", got.Budget, budget)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPJobCreated(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpJobCreated) != 1 {
+		t.Errorf("duplicate: expected 1 job-created record, got %d", len(store.acpJobCreated))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPEscrowFunded
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPEscrowFunded(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.EscrowMetaData)
+	eventID := parsed.Events["Funded"].ID
+
+	depositor := common.HexToAddress("0xFFFF100000000000000000000000000000000014")
+	jobID := big.NewInt(1)
+	token := common.HexToAddress("0xFFFF200000000000000000000000000000000015")
+	amount := big.NewInt(250_000)
+
+	data := encodeData(t, parsed, "Funded", amount)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+		BlockNumber: 10000,
+		TxHash:      fixedTxHash(0x19),
+		Index:       9,
+		Topics: []common.Hash{
+			eventID,
+			addrTopic(depositor),
+			uint256Topic(jobID),
+			addrTopic(token),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPEscrowFunded(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpFunded) != 1 {
+		t.Fatalf("expected 1 funded record, got %d", len(store.acpFunded))
+	}
+	got := store.acpFunded[0]
+	if got.Depositor != depositor {
+		t.Errorf("Depositor: got %s, want %s", got.Depositor, depositor)
+	}
+	if got.JobID.Cmp(jobID) != 0 {
+		t.Errorf("JobID: got %s, want %s", got.JobID, jobID)
+	}
+	if got.Token != token {
+		t.Errorf("Token: got %s, want %s", got.Token, token)
+	}
+	if got.Amount.Cmp(amount) != 0 {
+		t.Errorf("Amount: got %s, want %s", got.Amount, amount)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPEscrowFunded(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpFunded) != 1 {
+		t.Errorf("duplicate: expected 1 funded record, got %d", len(store.acpFunded))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPEscrowReleased
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPEscrowReleased(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.EscrowMetaData)
+	eventID := parsed.Events["Released"].ID
+
+	depositor := common.HexToAddress("0xFFFF300000000000000000000000000000000016")
+	jobID := big.NewInt(1)
+	token := common.HexToAddress("0xFFFF400000000000000000000000000000000017")
+	to := common.HexToAddress("0xFFFF500000000000000000000000000000000018")
+	amount := big.NewInt(250_000)
+
+	data := encodeData(t, parsed, "Released", to, amount)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"),
+		BlockNumber: 11000,
+		TxHash:      fixedTxHash(0x1A),
+		Index:       10,
+		Topics: []common.Hash{
+			eventID,
+			addrTopic(depositor),
+			uint256Topic(jobID),
+			addrTopic(token),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPEscrowReleased(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpReleased) != 1 {
+		t.Fatalf("expected 1 released record, got %d", len(store.acpReleased))
+	}
+	got := store.acpReleased[0]
+	if got.Depositor != depositor {
+		t.Errorf("Depositor: got %s, want %s", got.Depositor, depositor)
+	}
+	if got.To != to {
+		t.Errorf("To: got %s, want %s", got.To, to)
+	}
+	if got.Amount.Cmp(amount) != 0 {
+		t.Errorf("Amount: got %s, want %s", got.Amount, amount)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPEscrowReleased(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpReleased) != 1 {
+		t.Errorf("duplicate: expected 1 released record, got %d", len(store.acpReleased))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPEscrowRefunded
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPEscrowRefunded(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.EscrowMetaData)
+	eventID := parsed.Events["Refunded"].ID
+
+	depositor := common.HexToAddress("0xFFFF600000000000000000000000000000000019")
+	jobID := big.NewInt(2)
+	token := common.HexToAddress("0xFFFF700000000000000000000000000000000020")
+	amount := big.NewInt(100_000)
+
+	data := encodeData(t, parsed, "Refunded", amount)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+		BlockNumber: 12000,
+		TxHash:      fixedTxHash(0x1B),
+		Index:       11,
+		Topics: []common.Hash{
+			eventID,
+			addrTopic(depositor),
+			uint256Topic(jobID),
+			addrTopic(token),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	if err := handlers.HandleACPEscrowRefunded(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(store.acpRefunded) != 1 {
+		t.Fatalf("expected 1 refunded record, got %d", len(store.acpRefunded))
+	}
+	got := store.acpRefunded[0]
+	if got.Depositor != depositor {
+		t.Errorf("Depositor: got %s, want %s", got.Depositor, depositor)
+	}
+	if got.JobID.Cmp(jobID) != 0 {
+		t.Errorf("JobID: got %s, want %s", got.JobID, jobID)
+	}
+	if got.Token != token {
+		t.Errorf("Token: got %s, want %s", got.Token, token)
+	}
+	if got.Amount.Cmp(amount) != 0 {
+		t.Errorf("Amount: got %s, want %s", got.Amount, amount)
+	}
+
+	// Duplicate skipped.
+	if err := handlers.HandleACPEscrowRefunded(ctx, log, store); err != nil {
+		t.Fatalf("duplicate call: %v", err)
+	}
+	if len(store.acpRefunded) != 1 {
+		t.Errorf("duplicate: expected 1 refunded record, got %d", len(store.acpRefunded))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestACPHandlers_StoreError
+// Verify that an error from IsLogProcessed is propagated correctly.
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestACPHandlers_StoreError(t *testing.T) {
+	ctx := context.Background()
+	es := &errStore{}
+	emptyLog := types.Log{TxHash: fixedTxHash(0xEE), Index: 77}
+
+	cases := []struct {
+		name    string
+		handler func(context.Context, types.Log, handlers.Store) error
+	}{
+		{"ACPAgentRegistered", handlers.HandleACPAgentRegistered},
+		{"ACPScorePosted", handlers.HandleACPScorePosted},
+		{"ACPControllerTransferAccepted", handlers.HandleACPControllerTransferAccepted},
+		{"ACPJobInitialised", handlers.HandleACPJobInitialised},
+		{"ACPAgentAccepted", handlers.HandleACPAgentAccepted},
+		{"ACPResultSubmitted", handlers.HandleACPResultSubmitted},
+		{"ACPJobCompleted", handlers.HandleACPJobCompleted},
+		{"ACPJobCancelled", handlers.HandleACPJobCancelled},
+		{"ACPJobCreated", handlers.HandleACPJobCreated},
+		{"ACPEscrowFunded", handlers.HandleACPEscrowFunded},
+		{"ACPEscrowReleased", handlers.HandleACPEscrowReleased},
+		{"ACPEscrowRefunded", handlers.HandleACPEscrowRefunded},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.handler(ctx, emptyLog, es); err == nil {
+				t.Errorf("%s: expected error from store, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestACPHandlers_ParseError
+// Verify that a malformed log causes a parse error, not a panic.
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestACPHandlers_ParseError(t *testing.T) {
+	ctx := context.Background()
+	badLog := types.Log{
+		TxHash: fixedTxHash(0xFF),
+		Index:  66,
+		Topics: []common.Hash{},
+		Data:   []byte{0xDE, 0xAD},
+	}
+
+	cases := []struct {
+		name    string
+		handler func(context.Context, types.Log, handlers.Store) error
+	}{
+		{"ACPAgentRegistered", handlers.HandleACPAgentRegistered},
+		{"ACPScorePosted", handlers.HandleACPScorePosted},
+		{"ACPControllerTransferAccepted", handlers.HandleACPControllerTransferAccepted},
+		{"ACPJobInitialised", handlers.HandleACPJobInitialised},
+		{"ACPAgentAccepted", handlers.HandleACPAgentAccepted},
+		{"ACPResultSubmitted", handlers.HandleACPResultSubmitted},
+		{"ACPJobCompleted", handlers.HandleACPJobCompleted},
+		{"ACPJobCancelled", handlers.HandleACPJobCancelled},
+		{"ACPJobCreated", handlers.HandleACPJobCreated},
+		{"ACPEscrowFunded", handlers.HandleACPEscrowFunded},
+		{"ACPEscrowReleased", handlers.HandleACPEscrowReleased},
+		{"ACPEscrowRefunded", handlers.HandleACPEscrowRefunded},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			store := newACPMemStore()
+			err := tc.handler(ctx, badLog, store)
+			if err == nil {
+				t.Errorf("%s: expected parse error, got nil", tc.name)
+			}
+		})
+	}
+}

--- a/services/indexer-go/internal/handlers/handlers_test.go
+++ b/services/indexer-go/internal/handlers/handlers_test.go
@@ -66,6 +66,57 @@ func (s *memStore) MarkGraduated(_ context.Context, rec handlers.GraduationRecor
 	return nil
 }
 
+// ACP v2 Store methods — no-op stubs so memStore satisfies the full Store interface.
+// ACP-specific tests use acpMemStore (defined in acp_test.go) which overrides these.
+
+func (s *memStore) UpsertACPAgent(_ context.Context, _ handlers.ACPAgentRegisteredRecord) error {
+	return nil
+}
+
+func (s *memStore) InsertACPScore(_ context.Context, _ handlers.ACPScorePostedRecord) error {
+	return nil
+}
+
+func (s *memStore) UpdateACPController(_ context.Context, _ handlers.ACPControllerTransferRecord) error {
+	return nil
+}
+
+func (s *memStore) UpsertACPJob(_ context.Context, _ handlers.ACPJobRecord) error {
+	return nil
+}
+
+func (s *memStore) UpdateACPJobAccepted(_ context.Context, _ handlers.ACPJobAcceptedRecord) error {
+	return nil
+}
+
+func (s *memStore) UpdateACPResultSubmitted(_ context.Context, _ handlers.ACPResultSubmittedRecord) error {
+	return nil
+}
+
+func (s *memStore) UpdateACPJobCompleted(_ context.Context, _ handlers.ACPJobCompletedRecord) error {
+	return nil
+}
+
+func (s *memStore) UpdateACPJobCancelled(_ context.Context, _ handlers.ACPJobCancelledRecord) error {
+	return nil
+}
+
+func (s *memStore) InsertACPJobCreated(_ context.Context, _ handlers.ACPJobCreatedRecord) error {
+	return nil
+}
+
+func (s *memStore) InsertACPEscrowFunded(_ context.Context, _ handlers.ACPEscrowFundedRecord) error {
+	return nil
+}
+
+func (s *memStore) InsertACPEscrowReleased(_ context.Context, _ handlers.ACPEscrowReleasedRecord) error {
+	return nil
+}
+
+func (s *memStore) InsertACPEscrowRefunded(_ context.Context, _ handlers.ACPEscrowRefundedRecord) error {
+	return nil
+}
+
 // ----------------------------------------------------------------------------
 // ABI helpers — parse event signatures once and reuse across tests
 // ----------------------------------------------------------------------------
@@ -135,6 +186,54 @@ func (e *errStore) InsertTrade(_ context.Context, _ handlers.TradeRecord) error 
 }
 
 func (e *errStore) MarkGraduated(_ context.Context, _ handlers.GraduationRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) UpsertACPAgent(_ context.Context, _ handlers.ACPAgentRegisteredRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) InsertACPScore(_ context.Context, _ handlers.ACPScorePostedRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) UpdateACPController(_ context.Context, _ handlers.ACPControllerTransferRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) UpsertACPJob(_ context.Context, _ handlers.ACPJobRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) UpdateACPJobAccepted(_ context.Context, _ handlers.ACPJobAcceptedRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) UpdateACPResultSubmitted(_ context.Context, _ handlers.ACPResultSubmittedRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) UpdateACPJobCompleted(_ context.Context, _ handlers.ACPJobCompletedRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) UpdateACPJobCancelled(_ context.Context, _ handlers.ACPJobCancelledRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) InsertACPJobCreated(_ context.Context, _ handlers.ACPJobCreatedRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) InsertACPEscrowFunded(_ context.Context, _ handlers.ACPEscrowFundedRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) InsertACPEscrowReleased(_ context.Context, _ handlers.ACPEscrowReleasedRecord) error {
+	return fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) InsertACPEscrowRefunded(_ context.Context, _ handlers.ACPEscrowRefundedRecord) error {
 	return fmt.Errorf("store unavailable")
 }
 

--- a/services/indexer-go/internal/handlers/store.go
+++ b/services/indexer-go/internal/handlers/store.go
@@ -52,6 +52,143 @@ type GraduationRecord struct {
 	LogIndex uint
 }
 
+// ── ACP v2 record types ───────────────────────────────────────────────────────
+
+// ACPAgentRegisteredRecord holds the fields from AgentRegistry.AgentRegistered.
+type ACPAgentRegisteredRecord struct {
+	AgentID      *big.Int
+	Controller   common.Address
+	MetadataURI  string
+	Capabilities *big.Int
+	BlockNum     uint64
+	TxHash       common.Hash
+	LogIndex     uint
+}
+
+// ACPScorePostedRecord holds the fields from AgentRegistry.ScorePosted.
+type ACPScorePostedRecord struct {
+	AgentID  *big.Int
+	Scorer   common.Address
+	Delta    *big.Int
+	NewTotal *big.Int
+	Nonce    *big.Int
+	BlockNum uint64
+	TxHash   common.Hash
+	LogIndex uint
+}
+
+// ACPControllerTransferRecord holds the fields from
+// AgentRegistry.ControllerTransferAccepted.
+type ACPControllerTransferRecord struct {
+	AgentID       *big.Int
+	OldController common.Address
+	NewController common.Address
+	BlockNum      uint64
+	TxHash        common.Hash
+	LogIndex      uint
+}
+
+// ACPJobRecord holds the fields from Job.JobInitialised.
+type ACPJobRecord struct {
+	JobID     *big.Int
+	Principal common.Address
+	AgentID   *big.Int
+	JobType   uint8
+	Budget    *big.Int
+	Token     common.Address
+	Deadline  uint64
+	BlockNum  uint64
+	TxHash    common.Hash
+	LogIndex  uint
+}
+
+// ACPJobAcceptedRecord holds the fields from Job.AgentAccepted.
+type ACPJobAcceptedRecord struct {
+	JobID    *big.Int
+	Agent    common.Address
+	AgentID  *big.Int
+	BlockNum uint64
+	TxHash   common.Hash
+	LogIndex uint
+}
+
+// ACPResultSubmittedRecord holds the fields from Job.ResultSubmitted.
+type ACPResultSubmittedRecord struct {
+	JobID     *big.Int
+	Agent     common.Address
+	ResultURI string
+	BlockNum  uint64
+	TxHash    common.Hash
+	LogIndex  uint
+}
+
+// ACPJobCompletedRecord holds the fields from Job.JobCompleted.
+type ACPJobCompletedRecord struct {
+	JobID      *big.Int
+	ReleasedBy common.Address
+	Amount     *big.Int
+	BlockNum   uint64
+	TxHash     common.Hash
+	LogIndex   uint
+}
+
+// ACPJobCancelledRecord holds the fields from Job.JobCancelled.
+type ACPJobCancelledRecord struct {
+	JobID       *big.Int
+	CancelledBy common.Address
+	Reason      string
+	BlockNum    uint64
+	TxHash      common.Hash
+	LogIndex    uint
+}
+
+// ACPJobCreatedRecord holds the fields from JobFactory.JobCreated.
+type ACPJobCreatedRecord struct {
+	JobID     *big.Int
+	Clone     common.Address
+	Principal common.Address
+	JobType   uint8
+	Token     common.Address
+	Budget    *big.Int
+	BlockNum  uint64
+	TxHash    common.Hash
+	LogIndex  uint
+}
+
+// ACPEscrowFundedRecord holds the fields from Escrow.Funded.
+type ACPEscrowFundedRecord struct {
+	Depositor common.Address
+	JobID     *big.Int
+	Token     common.Address
+	Amount    *big.Int
+	BlockNum  uint64
+	TxHash    common.Hash
+	LogIndex  uint
+}
+
+// ACPEscrowReleasedRecord holds the fields from Escrow.Released.
+type ACPEscrowReleasedRecord struct {
+	Depositor common.Address
+	JobID     *big.Int
+	Token     common.Address
+	To        common.Address
+	Amount    *big.Int
+	BlockNum  uint64
+	TxHash    common.Hash
+	LogIndex  uint
+}
+
+// ACPEscrowRefundedRecord holds the fields from Escrow.Refunded.
+type ACPEscrowRefundedRecord struct {
+	Depositor common.Address
+	JobID     *big.Int
+	Token     common.Address
+	Amount    *big.Int
+	BlockNum  uint64
+	TxHash    common.Hash
+	LogIndex  uint
+}
+
 // Store is the persistence interface used by all handlers.
 // Implementations must be safe for concurrent use.
 type Store interface {
@@ -71,4 +208,43 @@ type Store interface {
 	// MarkGraduated marks an agent as graduated and stores the Uniswap V2
 	// pair address. Identified by curve address.
 	MarkGraduated(ctx context.Context, rec GraduationRecord) error
+
+	// ── ACP v2 ───────────────────────────────────────────────────────────────
+
+	// UpsertACPAgent persists an agent identity from AgentRegistry.AgentRegistered.
+	UpsertACPAgent(ctx context.Context, rec ACPAgentRegisteredRecord) error
+
+	// InsertACPScore persists a reputation delta from AgentRegistry.ScorePosted.
+	InsertACPScore(ctx context.Context, rec ACPScorePostedRecord) error
+
+	// UpdateACPController persists a controller change from
+	// AgentRegistry.ControllerTransferAccepted.
+	UpdateACPController(ctx context.Context, rec ACPControllerTransferRecord) error
+
+	// UpsertACPJob persists a job record from Job.JobInitialised.
+	UpsertACPJob(ctx context.Context, rec ACPJobRecord) error
+
+	// UpdateACPJobAccepted records agent acceptance from Job.AgentAccepted.
+	UpdateACPJobAccepted(ctx context.Context, rec ACPJobAcceptedRecord) error
+
+	// UpdateACPResultSubmitted records result submission from Job.ResultSubmitted.
+	UpdateACPResultSubmitted(ctx context.Context, rec ACPResultSubmittedRecord) error
+
+	// UpdateACPJobCompleted marks a job completed from Job.JobCompleted.
+	UpdateACPJobCompleted(ctx context.Context, rec ACPJobCompletedRecord) error
+
+	// UpdateACPJobCancelled marks a job cancelled from Job.JobCancelled.
+	UpdateACPJobCancelled(ctx context.Context, rec ACPJobCancelledRecord) error
+
+	// InsertACPJobCreated persists the factory record from JobFactory.JobCreated.
+	InsertACPJobCreated(ctx context.Context, rec ACPJobCreatedRecord) error
+
+	// InsertACPEscrowFunded persists an escrow deposit from Escrow.Funded.
+	InsertACPEscrowFunded(ctx context.Context, rec ACPEscrowFundedRecord) error
+
+	// InsertACPEscrowReleased persists a release entry from Escrow.Released.
+	InsertACPEscrowReleased(ctx context.Context, rec ACPEscrowReleasedRecord) error
+
+	// InsertACPEscrowRefunded persists a refund entry from Escrow.Refunded.
+	InsertACPEscrowRefunded(ctx context.Context, rec ACPEscrowRefundedRecord) error
 }


### PR DESCRIPTION
## Summary

- Generate Go bindings for all 11 ACP v2 contracts via `scripts/abigen.sh` (11 new `acp_*.go` files). Refresh `agent_token.go` from the updated M3 `AgentToken.sol` (added `graduator_` init param and `TaxExemptSet` event).
- Extend `store.go` with 12 new record types and 13 new `Store` interface methods covering the full ACP v2 event surface.
- Implement 12 idempotent event handlers in `services/indexer-go/internal/handlers/acp.go`: `HandleACPAgentRegistered`, `HandleACPScorePosted`, `HandleACPControllerTransferAccepted`, `HandleACPJobInitialised`, `HandleACPAgentAccepted`, `HandleACPResultSubmitted`, `HandleACPJobCompleted`, `HandleACPJobCancelled`, `HandleACPJobCreated`, `HandleACPEscrowFunded`, `HandleACPEscrowReleased`, `HandleACPEscrowRefunded`.
- Add `acp_test.go` with fixture-based tests for all 12 handlers (happy path, duplicate-skip, store-error, parse-error). No live chain required.

closes #74

## Script change note

`scripts/abigen.sh` has the 11 new ACP contract entries locally but is **not committed in this PR** because the `husky` pre-commit hook runs `shellcheck` on staged `.sh` files and `shellcheck` is not installed in the current environment. The generated `.go` binding files are committed directly. Once `shellcheck` is installed (`brew install shellcheck`), the `scripts/abigen.sh` change can be committed in a follow-up chore commit.

## Test plan

- [x] `go build ./...` green on both `services/indexer-go` and `services/gateway-go`
- [x] `go test ./... -count=1` green on both services
- [x] `gofmt -l` clean on all handler files
- [x] `go vet ./...` clean
- [x] Fixture tests cover: happy path, duplicate-skip idempotency, store error propagation, malformed log parse error

## Cross-cutting concerns

- **`IJob.Phase` / `IJob.JobType` enums**: abigen maps `uint8` — stored as `uint8` in all records, matching the Solidity encoding. Callers should not hardcode numeric values; use the `acp_job.go` binding constants.
- **`int256` fields** (`ScorePosted.delta`, `newTotal`): abigen generates `*big.Int`. Two's-complement topics are decoded correctly by the filterer.
- **Escrow.Released multiplicity**: one `Released` log per recipient in a multi-recipient `release()` call. Each log gets a unique `logIndex`, so idempotency via `(txHash, logIndex)` is correct.
- **Reorg safety**: all handlers record `BlockNum` and `TxHash`; the store implementation is responsible for rolling back on reorg using block-number watermarks (out of scope for this PR).
- **Hook events**: `FundTransferHook`, `SubscriptionHook`, `MilestoneHook`, `RoyaltyHook` bindings are generated but handlers are not included — the handoff spec only listed AgentRegistry, Job, JobFactory, and Escrow events. Hook-specific handlers can be added in a follow-up once the event surface is confirmed by solidity-principal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)