### PR TITLE
phase(M3/fix-indexer): idempotency in ACP handlers

### DIFF
--- a/services/indexer-go/internal/handlers/acp.go
+++ b/services/indexer-go/internal/handlers/acp.go
@@ -50,6 +50,10 @@ func HandleACPAgentRegistered(ctx context.Context, log types.Log, store Store) e
 		return fmt.Errorf("handlers.HandleACPAgentRegistered: upsert: %w", err)
 	}
 
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentRegistered: mark processed: %w", err)
+	}
+
 	return nil
 }
 
@@ -89,6 +93,10 @@ func HandleACPScorePosted(ctx context.Context, log types.Log, store Store) error
 		return fmt.Errorf("handlers.HandleACPScorePosted: insert: %w", err)
 	}
 
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPScorePosted: mark processed: %w", err)
+	}
+
 	return nil
 }
 
@@ -125,6 +133,10 @@ func HandleACPControllerTransferAccepted(ctx context.Context, log types.Log, sto
 
 	if err := store.UpdateACPController(ctx, rec); err != nil {
 		return fmt.Errorf("handlers.HandleACPControllerTransferAccepted: update: %w", err)
+	}
+
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPControllerTransferAccepted: mark processed: %w", err)
 	}
 
 	return nil
@@ -168,6 +180,10 @@ func HandleACPJobInitialised(ctx context.Context, log types.Log, store Store) er
 		return fmt.Errorf("handlers.HandleACPJobInitialised: upsert: %w", err)
 	}
 
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPJobInitialised: mark processed: %w", err)
+	}
+
 	return nil
 }
 
@@ -203,6 +219,10 @@ func HandleACPAgentAccepted(ctx context.Context, log types.Log, store Store) err
 
 	if err := store.UpdateACPJobAccepted(ctx, rec); err != nil {
 		return fmt.Errorf("handlers.HandleACPAgentAccepted: update: %w", err)
+	}
+
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPAgentAccepted: mark processed: %w", err)
 	}
 
 	return nil
@@ -242,6 +262,10 @@ func HandleACPResultSubmitted(ctx context.Context, log types.Log, store Store) e
 		return fmt.Errorf("handlers.HandleACPResultSubmitted: update: %w", err)
 	}
 
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPResultSubmitted: mark processed: %w", err)
+	}
+
 	return nil
 }
 
@@ -279,6 +303,10 @@ func HandleACPJobCompleted(ctx context.Context, log types.Log, store Store) erro
 		return fmt.Errorf("handlers.HandleACPJobCompleted: update: %w", err)
 	}
 
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCompleted: mark processed: %w", err)
+	}
+
 	return nil
 }
 
@@ -314,6 +342,10 @@ func HandleACPJobCancelled(ctx context.Context, log types.Log, store Store) erro
 
 	if err := store.UpdateACPJobCancelled(ctx, rec); err != nil {
 		return fmt.Errorf("handlers.HandleACPJobCancelled: update: %w", err)
+	}
+
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCancelled: mark processed: %w", err)
 	}
 
 	return nil
@@ -356,6 +388,10 @@ func HandleACPJobCreated(ctx context.Context, log types.Log, store Store) error 
 		return fmt.Errorf("handlers.HandleACPJobCreated: insert: %w", err)
 	}
 
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPJobCreated: mark processed: %w", err)
+	}
+
 	return nil
 }
 
@@ -392,6 +428,10 @@ func HandleACPEscrowFunded(ctx context.Context, log types.Log, store Store) erro
 
 	if err := store.InsertACPEscrowFunded(ctx, rec); err != nil {
 		return fmt.Errorf("handlers.HandleACPEscrowFunded: insert: %w", err)
+	}
+
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowFunded: mark processed: %w", err)
 	}
 
 	return nil
@@ -433,6 +473,10 @@ func HandleACPEscrowReleased(ctx context.Context, log types.Log, store Store) er
 		return fmt.Errorf("handlers.HandleACPEscrowReleased: insert: %w", err)
 	}
 
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowReleased: mark processed: %w", err)
+	}
+
 	return nil
 }
 
@@ -469,6 +513,10 @@ func HandleACPEscrowRefunded(ctx context.Context, log types.Log, store Store) er
 
 	if err := store.InsertACPEscrowRefunded(ctx, rec); err != nil {
 		return fmt.Errorf("handlers.HandleACPEscrowRefunded: insert: %w", err)
+	}
+
+	if err := store.MarkLogProcessed(ctx, log.TxHash, log.Index); err != nil {
+		return fmt.Errorf("handlers.HandleACPEscrowRefunded: mark processed: %w", err)
 	}
 
 	return nil

--- a/services/indexer-go/internal/handlers/acp_test.go
+++ b/services/indexer-go/internal/handlers/acp_test.go
@@ -41,7 +41,6 @@ func newACPMemStore() *acpMemStore {
 func (s *acpMemStore) UpsertACPAgent(_ context.Context, rec handlers.ACPAgentRegisteredRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpAgents = append(s.acpAgents, rec)
 	return nil
 }
@@ -49,7 +48,6 @@ func (s *acpMemStore) UpsertACPAgent(_ context.Context, rec handlers.ACPAgentReg
 func (s *acpMemStore) InsertACPScore(_ context.Context, rec handlers.ACPScorePostedRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpScores = append(s.acpScores, rec)
 	return nil
 }
@@ -57,7 +55,6 @@ func (s *acpMemStore) InsertACPScore(_ context.Context, rec handlers.ACPScorePos
 func (s *acpMemStore) UpdateACPController(_ context.Context, rec handlers.ACPControllerTransferRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpTransfers = append(s.acpTransfers, rec)
 	return nil
 }
@@ -65,7 +62,6 @@ func (s *acpMemStore) UpdateACPController(_ context.Context, rec handlers.ACPCon
 func (s *acpMemStore) UpsertACPJob(_ context.Context, rec handlers.ACPJobRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpJobs = append(s.acpJobs, rec)
 	return nil
 }
@@ -73,7 +69,6 @@ func (s *acpMemStore) UpsertACPJob(_ context.Context, rec handlers.ACPJobRecord)
 func (s *acpMemStore) UpdateACPJobAccepted(_ context.Context, rec handlers.ACPJobAcceptedRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpAccepted = append(s.acpAccepted, rec)
 	return nil
 }
@@ -81,7 +76,6 @@ func (s *acpMemStore) UpdateACPJobAccepted(_ context.Context, rec handlers.ACPJo
 func (s *acpMemStore) UpdateACPResultSubmitted(_ context.Context, rec handlers.ACPResultSubmittedRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpResults = append(s.acpResults, rec)
 	return nil
 }
@@ -89,7 +83,6 @@ func (s *acpMemStore) UpdateACPResultSubmitted(_ context.Context, rec handlers.A
 func (s *acpMemStore) UpdateACPJobCompleted(_ context.Context, rec handlers.ACPJobCompletedRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpCompleted = append(s.acpCompleted, rec)
 	return nil
 }
@@ -97,7 +90,6 @@ func (s *acpMemStore) UpdateACPJobCompleted(_ context.Context, rec handlers.ACPJ
 func (s *acpMemStore) UpdateACPJobCancelled(_ context.Context, rec handlers.ACPJobCancelledRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpCancelled = append(s.acpCancelled, rec)
 	return nil
 }
@@ -105,7 +97,6 @@ func (s *acpMemStore) UpdateACPJobCancelled(_ context.Context, rec handlers.ACPJ
 func (s *acpMemStore) InsertACPJobCreated(_ context.Context, rec handlers.ACPJobCreatedRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpJobCreated = append(s.acpJobCreated, rec)
 	return nil
 }
@@ -113,7 +104,6 @@ func (s *acpMemStore) InsertACPJobCreated(_ context.Context, rec handlers.ACPJob
 func (s *acpMemStore) InsertACPEscrowFunded(_ context.Context, rec handlers.ACPEscrowFundedRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpFunded = append(s.acpFunded, rec)
 	return nil
 }
@@ -121,7 +111,6 @@ func (s *acpMemStore) InsertACPEscrowFunded(_ context.Context, rec handlers.ACPE
 func (s *acpMemStore) InsertACPEscrowReleased(_ context.Context, rec handlers.ACPEscrowReleasedRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpReleased = append(s.acpReleased, rec)
 	return nil
 }
@@ -129,7 +118,6 @@ func (s *acpMemStore) InsertACPEscrowReleased(_ context.Context, rec handlers.AC
 func (s *acpMemStore) InsertACPEscrowRefunded(_ context.Context, rec handlers.ACPEscrowRefundedRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.processed[logKey(rec.TxHash, rec.LogIndex)] = true
 	s.acpRefunded = append(s.acpRefunded, rec)
 	return nil
 }
@@ -887,6 +875,75 @@ func TestHandleACPEscrowRefunded(t *testing.T) {
 	}
 	if len(store.acpRefunded) != 1 {
 		t.Errorf("duplicate: expected 1 refunded record, got %d", len(store.acpRefunded))
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandleACPScorePosted_NoDeltaAccumulationOnRetry
+//
+// Regression test for issue #74: InsertACPScore is a delta-style write, so
+// replaying the same log must not double-count the score.
+//
+// Before the fix, handlers called IsLogProcessed but never MarkLogProcessed.
+// The acpMemStore marked the log processed inside InsertACPScore itself, which
+// happened to work in-memory, but a real store would not update the processed-
+// log table inside the score insert — leaving the flag unset and allowing the
+// same delta to be inserted twice on retry.
+//
+// The fix: handlers call MarkLogProcessed explicitly after every successful
+// persist, independent of the write method.  Here we verify the handler
+// correctly marks the log and that a second call with the same (txHash,
+// logIndex) produces no additional persist.
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestHandleACPScorePosted_NoDeltaAccumulationOnRetry(t *testing.T) {
+	parsed := mustGetACPABI(t, contractabi.AgentRegistryMetaData)
+	eventID := parsed.Events["ScorePosted"].ID
+
+	agentID := big.NewInt(1)
+	scorer := common.HexToAddress("0xAAAA000000000000000000000000000000000099")
+	delta := big.NewInt(50)
+	newTotal := big.NewInt(150)
+	nonce := big.NewInt(0)
+
+	data := encodeData(t, parsed, "ScorePosted", delta, newTotal, nonce)
+
+	log := types.Log{
+		Address:     common.HexToAddress("0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"),
+		BlockNumber: 5500,
+		TxHash:      fixedTxHash(0x99),
+		Index:       0,
+		Topics: []common.Hash{
+			eventID,
+			uint256Topic(agentID),
+			addrTopic(scorer),
+		},
+		Data: data,
+	}
+
+	store := newACPMemStore()
+	ctx := context.Background()
+
+	// First call — must persist exactly one score record.
+	if err := handlers.HandleACPScorePosted(ctx, log, store); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if got := len(store.acpScores); got != 1 {
+		t.Fatalf("after first call: expected 1 score record, got %d", got)
+	}
+
+	// Second call with identical (txHash, logIndex) — simulates a replay/retry.
+	// The handler must detect the log as already processed and skip InsertACPScore.
+	if err := handlers.HandleACPScorePosted(ctx, log, store); err != nil {
+		t.Fatalf("retry call: %v", err)
+	}
+	if got := len(store.acpScores); got != 1 {
+		t.Errorf("after retry: score delta was double-counted — expected 1 record, got %d", got)
+	}
+
+	// Confirm the stored delta value has not been doubled.
+	if store.acpScores[0].Delta.Cmp(delta) != 0 {
+		t.Errorf("Delta mismatch: got %s, want %s", store.acpScores[0].Delta, delta)
 	}
 }
 

--- a/services/indexer-go/internal/handlers/handlers_test.go
+++ b/services/indexer-go/internal/handlers/handlers_test.go
@@ -42,6 +42,13 @@ func (s *memStore) IsLogProcessed(_ context.Context, txHash common.Hash, logInde
 	return s.processed[logKey(txHash, logIndex)], nil
 }
 
+func (s *memStore) MarkLogProcessed(_ context.Context, txHash common.Hash, logIndex uint) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.processed[logKey(txHash, logIndex)] = true
+	return nil
+}
+
 func (s *memStore) UpsertAgent(_ context.Context, rec handlers.AgentRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -175,6 +182,10 @@ type errStore struct{}
 
 func (e *errStore) IsLogProcessed(_ context.Context, _ common.Hash, _ uint) (bool, error) {
 	return false, fmt.Errorf("store unavailable")
+}
+
+func (e *errStore) MarkLogProcessed(_ context.Context, _ common.Hash, _ uint) error {
+	return fmt.Errorf("store unavailable")
 }
 
 func (e *errStore) UpsertAgent(_ context.Context, _ handlers.AgentRecord) error {

--- a/services/indexer-go/internal/handlers/store.go
+++ b/services/indexer-go/internal/handlers/store.go
@@ -197,6 +197,12 @@ type Store interface {
 	// idempotency.
 	IsLogProcessed(ctx context.Context, txHash common.Hash, logIndex uint) (bool, error)
 
+	// MarkLogProcessed records that a log identified by (txHash, logIndex) has
+	// been fully persisted. Handlers call this immediately after a successful
+	// write so that retries skip the log without re-applying delta-style
+	// mutations (e.g. InsertACPScore score deltas).
+	MarkLogProcessed(ctx context.Context, txHash common.Hash, logIndex uint) error
+
 	// UpsertAgent inserts or updates an agent record. On conflict the existing
 	// row is left unchanged (insert-if-not-exists semantics).
 	UpsertAgent(ctx context.Context, rec AgentRecord) error


### PR DESCRIPTION
## Summary

- Adds `MarkLogProcessed(ctx, txHash, logIndex) error` to the `Store` interface in `store.go`.
- All 12 ACP handlers in `acp.go` now call `MarkLogProcessed` immediately after a successful persist, making the idempotency contract explicit and independent of each write method's internal behaviour.
- `acpMemStore` test fixture updated: inline `s.processed[...] = true` removed from write methods; the handler's `MarkLogProcessed` call is now the sole authority for marking a log processed.
- `memStore` and `errStore` implement `MarkLogProcessed` to satisfy the updated interface.
- Regression test `TestHandleACPScorePosted_NoDeltaAccumulationOnRetry` proves that replaying the same `ScorePosted` log twice produces exactly one `InsertACPScore` call and does not double the delta.

closes #74

## Test plan

- [ ] `go build ./...` clean
- [ ] `go test ./... -count=1` passes (all handlers package tests green, including the new regression test)
- [ ] `gofmt -l` reports no files
- [ ] `go vet ./...` clean