### PR TITLE
fix(contracts): M3 tier-2 review blockers — Escrow witness (#56), Job/FeeSplitter wiring (#55), BuybackBurner (#58)

### DIFF
--- a/contracts/evm/script/DeployPhase3.s.sol
+++ b/contracts/evm/script/DeployPhase3.s.sol
@@ -76,47 +76,62 @@ contract DeployPhase3 is Script {
         vm.startBroadcast();
         _deployCore(admin, arbiter, permit2, treasury);
         _deployBuybackAndFees(admin, paymentToken, titu, uniRouter, treasury);
+        _deployFeeSplitter(admin, treasury);
+        _deployJobFactory(admin, arbiter);
         _deployHooks(admin);
         vm.stopBroadcast();
 
         _writeDeployments(admin, permit2, arbiter);
     }
 
-    function _deployCore(address admin, address arbiter, address permit2, address) internal {
+    function _deployCore(address admin, address arbiter, address permit2, address treasury) internal {
         agentRegistry = new AgentRegistry(admin);
         console2.log("AgentRegistry:", address(agentRegistry));
 
-        jobImpl = new Job();
-        console2.log("Job (impl):", address(jobImpl));
-
-        jobFactory = new JobFactory(admin, address(jobImpl), agentRegistry, arbiter);
-        console2.log("JobFactory:", address(jobFactory));
-
+        // Deploy Escrow and FeeSplitter first (needed by JobFactory constructor)
         escrow = new Escrow(admin, permit2);
         console2.log("Escrow:", address(escrow));
+
+        // BuybackBurner is deployed in _deployBuybackAndFees; use address(1) as placeholder
+        // and update after that step. FeeSplitter requires buybackBurner address at construction.
+        // Deploy order: Escrow → BuybackBurner → FeeSplitter → HookRegistry → Job impl → JobFactory
+
+        jobImpl = new Job();
+        console2.log("Job (impl):", address(jobImpl));
     }
 
-    function _deployBuybackAndFees(
-        address admin,
-        address paymentToken,
-        address titu,
-        address uniRouter,
-        address treasury
-    ) internal {
+    function _deployFeeSplitter(address admin, address treasury) internal {
+        feeSplitter = new FeeSplitter(admin, treasury, address(buybackBurner));
+        console2.log("FeeSplitter:", address(feeSplitter));
+
+        hookRegistry = new HookRegistry(admin);
+        console2.log("HookRegistry (pre-hooks):", address(hookRegistry));
+    }
+
+    function _deployJobFactory(address admin, address arbiter) internal {
+        jobFactory = new JobFactory(admin, address(jobImpl), agentRegistry, arbiter, escrow, feeSplitter, hookRegistry);
+        console2.log("JobFactory:", address(jobFactory));
+
+        // Grant JobFactory DEFAULT_ADMIN_ROLE on Escrow so it can grant RELEASER_ROLE to clones
+        escrow.grantRole(escrow.DEFAULT_ADMIN_ROLE(), address(jobFactory));
+        // Grant JobFactory DEFAULT_ADMIN_ROLE on FeeSplitter so it can grant CALLER_ROLE to clones
+        feeSplitter.grantRole(feeSplitter.DEFAULT_ADMIN_ROLE(), address(jobFactory));
+        console2.log("Roles wired: JobFactory -> Escrow + FeeSplitter");
+    }
+
+    function _deployBuybackAndFees(address admin, address paymentToken, address titu, address uniRouter, address)
+        internal
+    {
         address[] memory swapPath = new address[](2);
         swapPath[0] = paymentToken;
         swapPath[1] = titu;
-        buybackBurner = new BuybackBurner(admin, uniRouter, paymentToken, titu, swapPath, 9000, 300);
+        // minTituOut = 0 initially (admin should set a sensible floor after deployment)
+        buybackBurner = new BuybackBurner(admin, uniRouter, paymentToken, titu, swapPath, 0, 300);
         console2.log("BuybackBurner:", address(buybackBurner));
-
-        feeSplitter = new FeeSplitter(admin, treasury, address(buybackBurner));
-        console2.log("FeeSplitter:", address(feeSplitter));
     }
 
-    function _deployHooks(address admin) internal {
-        hookRegistry = new HookRegistry(admin);
-        console2.log("HookRegistry:", address(hookRegistry));
-
+    function _deployHooks(address) internal {
+        // HookRegistry was already deployed in _deployFeeSplitter
         fundTransferHook = new FundTransferHook();
         subscriptionHook = new SubscriptionHook();
         milestoneHook = new MilestoneHook();
@@ -127,6 +142,7 @@ contract DeployPhase3 is Script {
         hookRegistry.registerHook(address(milestoneHook));
         hookRegistry.registerHook(address(royaltyHook));
 
+        console2.log("HookRegistry:", address(hookRegistry));
         console2.log("FundTransferHook:", address(fundTransferHook));
         console2.log("SubscriptionHook:", address(subscriptionHook));
         console2.log("MilestoneHook:", address(milestoneHook));

--- a/contracts/evm/src/acp/BuybackBurner.sol
+++ b/contracts/evm/src/acp/BuybackBurner.sol
@@ -25,16 +25,18 @@ interface IERC20Burnable is IERC20 {
 
 /// @title BuybackBurner
 /// @notice Receives a payment token, swaps it for TITU on Uniswap V2, then burns
-///         the TITU using ERC20Burnable.burnFrom.
+///         the TITU using ERC20Burnable.burn.
 /// @dev    Role model:
 ///           - DEFAULT_ADMIN_ROLE: update router, path, and slippage parameters.
 ///           - EXECUTOR_ROLE: allowed to call `buybackAndBurn`.
 ///
-///         Slippage: caller supplies `amountOutMin`; the contract enforces a
-///         global floor `minOutBps` (in BPS of input amount) as an extra safety
-///         net. Set `minOutBps = 0` to disable the floor (not recommended).
+///         Slippage: caller supplies `amountOutMin` in TITU units (the output token).
+///         The admin-configurable `minTituOut` provides an absolute TITU floor; the
+///         effective minimum passed to the router is max(amountOutMin, minTituOut).
+///         Both quantities are expressed in TITU, ensuring dimensional consistency.
+///         Set `minTituOut = 0` to disable the floor (not recommended in production).
 ///
-///         CEI: safeApprove the router, then swap, then burn.  No state changes
+///         CEI: forceApprove the router, then swap, then burn.  No state changes
 ///         occur after the external calls, so ReentrancyGuard covers residual risk.
 contract BuybackBurner is AccessControl, ReentrancyGuard {
     using SafeERC20 for IERC20;
@@ -44,12 +46,6 @@ contract BuybackBurner is AccessControl, ReentrancyGuard {
     // ─────────────────────────────────────────────────────────────
 
     bytes32 public constant EXECUTOR_ROLE = keccak256("EXECUTOR_ROLE");
-
-    // ─────────────────────────────────────────────────────────────
-    // Constants
-    // ─────────────────────────────────────────────────────────────
-
-    uint256 public constant BPS = 10_000;
 
     // ─────────────────────────────────────────────────────────────
     // State
@@ -68,9 +64,12 @@ contract BuybackBurner is AccessControl, ReentrancyGuard {
     ///         and end with address(titu).  May include intermediate hops.
     address[] public swapPath;
 
-    /// @notice Minimum output in BPS of the input amount.  Acts as a global floor.
-    ///         E.g. 9000 = 90%. Set to 0 to disable.
-    uint256 public minOutBps;
+    /// @notice Minimum TITU output per swap (absolute amount, not BPS).
+    ///         The caller supplies `amountOutMin` to `buybackAndBurn`; this field
+    ///         is an admin-configurable hard floor expressed in TITU units so the
+    ///         comparison is dimensionally consistent (TITU out vs TITU floor).
+    ///         Set to 0 to disable the floor check.
+    uint256 public minTituOut;
 
     /// @notice Swap deadline extension in seconds added to block.timestamp.
     uint256 public immutable swapDeadlineBuffer;
@@ -88,8 +87,8 @@ contract BuybackBurner is AccessControl, ReentrancyGuard {
     /// @notice Emitted when swap path is updated.
     event SwapPathUpdated(address[] path);
 
-    /// @notice Emitted when min-out BPS floor is updated.
-    event MinOutBpsUpdated(uint256 oldBps, uint256 newBps);
+    /// @notice Emitted when the minimum TITU output floor is updated.
+    event MinTituOutUpdated(uint256 oldMin, uint256 newMin);
 
     // ─────────────────────────────────────────────────────────────
     // Errors
@@ -98,8 +97,7 @@ contract BuybackBurner is AccessControl, ReentrancyGuard {
     error ZeroAddress();
     error ZeroAmount();
     error InvalidSwapPath();
-    error InvalidBps();
-    error InsufficientAmountOut(uint256 amountIn, uint256 minOut, uint256 actualOut);
+    error RescuePaymentTokenForbidden();
 
     // ─────────────────────────────────────────────────────────────
     // Constructor
@@ -110,7 +108,7 @@ contract BuybackBurner is AccessControl, ReentrancyGuard {
     /// @param _paymentToken     ERC-20 received and swapped.
     /// @param _titu             TITU token address (must implement burnFrom).
     /// @param _swapPath         Initial swap path (must start with _paymentToken, end with _titu).
-    /// @param _minOutBps        Minimum output BPS (0–10 000).
+    /// @param _minTituOut       Minimum TITU output per swap in absolute TITU units (0 = no floor).
     /// @param _swapDeadlineBuffer Seconds added to block.timestamp for swap deadline.
     constructor(
         address admin,
@@ -118,21 +116,20 @@ contract BuybackBurner is AccessControl, ReentrancyGuard {
         address _paymentToken,
         address _titu,
         address[] memory _swapPath,
-        uint256 _minOutBps,
+        uint256 _minTituOut,
         uint256 _swapDeadlineBuffer
     ) {
         if (admin == address(0)) revert ZeroAddress();
         if (_router == address(0)) revert ZeroAddress();
         if (_paymentToken == address(0)) revert ZeroAddress();
         if (_titu == address(0)) revert ZeroAddress();
-        if (_minOutBps > BPS) revert InvalidBps();
         _validatePath(_swapPath, _paymentToken, _titu);
 
         router = IUniswapV2Router02(_router);
         paymentToken = _paymentToken;
         titu = IERC20Burnable(_titu);
         swapPath = _swapPath;
-        minOutBps = _minOutBps;
+        minTituOut = _minTituOut;
         swapDeadlineBuffer = _swapDeadlineBuffer;
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
@@ -145,21 +142,24 @@ contract BuybackBurner is AccessControl, ReentrancyGuard {
 
     /// @notice Swap all held `paymentToken` for TITU via Uniswap V2 and burn the TITU.
     /// @dev    Caller must hold EXECUTOR_ROLE.
-    /// @param  amountIn    Amount of paymentToken to swap.
-    /// @param  amountOutMin Minimum TITU out (caller's slippage tolerance).
+    ///         `amountOutMin` is expressed in TITU units (the same token that is received
+    ///         from the swap), making the slippage check dimensionally consistent.
+    ///         The admin-set `minTituOut` floor is also in TITU units; the effective floor
+    ///         passed to the router is max(amountOutMin, minTituOut).
+    /// @param  amountIn     Amount of paymentToken to swap.
+    /// @param  amountOutMin Caller's minimum TITU output (in TITU units).
     function buybackAndBurn(uint256 amountIn, uint256 amountOutMin) external nonReentrant onlyRole(EXECUTOR_ROLE) {
         if (amountIn == 0) revert ZeroAmount();
 
-        // Enforce global floor if configured
-        if (minOutBps > 0) {
-            uint256 floor = (amountIn * minOutBps) / BPS;
-            if (amountOutMin < floor) {
-                amountOutMin = floor;
-            }
+        // Enforce global TITU floor: both amountOutMin and minTituOut are in TITU
+        // units, making the comparison dimensionally consistent. Use the higher of
+        // the two as the effective minimum passed to the router.
+        uint256 floor = minTituOut;
+        if (floor > amountOutMin) {
+            amountOutMin = floor;
         }
 
         address _paymentToken = paymentToken;
-        address _titu = address(titu);
 
         // Record TITU balance before swap to calculate actual amount received
         uint256 tituBefore = titu.balanceOf(address(this));
@@ -205,20 +205,21 @@ contract BuybackBurner is AccessControl, ReentrancyGuard {
         emit SwapPathUpdated(path);
     }
 
-    /// @notice Update the minimum output BPS floor.
-    /// @param  newBps New BPS value (0–10 000).
-    function setMinOutBps(uint256 newBps) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (newBps > BPS) revert InvalidBps();
-        uint256 old = minOutBps;
-        minOutBps = newBps;
-        emit MinOutBpsUpdated(old, newBps);
+    /// @notice Update the minimum TITU output floor (absolute amount in TITU units).
+    /// @param  newMin New minimum TITU out (0 = no floor).
+    function setMinTituOut(uint256 newMin) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        uint256 old = minTituOut;
+        minTituOut = newMin;
+        emit MinTituOutUpdated(old, newMin);
     }
 
-    /// @notice Rescue ERC-20 tokens accidentally sent to this contract (excludes paymentToken mid-swap).
-    /// @param  tokenAddr Token to rescue.
+    /// @notice Rescue ERC-20 tokens accidentally sent to this contract.
+    /// @dev    Rescuing `paymentToken` is forbidden to prevent draining mid-swap balances.
+    /// @param  tokenAddr Token to rescue (must not be paymentToken).
     /// @param  to        Recipient.
     /// @param  amount    Amount to rescue.
     function rescueTokens(address tokenAddr, address to, uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (tokenAddr == paymentToken) revert RescuePaymentTokenForbidden();
         if (to == address(0)) revert ZeroAddress();
         IERC20(tokenAddr).safeTransfer(to, amount);
     }

--- a/contracts/evm/src/acp/Escrow.sol
+++ b/contracts/evm/src/acp/Escrow.sol
@@ -11,7 +11,9 @@ import {IPermit2} from "./IPermit2.sol";
 /// @notice Multi-token escrow with atomic multi-recipient release and Permit2 support.
 /// @dev    Funds are held in this contract; balances tracked per (depositor, jobId, token).
 ///         `release` atomically transfers to N recipients.
-///         `fundWithPermit2` allows gasless ERC-20 approval via Permit2 EIP-712 signature.
+///         `fundWithPermit2` allows gasless ERC-20 approval via Permit2 witness transfer.
+///         The witness binds (depositor, jobId, token, amount) to the signature so it
+///         cannot be replayed across jobs or used to drain a different token.
 ///         RELEASER_ROLE: addresses allowed to call `release` and `refund`.
 ///         CEI: all storage writes before external SafeERC20/Permit2 transfers.
 ///         ReentrancyGuard on `fund`, `fundWithPermit2`, `release`, `refund`.
@@ -42,6 +44,26 @@ contract Escrow is AccessControl, ReentrancyGuard {
     error RecipientZeroAddress(uint256 index);
     error RecipientZeroAmount(uint256 index);
     error SumExceedsBalance(uint256 sum, uint256 balance);
+    error Permit2TokenMismatch(address permitToken, address requestedToken);
+    error Permit2AmountMismatch(uint256 permitAmount, uint256 requestedAmount);
+
+    // ─────────────────────────────────────────────────────────────
+    // Permit2 witness
+    // ─────────────────────────────────────────────────────────────
+
+    /// @dev EIP-712 type string for the escrow witness struct.
+    ///      Must match the struct layout of EscrowWitness exactly.
+    ///      Permit2 appends this to its own type hash as:
+    ///        keccak256("PermitWitnessTransferFrom(...TokenPermissions permitted,...)EscrowWitness(...)")
+    string public constant ESCROW_WITNESS_TYPE =
+        "EscrowWitness(address depositor,uint256 jobId,address token,uint256 amount)";
+
+    /// @dev keccak256 of ESCROW_WITNESS_TYPE, cached for gas efficiency.
+    bytes32 public constant ESCROW_WITNESS_TYPEHASH = keccak256(bytes(ESCROW_WITNESS_TYPE));
+
+    // ─────────────────────────────────────────────────────────────
+    // Constructor
+    // ─────────────────────────────────────────────────────────────
 
     /// @param admin    Address granted DEFAULT_ADMIN_ROLE and RELEASER_ROLE.
     /// @param _permit2 Permit2 contract address (canonical: 0x000000000022D473030F116dDEE9F6B43aC78BA3).
@@ -67,13 +89,20 @@ contract Escrow is AccessControl, ReentrancyGuard {
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
     }
 
-    /// @notice Deposit via Permit2 signed transfer (no prior approve needed).
-    /// @param depositor Address whose balance increases (must be the Permit2 signer).
-    /// @param jobId Opaque job identifier.
-    /// @param token ERC-20 token address.
-    /// @param amount Amount to deposit (must be > 0).
-    /// @param permit Permit2 PermitTransferFrom struct.
-    /// @param signature EIP-712 signature by depositor over permit.
+    /// @notice Deposit via Permit2 witness signed transfer (no prior approve needed).
+    /// @dev    The witness struct `EscrowWitness(depositor, jobId, token, amount)` is bound
+    ///         into the EIP-712 signature so the signature cannot be:
+    ///           - replayed for a different jobId,
+    ///           - used to drain a different token than signed for,
+    ///           - used for a different amount than signed for.
+    ///         The `permit.permitted.token` must equal `token` and
+    ///         `permit.permitted.amount` must equal `amount` to prevent spoofed arguments.
+    /// @param depositor  Address whose balance increases (must be the Permit2 signer).
+    /// @param jobId      Opaque job identifier bound into the witness.
+    /// @param token      ERC-20 token address; must match permit.permitted.token.
+    /// @param amount     Amount to deposit; must match permit.permitted.amount.
+    /// @param permit     Permit2 PermitTransferFrom struct signed by depositor.
+    /// @param signature  EIP-712 signature by depositor over permit + witness.
     function fundWithPermit2(
         address depositor,
         uint256 jobId,
@@ -85,14 +114,31 @@ contract Escrow is AccessControl, ReentrancyGuard {
         if (depositor == address(0)) revert ZeroAddress();
         if (token == address(0)) revert ZeroAddress();
         if (amount == 0) revert ZeroAmount();
+
+        // Validate that permit fields match the requested transfer to prevent
+        // cross-token drain (spoofed `token` arg) and amount manipulation.
+        if (permit.permitted.token != token) {
+            revert Permit2TokenMismatch(permit.permitted.token, token);
+        }
+        if (permit.permitted.amount != amount) {
+            revert Permit2AmountMismatch(permit.permitted.amount, amount);
+        }
+
+        // Build witness hash binding (depositor, jobId, token, amount) into the
+        // signature so it cannot be replayed across jobs.
+        bytes32 witness = keccak256(abi.encode(ESCROW_WITNESS_TYPEHASH, depositor, jobId, token, amount));
+
         // Effects before interaction (CEI)
         balances[depositor][jobId][token] += amount;
         emit Funded(depositor, jobId, token, amount);
-        // Interaction via Permit2
-        permit2.permitTransferFrom(
+
+        // Interaction via Permit2 witness transfer
+        permit2.permitWitnessTransferFrom(
             permit,
             IPermit2.SignatureTransferDetails({to: address(this), requestedAmount: amount}),
             depositor,
+            witness,
+            ESCROW_WITNESS_TYPE,
             signature
         );
     }

--- a/contracts/evm/src/acp/IPermit2.sol
+++ b/contracts/evm/src/acp/IPermit2.sol
@@ -19,6 +19,7 @@ interface IPermit2 {
         address to;
         uint256 requestedAmount;
     }
+
     /// @notice Transfer tokens using a signed Permit2 message.
     /// @param permit Permit data (token, amount, nonce, deadline).
     /// @param transferDetails Transfer destination and amount.
@@ -28,6 +29,24 @@ interface IPermit2 {
         PermitTransferFrom calldata permit,
         SignatureTransferDetails calldata transferDetails,
         address owner,
+        bytes calldata signature
+    ) external;
+
+    /// @notice Transfer tokens using a signed Permit2 message that includes a
+    ///         typed witness binding additional data to the signature domain.
+    /// @param permit          Permit data (token, amount, nonce, deadline).
+    /// @param transferDetails Transfer destination and amount.
+    /// @param owner           The account whose tokens will be transferred.
+    /// @param witness         Keccak-256 hash of the encoded witness struct.
+    /// @param witnessTypeString ABI type string for the witness struct, appended to
+    ///                          the Permit2 EIP-712 type hash (see Permit2 spec).
+    /// @param signature       EIP-712 signature over the permit + witness.
+    function permitWitnessTransferFrom(
+        PermitTransferFrom calldata permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes32 witness,
+        string calldata witnessTypeString,
         bytes calldata signature
     ) external;
 }

--- a/contracts/evm/src/acp/Job.sol
+++ b/contracts/evm/src/acp/Job.sol
@@ -7,6 +7,10 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IJob} from "./IJob.sol";
 import {AgentRegistry} from "./AgentRegistry.sol";
+import {Escrow} from "./Escrow.sol";
+import {FeeSplitter} from "./FeeSplitter.sol";
+import {HookRegistry} from "./HookRegistry.sol";
+import {IHook} from "./IHook.sol";
 
 /// @title Job
 /// @notice ACP v2 Job — EIP-1167-clonable state machine for agent work agreements.
@@ -16,20 +20,26 @@ import {AgentRegistry} from "./AgentRegistry.sol";
 ///
 ///         Phase graph (allowed transitions):
 ///           Open      → Active     (agent accepts)
-///           Open      → Cancelled  (principal cancels; budget refunded)
+///           Open      → Cancelled  (principal cancels; escrow refunded via Escrow.refund)
 ///           Open      → Cancelled  (expiry triggers expireJob)
 ///           Active    → Review     (agent submits result)
 ///           Active    → Disputed   (principal raises dispute)
 ///           Active    → Cancelled  (expiry triggers expireJob)
-///           Review    → Completed  (principal/evaluator approves; escrow released)
+///           Review    → Completed  (principal/evaluator approves; Escrow.release → FeeSplitter)
 ///           Review    → Active     (evaluator rejects; agent may resubmit)
 ///           Review    → Disputed   (principal or agent raises dispute)
 ///           Completed → —          (terminal)
 ///           Cancelled → —          (terminal)
-///           Disputed  → Completed  (arbiter resolves agent-favoured; escrow released)
-///           Disputed  → Cancelled  (arbiter resolves principal-favoured; budget refunded)
+///           Disputed  → Completed  (arbiter resolves agent-favoured; Escrow.release → FeeSplitter)
+///           Disputed  → Cancelled  (arbiter resolves principal-favoured; escrow refunded)
 ///
-///         CEI order is enforced throughout; ReentrancyGuard on all token transfers.
+///         Token custody: budget is held by `Escrow` under (principal, jobId, token).
+///         Job never holds tokens itself; it only drives Escrow state transitions.
+///
+///         Hooks: registered in HookRegistry are called at each lifecycle point.
+///         Unapproved hooks are silently skipped (non-blocking).
+///
+///         CEI order is enforced throughout; ReentrancyGuard on all external calls.
 contract Job is IJob, ReentrancyGuard, Initializable {
     using SafeERC20 for IERC20;
 
@@ -52,8 +62,20 @@ contract Job is IJob, ReentrancyGuard, Initializable {
     /// @notice ERC-20 token used for payment (address(0) means native ETH — not supported in v1).
     address public token;
 
-    /// @notice Total budget locked in this contract.
+    /// @notice Total budget locked in Escrow under (principal, jobId, token).
     uint256 public budget;
+
+    /// @notice Escrow contract holding the job budget.
+    Escrow public escrow;
+
+    /// @notice FeeSplitter that distributes payment on completion.
+    FeeSplitter public feeSplitter;
+
+    /// @notice HookRegistry used to validate hook addresses before calling them.
+    HookRegistry public hookRegistry;
+
+    /// @notice Lifecycle hooks registered for this job.
+    address[] public hooks;
 
     /// @notice UNIX timestamp after which the job may be expired.
     uint64 public deadline;
@@ -113,6 +135,7 @@ contract Job is IJob, ReentrancyGuard, Initializable {
     error EvaluatorRequired();
     error DirectJobNoEvaluator();
     error TokenMismatch();
+    error UnapprovedHook(address hook);
 
     // ─────────────────────────────────────────────────────────────
     // Modifiers
@@ -144,8 +167,14 @@ contract Job is IJob, ReentrancyGuard, Initializable {
     }
 
     // ─────────────────────────────────────────────────────────────
-    // Initializer (replaces constructor for EIP-1167 clones)
+    // Constructor (disables initializers on the implementation)
     // ─────────────────────────────────────────────────────────────
+
+    /// @dev Prevents the implementation contract from being initialized directly.
+    ///      Only clones produced by JobFactory may be initialized.
+    constructor() {
+        _disableInitializers();
+    }
 
     // ─────────────────────────────────────────────────────────────
     // Init config struct (avoids stack-too-deep in initializer)
@@ -163,6 +192,14 @@ contract Job is IJob, ReentrancyGuard, Initializable {
         JobType jobType;
         address evaluator;
         address arbiter;
+        /// @notice Escrow contract holding the job budget.
+        Escrow escrow;
+        /// @notice FeeSplitter that distributes payment on completion.
+        FeeSplitter feeSplitter;
+        /// @notice HookRegistry used to validate hooks.
+        HookRegistry hookRegistry;
+        /// @notice Optional lifecycle hooks for this job (each must be approved in hookRegistry).
+        address[] hooks;
     }
 
     /// @notice Initialise a newly-cloned Job contract.
@@ -175,8 +212,16 @@ contract Job is IJob, ReentrancyGuard, Initializable {
         // slither-disable-next-line timestamp
         if (p.deadline <= block.timestamp) revert InvalidDeadline();
         if (p.arbiter == address(0)) revert ZeroAddress();
+        if (address(p.escrow) == address(0)) revert ZeroAddress();
+        if (address(p.feeSplitter) == address(0)) revert ZeroAddress();
+        if (address(p.hookRegistry) == address(0)) revert ZeroAddress();
         if (p.jobType == JobType.Evaluated && p.evaluator == address(0)) revert EvaluatorRequired();
         if (p.jobType == JobType.Direct && p.evaluator != address(0)) revert DirectJobNoEvaluator();
+
+        // Validate all hooks are approved before storing them
+        for (uint256 i = 0; i < p.hooks.length; ++i) {
+            if (!p.hookRegistry.isApproved(p.hooks[i])) revert UnapprovedHook(p.hooks[i]);
+        }
 
         jobId = p.jobId;
         principal = p.principal;
@@ -188,6 +233,13 @@ contract Job is IJob, ReentrancyGuard, Initializable {
         jobType = p.jobType;
         evaluator = p.evaluator;
         arbiter = p.arbiter;
+        escrow = p.escrow;
+        feeSplitter = p.feeSplitter;
+        hookRegistry = p.hookRegistry;
+        // Copy hooks array into storage
+        for (uint256 i = 0; i < p.hooks.length; ++i) {
+            hooks.push(p.hooks[i]);
+        }
 
         // phase defaults to Open (Phase(0))
 
@@ -217,6 +269,9 @@ contract Job is IJob, ReentrancyGuard, Initializable {
         agentId = _agentId;
 
         emit AgentAccepted(jobId, msg.sender, _agentId);
+
+        // Hooks (non-blocking; unapproved hooks are skipped)
+        _fireHooks(HookEvent.Accept);
     }
 
     /// @notice Submit a result URI. Transitions Active → Review.
@@ -229,6 +284,9 @@ contract Job is IJob, ReentrancyGuard, Initializable {
         resultSubmittedAt = uint64(block.timestamp);
 
         emit ResultSubmitted(jobId, msg.sender, _resultURI);
+
+        // Hooks
+        _fireHooks(HookEvent.Submit);
     }
 
     /// @notice Approve a submitted result. Transitions Review → Completed.
@@ -258,6 +316,9 @@ contract Job is IJob, ReentrancyGuard, Initializable {
         resultSubmittedAt = 0;
 
         emit ResultRejected(jobId, msg.sender, reason);
+
+        // Hooks
+        _fireHooks(HookEvent.Reject);
     }
 
     /// @notice Release budget to the agent after grace period (Direct jobs) or after
@@ -269,7 +330,7 @@ contract Job is IJob, ReentrancyGuard, Initializable {
         _completeJob();
     }
 
-    /// @notice Cancel the job. Refunds the principal.
+    /// @notice Cancel the job. Refunds the principal via Escrow.
     ///         Allowed from Open (any time) or Active/Review (principal only, before agent submits final).
     /// @param reason Human-readable reason.
     function cancel(string calldata reason) external nonReentrant {
@@ -281,12 +342,18 @@ contract Job is IJob, ReentrancyGuard, Initializable {
 
         // Effects before interaction
         phase = Phase.Cancelled;
+        uint256 refundAmt = budget;
+        budget = 0;
         emit JobCancelled(jobId, msg.sender, reason);
 
-        // Interaction
-        uint256 refund = budget;
-        budget = 0;
-        IERC20(token).safeTransfer(principal, refund);
+        // Hooks fired before escrow interaction
+        _fireHooks(HookEvent.Cancel);
+
+        // Interaction — return funds from escrow to principal
+        escrow.refund(principal, jobId, token);
+
+        // Silence unused variable warning (refundAmt recorded for event readability)
+        refundAmt;
     }
 
     /// @notice Raise a dispute. Transitions Active or Review → Disputed.
@@ -303,24 +370,27 @@ contract Job is IJob, ReentrancyGuard, Initializable {
     }
 
     /// @notice Resolve a dispute. Transitions Disputed → Completed (agent wins) or Cancelled (principal wins).
-    /// @param agentFavoured If true, releases budget to agent; if false, refunds principal.
+    /// @param agentFavoured If true, releases budget to agent via FeeSplitter; if false, refunds principal via Escrow.
     function resolveDispute(bool agentFavoured) external onlyPhase(Phase.Disputed) onlyArbiter nonReentrant {
         if (agentFavoured) {
             emit DisputeResolved(jobId, msg.sender, true);
             _completeJob();
         } else {
             phase = Phase.Cancelled;
+            budget = 0;
             emit DisputeResolved(jobId, msg.sender, false);
             emit JobCancelled(jobId, msg.sender, "dispute resolved: principal favoured");
 
-            uint256 refund = budget;
-            budget = 0;
-            IERC20(token).safeTransfer(principal, refund);
+            // Hooks
+            _fireHooks(HookEvent.Cancel);
+
+            // Interaction — return funds from escrow to principal
+            escrow.refund(principal, jobId, token);
         }
     }
 
     /// @notice Expire a job that has passed its deadline without being completed.
-    ///         Open → Cancelled (refund principal), Active → Cancelled (refund principal).
+    ///         Open → Cancelled (refund principal via Escrow), Active → Cancelled (refund principal via Escrow).
     function expireJob() external nonReentrant {
         // slither-disable-next-line timestamp
         if (block.timestamp <= deadline) revert JobNotExpired();
@@ -330,11 +400,14 @@ contract Job is IJob, ReentrancyGuard, Initializable {
         }
 
         phase = Phase.Cancelled;
+        budget = 0;
         emit JobCancelled(jobId, msg.sender, "expired");
 
-        uint256 refund = budget;
-        budget = 0;
-        IERC20(token).safeTransfer(principal, refund);
+        // Hooks
+        _fireHooks(HookEvent.Cancel);
+
+        // Interaction — return funds from escrow to principal
+        escrow.refund(principal, jobId, token);
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -351,17 +424,70 @@ contract Job is IJob, ReentrancyGuard, Initializable {
     // Internal helpers
     // ─────────────────────────────────────────────────────────────
 
-    /// @dev Finalise job: set terminal state, emit event, transfer budget to agent.
-    ///      Must be called before external token transfer (CEI).
+    /// @dev Hook lifecycle event enum used by _fireHooks.
+    enum HookEvent {
+        Accept,
+        Submit,
+        Approve,
+        Reject,
+        Cancel
+    }
+
+    /// @dev Finalise job: set terminal state, emit event, then route payment through
+    ///      Escrow.release → FeeSplitter (Schedule A: 95% agent, 3% treasury, 2% buyback).
+    ///      CEI: all state updates before external interactions.
     function _completeJob() internal {
         phase = Phase.Completed;
         uint256 payout = budget;
         budget = 0;
-        address recipient = agent;
+        address _agent = agent;
+        uint256 _jobId = jobId;
+        address _token = token;
+        address _principal = principal;
 
-        emit JobCompleted(jobId, msg.sender, payout);
+        emit JobCompleted(_jobId, msg.sender, payout);
 
-        // Interaction last
-        IERC20(token).safeTransfer(recipient, payout);
+        // Hooks fired before escrow interaction (state already updated)
+        _fireHooks(HookEvent.Approve);
+
+        // Step 1: Escrow releases the full budget to this Job clone
+        Escrow.Recipient[] memory recipients = new Escrow.Recipient[](1);
+        recipients[0] = Escrow.Recipient({to: address(this), amount: payout});
+        escrow.release(_principal, _jobId, _token, recipients);
+
+        // Step 2: Approve FeeSplitter to pull the budget from this contract
+        IERC20(_token).forceApprove(address(feeSplitter), payout);
+
+        // Step 3: FeeSplitter distributes: 95% → agent, 3% → treasury, 2% → buyback (Schedule A)
+        feeSplitter.split(_token, payout, _agent, FeeSplitter.Schedule.A);
+    }
+
+    /// @dev Fire all registered hooks for a given lifecycle event.
+    ///      Hooks that are no longer approved in HookRegistry are skipped silently.
+    ///      Any individual hook that reverts causes the entire transaction to revert
+    ///      (blocking hook behaviour).  Use try/catch in hook implementations for
+    ///      permissive behaviour.
+    /// @param ev The hook lifecycle event.
+    function _fireHooks(HookEvent ev) internal {
+        uint256 len = hooks.length;
+        if (len == 0) return;
+        HookRegistry _registry = hookRegistry;
+        uint256 _jobId = jobId;
+        bytes memory ctx = abi.encode(_jobId);
+        for (uint256 i = 0; i < len; ++i) {
+            address h = hooks[i];
+            if (!_registry.isApproved(h)) continue; // skip revoked hooks
+            if (ev == HookEvent.Accept) {
+                IHook(h).onAccept(_jobId, ctx);
+            } else if (ev == HookEvent.Submit) {
+                IHook(h).onSubmit(_jobId, ctx);
+            } else if (ev == HookEvent.Approve) {
+                IHook(h).onApprove(_jobId, ctx);
+            } else if (ev == HookEvent.Reject) {
+                IHook(h).onReject(_jobId, ctx);
+            } else {
+                IHook(h).onCancel(_jobId, ctx);
+            }
+        }
     }
 }

--- a/contracts/evm/src/acp/JobFactory.sol
+++ b/contracts/evm/src/acp/JobFactory.sol
@@ -9,10 +9,13 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {Job} from "./Job.sol";
 import {IJob} from "./IJob.sol";
 import {AgentRegistry} from "./AgentRegistry.sol";
+import {Escrow} from "./Escrow.sol";
+import {FeeSplitter} from "./FeeSplitter.sol";
+import {HookRegistry} from "./HookRegistry.sol";
 
 /// @title JobFactory
-/// @notice Deploys EIP-1167 minimal-proxy clones of the `Job` implementation and
-///         transfers the budget ERC-20 tokens into each clone before calling `initialize`.
+/// @notice Deploys EIP-1167 minimal-proxy clones of the `Job` implementation,
+///         funds escrow with the budget, and initialises each clone.
 /// @dev    Access control:
 ///           - DEFAULT_ADMIN_ROLE : set implementation address, pause/unpause.
 ///           - PAUSER_ROLE        : pause/unpause.
@@ -20,8 +23,8 @@ import {AgentRegistry} from "./AgentRegistry.sol";
 ///
 ///         Token flow:
 ///           1. Caller approves JobFactory for `budget` of `token`.
-///           2. `createJob` transfers `budget` from caller → new Job clone.
-///           3. Job clone is initialised; budget is locked inside the clone.
+///           2. `createJob` transfers `budget` from caller → Escrow (via Escrow.fund).
+///           3. Job clone is initialised; escrow balance tracked under (principal, jobId, token).
 contract JobFactory is AccessControl, Pausable {
     using SafeERC20 for IERC20;
     using Clones for address;
@@ -41,6 +44,15 @@ contract JobFactory is AccessControl, Pausable {
 
     /// @notice AgentRegistry used to validate agent IDs at job creation time.
     AgentRegistry public immutable registry;
+
+    /// @notice Escrow contract that holds job budgets.
+    Escrow public immutable escrow;
+
+    /// @notice FeeSplitter that distributes payments on job completion.
+    FeeSplitter public immutable feeSplitter;
+
+    /// @notice HookRegistry used by Job clones to validate hooks.
+    HookRegistry public immutable hookRegistry;
 
     /// @notice Default arbiter for dispute resolution (configurable by admin).
     address public defaultArbiter;
@@ -90,15 +102,32 @@ contract JobFactory is AccessControl, Pausable {
     /// @param _jobImpl        Initial Job implementation for cloning.
     /// @param _registry       AgentRegistry reference.
     /// @param _defaultArbiter Default arbiter for all created jobs.
-    constructor(address admin, address _jobImpl, AgentRegistry _registry, address _defaultArbiter) {
+    /// @param _escrow         Escrow contract that will hold job budgets.
+    /// @param _feeSplitter    FeeSplitter that distributes payments.
+    /// @param _hookRegistry   HookRegistry for hook validation.
+    constructor(
+        address admin,
+        address _jobImpl,
+        AgentRegistry _registry,
+        address _defaultArbiter,
+        Escrow _escrow,
+        FeeSplitter _feeSplitter,
+        HookRegistry _hookRegistry
+    ) {
         if (admin == address(0)) revert ZeroAddress();
         if (_jobImpl == address(0)) revert ZeroAddress();
         if (address(_registry) == address(0)) revert ZeroAddress();
         if (_defaultArbiter == address(0)) revert ZeroAddress();
+        if (address(_escrow) == address(0)) revert ZeroAddress();
+        if (address(_feeSplitter) == address(0)) revert ZeroAddress();
+        if (address(_hookRegistry) == address(0)) revert ZeroAddress();
 
         jobImplementation = _jobImpl;
         registry = _registry;
         defaultArbiter = _defaultArbiter;
+        escrow = _escrow;
+        feeSplitter = _feeSplitter;
+        hookRegistry = _hookRegistry;
 
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(PAUSER_ROLE, admin);
@@ -108,15 +137,19 @@ contract JobFactory is AccessControl, Pausable {
     // Job creation
     // ─────────────────────────────────────────────────────────────
 
-    /// @notice Create a new Job clone, transfer the budget into it, and initialise it.
+    /// @notice Create a new Job clone, fund escrow with the budget, and initialise the clone.
     /// @dev    Caller must have pre-approved this contract for `budget` of `token`.
+    ///         The factory must hold RELEASER_ROLE on Escrow (granted during deployment)
+    ///         so that Job clones it produces can call Escrow.release / Escrow.refund.
+    ///         In practice the factory grants each clone RELEASER_ROLE after deploy.
     /// @param  targetAgentId Agent registry ID to target (0 = open to any active agent).
     /// @param  token         ERC-20 token address for payment.
-    /// @param  budget        Amount to lock into the escrow.
+    /// @param  budget        Amount to lock into Escrow.
     /// @param  deadline      UNIX timestamp after which the job may be expired.
     /// @param  jobType       Direct (no evaluator) or Evaluated.
     /// @param  evaluator     Evaluator address; must be non-zero iff jobType == Evaluated.
     /// @param  arbiter       Arbiter override; if address(0), uses defaultArbiter.
+    /// @param  jobHooks      Optional list of hook addresses; each must be approved in HookRegistry.
     /// @return jobId         The monotonic ID assigned to this job.
     /// @return clone         The address of the deployed Job clone.
     function createJob(
@@ -126,7 +159,8 @@ contract JobFactory is AccessControl, Pausable {
         uint64 deadline,
         IJob.JobType jobType,
         address evaluator,
-        address arbiter
+        address arbiter,
+        address[] calldata jobHooks
     ) external whenNotPaused returns (uint256 jobId, address clone) {
         if (token == address(0)) revert ZeroAddress();
         if (budget == 0) revert ZeroAmount();
@@ -144,8 +178,16 @@ contract JobFactory is AccessControl, Pausable {
         // Emit before external calls (satisfies CEI for event ordering)
         emit JobCreated(jobId, clone, msg.sender, jobType, token, budget);
 
-        // Transfer budget from principal → clone before initialise
-        IERC20(token).safeTransferFrom(msg.sender, clone, budget);
+        // Transfer budget from principal → Escrow; tracked under (principal, jobId, token)
+        IERC20(token).safeTransferFrom(msg.sender, address(this), budget);
+        IERC20(token).forceApprove(address(escrow), budget);
+        escrow.fund(msg.sender, jobId, token, budget);
+
+        // Grant the clone RELEASER_ROLE so it can call escrow.release / escrow.refund
+        escrow.grantRole(escrow.RELEASER_ROLE(), clone);
+
+        // Grant the clone CALLER_ROLE on FeeSplitter so it can call feeSplitter.split
+        feeSplitter.grantRole(feeSplitter.CALLER_ROLE(), clone);
 
         // Initialise the clone
         Job.InitParams memory p = Job.InitParams({
@@ -158,7 +200,11 @@ contract JobFactory is AccessControl, Pausable {
             deadline: deadline,
             jobType: jobType,
             evaluator: evaluator,
-            arbiter: resolvedArbiter
+            arbiter: resolvedArbiter,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: jobHooks
         });
         Job(clone).initialize(p);
     }

--- a/contracts/evm/test/acp/BuybackBurner.t.sol
+++ b/contracts/evm/test/acp/BuybackBurner.t.sol
@@ -63,7 +63,7 @@ contract BuybackBurnerTest is Test {
     address internal executor = makeAddr("executor");
     address internal stranger = makeAddr("stranger");
 
-    // FIXED_OUTPUT must be >= floor = AMOUNT_IN * minOutBps / 10000 = 1000e18 * 9000 / 10000 = 900e18
+    // FIXED_OUTPUT must be >= minTituOut floor (set to 900e18 = 90% of AMOUNT_IN in TITU terms)
     uint256 internal constant FIXED_OUTPUT = 950e18;
     uint256 internal constant AMOUNT_IN = 1000e18;
 
@@ -84,7 +84,7 @@ contract BuybackBurnerTest is Test {
             address(payment),
             address(titu),
             path,
-            9000, // 90% min out floor
+            900e18, // minTituOut floor: 900 TITU (absolute, not BPS)
             300 // 5 min swap deadline
         );
 
@@ -105,7 +105,7 @@ contract BuybackBurnerTest is Test {
         assertEq(address(burner.router()), address(router));
         assertEq(burner.paymentToken(), address(payment));
         assertEq(address(burner.titu()), address(titu));
-        assertEq(burner.minOutBps(), 9000);
+        assertEq(burner.minTituOut(), 900e18);
         assertEq(burner.swapDeadlineBuffer(), 300);
         address[] memory path = burner.getSwapPath();
         assertEq(path[0], address(payment));
@@ -120,12 +120,16 @@ contract BuybackBurnerTest is Test {
         new BuybackBurner(address(0), address(router), address(payment), address(titu), path, 9000, 300);
     }
 
-    function test_constructor_revert_invalidBps() public {
+    /// @notice `InvalidBps` was removed; any uint256 is a valid minTituOut now.
+    ///         Verify that a large minTituOut value does not revert during construction.
+    function test_constructor_largeMinTituOut_doesNotRevert() public {
         address[] memory path = new address[](2);
         path[0] = address(payment);
         path[1] = address(titu);
-        vm.expectRevert(BuybackBurner.InvalidBps.selector);
-        new BuybackBurner(admin, address(router), address(payment), address(titu), path, 10_001, 300);
+        // Should NOT revert — minTituOut has no upper bound
+        BuybackBurner b =
+            new BuybackBurner(admin, address(router), address(payment), address(titu), path, type(uint256).max, 300);
+        assertEq(b.minTituOut(), type(uint256).max);
     }
 
     function test_constructor_revert_invalidPath_tooShort() public {
@@ -235,19 +239,43 @@ contract BuybackBurnerTest is Test {
     }
 
     // ─────────────────────────────────────────────────────────────
-    // Admin: setMinOutBps
+    // Admin: setMinTituOut
     // ─────────────────────────────────────────────────────────────
 
-    function test_setMinOutBps() public {
+    function test_setMinTituOut() public {
         vm.prank(admin);
-        burner.setMinOutBps(8500);
-        assertEq(burner.minOutBps(), 8500);
+        burner.setMinTituOut(850e18);
+        assertEq(burner.minTituOut(), 850e18);
     }
 
-    function test_setMinOutBps_revert_tooHigh() public {
-        vm.expectRevert(BuybackBurner.InvalidBps.selector);
+    function test_setMinTituOut_zero_disablesFloor() public {
         vm.prank(admin);
-        burner.setMinOutBps(10_001);
+        burner.setMinTituOut(0);
+        assertEq(burner.minTituOut(), 0);
+    }
+
+    function test_setMinTituOut_revert_notAdmin() public {
+        vm.expectRevert();
+        vm.prank(stranger);
+        burner.setMinTituOut(100e18);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // rescueTokens: paymentToken blocked
+    // ─────────────────────────────────────────────────────────────
+
+    function test_rescueTokens_revert_paymentToken() public {
+        vm.expectRevert(BuybackBurner.RescuePaymentTokenForbidden.selector);
+        vm.prank(admin);
+        burner.rescueTokens(address(payment), admin, 1);
+    }
+
+    function test_rescueTokens_allowsOtherToken() public {
+        MockTITU other = new MockTITU();
+        other.mint(address(burner), 100e18);
+        vm.prank(admin);
+        burner.rescueTokens(address(other), admin, 100e18);
+        assertEq(other.balanceOf(admin), 100e18);
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -257,12 +285,12 @@ contract BuybackBurnerTest is Test {
     function testFuzz_buybackAndBurn_variousAmounts(uint256 amountIn) public {
         amountIn = bound(amountIn, 1, type(uint128).max);
 
-        // Deploy a burner with minOutBps=0 (no floor) so the fixed-output mock always passes
+        // Deploy a burner with minTituOut=0 (no floor) so the fixed-output mock always passes
         address[] memory path = new address[](2);
         path[0] = address(payment);
         path[1] = address(titu);
         BuybackBurner fuzzBurner =
-            new BuybackBurner(admin, address(router), address(payment), address(titu), path, 0, 300);
+            new BuybackBurner(admin, address(router), address(payment), address(titu), path, 0, 300); // minTituOut=0
         bytes32 executorRole = fuzzBurner.EXECUTOR_ROLE();
         vm.prank(admin);
         fuzzBurner.grantRole(executorRole, executor);

--- a/contracts/evm/test/acp/EscrowPermit2.t.sol
+++ b/contracts/evm/test/acp/EscrowPermit2.t.sol
@@ -23,6 +23,17 @@ contract MockPermit2 {
     ) external {
         ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
     }
+
+    function permitWitnessTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes32,
+        string calldata,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
 }
 
 contract EscrowPermit2Test is Test {
@@ -103,6 +114,43 @@ contract EscrowPermit2Test is Test {
     function test_fundWithPermit2_constructor_revert_zeroPermit2() public {
         vm.expectRevert(Escrow.ZeroAddress.selector);
         new Escrow(admin, address(0));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Cross-token drain protection (#56)
+    // ─────────────────────────────────────────────────────────────
+
+    /// @notice Proves that a depositor cannot drain token Y by providing a permit for token X.
+    ///         The `permit.permitted.token` must match the `token` argument exactly.
+    function test_fundWithPermit2_revert_tokenMismatch() public {
+        MockToken otherToken = new MockToken();
+        // Permit is for `otherToken` but caller passes `token` as the target
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({token: address(otherToken), amount: AMOUNT}),
+            nonce: 0,
+            deadline: block.timestamp + 1 hours
+        });
+        vm.expectRevert(
+            abi.encodeWithSelector(Escrow.Permit2TokenMismatch.selector, address(otherToken), address(token))
+        );
+        escrow.fundWithPermit2(depositor, JOB_ID, address(token), AMOUNT, permit, hex"1234");
+    }
+
+    /// @notice Proves that amount in permit must match the requested amount.
+    function test_fundWithPermit2_revert_amountMismatch() public {
+        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
+            permitted: IPermit2.TokenPermissions({token: address(token), amount: AMOUNT / 2}),
+            nonce: 0,
+            deadline: block.timestamp + 1 hours
+        });
+        vm.expectRevert(abi.encodeWithSelector(Escrow.Permit2AmountMismatch.selector, AMOUNT / 2, AMOUNT));
+        escrow.fundWithPermit2(depositor, JOB_ID, address(token), AMOUNT, permit, hex"1234");
+    }
+
+    /// @notice Proves the witness type constants are correctly set.
+    function test_witnessTypeHash_isCorrect() public view {
+        bytes32 expected = keccak256(bytes(escrow.ESCROW_WITNESS_TYPE()));
+        assertEq(escrow.ESCROW_WITNESS_TYPEHASH(), expected);
     }
 
     /// @notice Standard fund() still works after Permit2 constructor change.

--- a/contracts/evm/test/acp/Job.t.sol
+++ b/contracts/evm/test/acp/Job.t.sol
@@ -3,9 +3,16 @@ pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {Job} from "../../src/acp/Job.sol";
 import {IJob} from "../../src/acp/IJob.sol";
 import {AgentRegistry} from "../../src/acp/AgentRegistry.sol";
+import {Escrow} from "../../src/acp/Escrow.sol";
+import {FeeSplitter} from "../../src/acp/FeeSplitter.sol";
+import {HookRegistry} from "../../src/acp/HookRegistry.sol";
+import {BuybackBurner} from "../../src/acp/BuybackBurner.sol";
+import {IPermit2} from "../../src/acp/IPermit2.sol";
 
 /// @dev Minimal ERC-20 mock for testing.
 contract MockERC20 is ERC20 {
@@ -16,9 +23,68 @@ contract MockERC20 is ERC20 {
     }
 }
 
+contract MockTITU is ERC20Burnable {
+    constructor() ERC20("TITU", "TITU") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @dev Minimal Permit2 mock (not needed for Job tests, just for Escrow init).
+contract MockPermit2 {
+    function permitTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+
+    function permitWitnessTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes32,
+        string calldata,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+}
+
+/// @dev Mock UniV2 router: mints TITU to recipient to simulate a swap.
+contract MockUniRouter {
+    MockTITU public titu;
+
+    constructor(MockTITU _titu) {
+        titu = _titu;
+    }
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256,
+        address[] calldata path,
+        address to,
+        uint256
+    ) external {
+        ERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
+        titu.mint(to, amountIn); // 1:1 for test simplicity
+    }
+}
+
 contract JobTest is Test {
     AgentRegistry internal registry;
     MockERC20 internal token;
+    MockTITU internal titu;
+    MockPermit2 internal mockPermit2;
+    MockUniRouter internal uniRouter;
+    Job internal jobImpl;
+    Escrow internal escrow;
+    FeeSplitter internal feeSplitter;
+    BuybackBurner internal buybackBurner;
+    HookRegistry internal hookRegistry;
 
     address internal admin = makeAddr("admin");
     address internal scorer = makeAddr("scorer");
@@ -26,12 +92,14 @@ contract JobTest is Test {
     address internal agentCtrl = makeAddr("agentCtrl");
     address internal evaluatorAddr = makeAddr("evaluator");
     address internal arbiterAddr = makeAddr("arbiter");
+    address internal treasury = makeAddr("treasury");
     address internal stranger = makeAddr("stranger");
 
     uint256 internal agentId0;
 
     uint256 internal constant BUDGET = 1000e18;
     uint64 internal constant DEADLINE_DELTA = 7 days;
+    uint256 internal constant JOB_ID = 1;
 
     // ─────────────────────────────────────────────────────────────
     // Helpers
@@ -47,11 +115,48 @@ contract JobTest is Test {
         agentId0 = registry.register(agentCtrl, "ipfs://QmAgent", 0x1);
     }
 
+    bytes32 internal releaserRole;
+    bytes32 internal callerRole;
+
+    function _deploySupporting() internal {
+        titu = new MockTITU();
+        mockPermit2 = new MockPermit2();
+        uniRouter = new MockUniRouter(titu);
+
+        escrow = new Escrow(admin, address(mockPermit2));
+        address[] memory swapPath = new address[](2);
+        swapPath[0] = address(token);
+        swapPath[1] = address(titu);
+        buybackBurner = new BuybackBurner(admin, address(uniRouter), address(token), address(titu), swapPath, 0, 300);
+        feeSplitter = new FeeSplitter(admin, treasury, address(buybackBurner));
+        hookRegistry = new HookRegistry(admin);
+        jobImpl = new Job();
+
+        // Cache role bytes32 values (avoid consuming vm.prank with staticcalls)
+        releaserRole = escrow.RELEASER_ROLE();
+        callerRole = feeSplitter.CALLER_ROLE();
+    }
+
+    /// @dev Creates a Job clone, funds escrow, and initializes the clone.
     function _newJob(IJob.JobType jType, address _evaluator) internal returns (Job j) {
-        j = new Job();
-        token.mint(address(j), BUDGET);
+        j = Job(Clones.clone(address(jobImpl)));
+
+        // Fund escrow for this job (principal sends tokens to escrow)
+        token.mint(principal, BUDGET);
+        vm.prank(principal);
+        token.approve(address(escrow), BUDGET);
+        vm.prank(principal);
+        escrow.fund(principal, JOB_ID, address(token), BUDGET);
+
+        // Grant the clone RELEASER_ROLE and FeeSplitter CALLER_ROLE
+        vm.prank(admin);
+        escrow.grantRole(releaserRole, address(j));
+        vm.prank(admin);
+        feeSplitter.grantRole(callerRole, address(j));
+
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
-            jobId: 1,
+            jobId: JOB_ID,
             principal: principal,
             registry: registry,
             targetAgentId: 0,
@@ -60,7 +165,11 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + DEADLINE_DELTA),
             jobType: jType,
             evaluator: _evaluator,
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         j.initialize(p);
     }
@@ -68,6 +177,7 @@ contract JobTest is Test {
     function setUp() public {
         _deployRegistry();
         token = new MockERC20();
+        _deploySupporting();
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -88,9 +198,32 @@ contract JobTest is Test {
         assertEq(j.evaluator(), evaluatorAddr);
     }
 
+    function test_initialize_revert_disabledOnImpl() public {
+        // The implementation itself should reject initialize()
+        address[] memory hooks = new address[](0);
+        Job.InitParams memory p = Job.InitParams({
+            jobId: 1,
+            principal: principal,
+            registry: registry,
+            targetAgentId: 0,
+            token: address(token),
+            budget: BUDGET,
+            deadline: uint64(block.timestamp + DEADLINE_DELTA),
+            jobType: IJob.JobType.Direct,
+            evaluator: address(0),
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
+        });
+        vm.expectRevert();
+        jobImpl.initialize(p);
+    }
+
     function test_initialize_revert_zeroPrincipal() public {
-        Job j = new Job();
-        token.mint(address(j), BUDGET);
+        Job j = Job(Clones.clone(address(jobImpl)));
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
             jobId: 1,
             principal: address(0),
@@ -101,14 +234,19 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + DEADLINE_DELTA),
             jobType: IJob.JobType.Direct,
             evaluator: address(0),
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         vm.expectRevert(Job.ZeroAddress.selector);
         j.initialize(p);
     }
 
     function test_initialize_revert_zeroToken() public {
-        Job j = new Job();
+        Job j = Job(Clones.clone(address(jobImpl)));
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
             jobId: 1,
             principal: principal,
@@ -119,14 +257,19 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + DEADLINE_DELTA),
             jobType: IJob.JobType.Direct,
             evaluator: address(0),
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         vm.expectRevert(Job.ZeroAddress.selector);
         j.initialize(p);
     }
 
     function test_initialize_revert_zeroBudget() public {
-        Job j = new Job();
+        Job j = Job(Clones.clone(address(jobImpl)));
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
             jobId: 1,
             principal: principal,
@@ -137,15 +280,19 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + DEADLINE_DELTA),
             jobType: IJob.JobType.Direct,
             evaluator: address(0),
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         vm.expectRevert(Job.ZeroAmount.selector);
         j.initialize(p);
     }
 
     function test_initialize_revert_pastDeadline() public {
-        Job j = new Job();
-        token.mint(address(j), BUDGET);
+        Job j = Job(Clones.clone(address(jobImpl)));
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
             jobId: 1,
             principal: principal,
@@ -156,15 +303,19 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp - 1),
             jobType: IJob.JobType.Direct,
             evaluator: address(0),
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         vm.expectRevert(Job.InvalidDeadline.selector);
         j.initialize(p);
     }
 
     function test_initialize_revert_evaluatedWithoutEvaluator() public {
-        Job j = new Job();
-        token.mint(address(j), BUDGET);
+        Job j = Job(Clones.clone(address(jobImpl)));
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
             jobId: 1,
             principal: principal,
@@ -175,15 +326,19 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + DEADLINE_DELTA),
             jobType: IJob.JobType.Evaluated,
             evaluator: address(0),
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         vm.expectRevert(Job.EvaluatorRequired.selector);
         j.initialize(p);
     }
 
     function test_initialize_revert_directWithEvaluator() public {
-        Job j = new Job();
-        token.mint(address(j), BUDGET);
+        Job j = Job(Clones.clone(address(jobImpl)));
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
             jobId: 1,
             principal: principal,
@@ -194,7 +349,11 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + DEADLINE_DELTA),
             jobType: IJob.JobType.Direct,
             evaluator: evaluatorAddr,
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         vm.expectRevert(Job.DirectJobNoEvaluator.selector);
         j.initialize(p);
@@ -202,6 +361,7 @@ contract JobTest is Test {
 
     function test_initialize_revert_doubleInit() public {
         Job j = _newJob(IJob.JobType.Direct, address(0));
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
             jobId: 2,
             principal: principal,
@@ -212,7 +372,11 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + DEADLINE_DELTA),
             jobType: IJob.JobType.Direct,
             evaluator: address(0),
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         vm.expectRevert();
         j.initialize(p);
@@ -262,11 +426,22 @@ contract JobTest is Test {
         vm.prank(stranger);
         uint256 agentId1 = registry.register(stranger, "ipfs://QmOther", 0x2);
 
+        // Fund escrow for this specific job
+        token.mint(principal, BUDGET);
+        vm.prank(principal);
+        token.approve(address(escrow), BUDGET);
+        vm.prank(principal);
+        escrow.fund(principal, 99, address(token), BUDGET);
+
         // Job targeted at agentId1
-        Job j = new Job();
-        token.mint(address(j), BUDGET);
+        Job j = Job(Clones.clone(address(jobImpl)));
+        vm.prank(admin);
+        escrow.grantRole(releaserRole, address(j));
+        vm.prank(admin);
+        feeSplitter.grantRole(callerRole, address(j));
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
-            jobId: 1,
+            jobId: 99,
             principal: principal,
             registry: registry,
             targetAgentId: agentId1,
@@ -275,7 +450,11 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + DEADLINE_DELTA),
             jobType: IJob.JobType.Direct,
             evaluator: address(0),
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         j.initialize(p);
 
@@ -303,7 +482,10 @@ contract JobTest is Test {
         j.approveResult();
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
         assertEq(j.budget(), 0);
-        assertEq(token.balanceOf(agentCtrl), BUDGET);
+
+        // Agent receives 95% (Schedule A)
+        uint256 expectedAgent = (BUDGET * 9500) / 10_000;
+        assertGe(token.balanceOf(agentCtrl), expectedAgent);
     }
 
     function test_directJob_release_afterGrace() public {
@@ -337,7 +519,9 @@ contract JobTest is Test {
         vm.prank(evaluatorAddr);
         j.approveResult();
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
-        assertEq(token.balanceOf(agentCtrl), BUDGET);
+
+        // Agent receives 95%
+        assertGe(token.balanceOf(agentCtrl), (BUDGET * 9500) / 10_000);
     }
 
     function test_evaluatedJob_reject_resubmit() public {
@@ -390,20 +574,23 @@ contract JobTest is Test {
 
     function test_cancel_fromOpen() public {
         Job j = _newJob(IJob.JobType.Direct, address(0));
+        uint256 principalBefore = token.balanceOf(principal);
         vm.prank(principal);
         j.cancel("changed mind");
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Cancelled));
-        assertEq(token.balanceOf(principal), BUDGET);
+        // Principal is refunded via escrow
+        assertEq(token.balanceOf(principal), principalBefore + BUDGET);
     }
 
     function test_cancel_fromActive() public {
         Job j = _newJob(IJob.JobType.Direct, address(0));
         vm.prank(agentCtrl);
         j.accept(agentId0);
+        uint256 principalBefore = token.balanceOf(principal);
         vm.prank(principal);
         j.cancel("urgent");
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Cancelled));
-        assertEq(token.balanceOf(principal), BUDGET);
+        assertEq(token.balanceOf(principal), principalBefore + BUDGET);
     }
 
     function test_cancel_revert_notPrincipal() public {
@@ -443,7 +630,8 @@ contract JobTest is Test {
         vm.prank(arbiterAddr);
         j.resolveDispute(true);
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
-        assertEq(token.balanceOf(agentCtrl), BUDGET);
+        // Agent receives 95%
+        assertGe(token.balanceOf(agentCtrl), (BUDGET * 9500) / 10_000);
     }
 
     function test_dispute_principalFavoured() public {
@@ -451,13 +639,14 @@ contract JobTest is Test {
         vm.prank(agentCtrl);
         j.accept(agentId0);
 
+        uint256 principalBefore = token.balanceOf(principal);
         vm.prank(agentCtrl);
         j.raiseDispute();
 
         vm.prank(arbiterAddr);
         j.resolveDispute(false);
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Cancelled));
-        assertEq(token.balanceOf(principal), BUDGET);
+        assertEq(token.balanceOf(principal), principalBefore + BUDGET);
     }
 
     function test_dispute_revert_notArbiter() public {
@@ -498,10 +687,11 @@ contract JobTest is Test {
 
     function test_expireJob_fromOpen() public {
         Job j = _newJob(IJob.JobType.Direct, address(0));
+        uint256 principalBefore = token.balanceOf(principal);
         vm.warp(block.timestamp + DEADLINE_DELTA + 1);
         j.expireJob();
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Cancelled));
-        assertEq(token.balanceOf(principal), BUDGET);
+        assertEq(token.balanceOf(principal), principalBefore + BUDGET);
     }
 
     function test_expireJob_fromActive() public {
@@ -561,8 +751,20 @@ contract JobTest is Test {
     function testFuzz_directJob_fullLifecycle(uint256 budgetAmount) public {
         budgetAmount = bound(budgetAmount, 1, type(uint128).max);
 
-        Job j = new Job();
-        token.mint(address(j), budgetAmount);
+        Job j = Job(Clones.clone(address(jobImpl)));
+
+        token.mint(principal, budgetAmount);
+        vm.prank(principal);
+        token.approve(address(escrow), budgetAmount);
+        vm.prank(principal);
+        escrow.fund(principal, 99, address(token), budgetAmount);
+
+        vm.prank(admin);
+        escrow.grantRole(releaserRole, address(j));
+        vm.prank(admin);
+        feeSplitter.grantRole(callerRole, address(j));
+
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
             jobId: 99,
             principal: principal,
@@ -573,7 +775,11 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + 1 days),
             jobType: IJob.JobType.Direct,
             evaluator: address(0),
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         j.initialize(p);
 
@@ -584,17 +790,30 @@ contract JobTest is Test {
         vm.prank(principal);
         j.approveResult();
 
-        assertEq(token.balanceOf(agentCtrl), budgetAmount);
+        // Agent gets >= 95%
+        assertGe(token.balanceOf(agentCtrl), (budgetAmount * 9500) / 10_000);
         assertEq(j.budget(), 0);
     }
 
     function testFuzz_cancel_refundsPrincipal(uint256 budgetAmount) public {
         budgetAmount = bound(budgetAmount, 1, type(uint128).max);
 
-        Job j = new Job();
-        token.mint(address(j), budgetAmount);
+        Job j = Job(Clones.clone(address(jobImpl)));
+
+        token.mint(principal, budgetAmount);
+        vm.prank(principal);
+        token.approve(address(escrow), budgetAmount);
+        vm.prank(principal);
+        escrow.fund(principal, 98, address(token), budgetAmount);
+
+        vm.prank(admin);
+        escrow.grantRole(releaserRole, address(j));
+        vm.prank(admin);
+        feeSplitter.grantRole(callerRole, address(j));
+
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
-            jobId: 99,
+            jobId: 98,
             principal: principal,
             registry: registry,
             targetAgentId: 0,
@@ -603,12 +822,17 @@ contract JobTest is Test {
             deadline: uint64(block.timestamp + 1 days),
             jobType: IJob.JobType.Direct,
             evaluator: address(0),
-            arbiter: arbiterAddr
+            arbiter: arbiterAddr,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         j.initialize(p);
 
+        uint256 principalBefore = token.balanceOf(principal);
         vm.prank(principal);
         j.cancel("fuzz cancel");
-        assertEq(token.balanceOf(principal), budgetAmount);
+        assertEq(token.balanceOf(principal), principalBefore + budgetAmount);
     }
 }

--- a/contracts/evm/test/acp/JobFactory.t.sol
+++ b/contracts/evm/test/acp/JobFactory.t.sol
@@ -3,10 +3,16 @@ pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import {JobFactory} from "../../src/acp/JobFactory.sol";
 import {Job} from "../../src/acp/Job.sol";
 import {IJob} from "../../src/acp/IJob.sol";
 import {AgentRegistry} from "../../src/acp/AgentRegistry.sol";
+import {Escrow} from "../../src/acp/Escrow.sol";
+import {FeeSplitter} from "../../src/acp/FeeSplitter.sol";
+import {HookRegistry} from "../../src/acp/HookRegistry.sol";
+import {IPermit2} from "../../src/acp/IPermit2.sol";
+import {BuybackBurner} from "../../src/acp/BuybackBurner.sol";
 
 contract MockERC20 is ERC20 {
     constructor() ERC20("Mock", "MCK") {}
@@ -16,10 +22,69 @@ contract MockERC20 is ERC20 {
     }
 }
 
+contract MockTITU is ERC20Burnable {
+    constructor() ERC20("TITU", "TITU") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @dev Minimal Permit2 mock (not actually used by factory tests, just for Escrow init).
+contract MockPermit2 {
+    function permitTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+
+    function permitWitnessTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes32,
+        string calldata,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+}
+
+/// @dev Mock UniV2 router: mints TITU to recipient to simulate a swap.
+contract MockUniRouter {
+    MockTITU public titu;
+
+    constructor(MockTITU _titu) {
+        titu = _titu;
+    }
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256
+    ) external {
+        ERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
+        require(amountOutMin == 0 || amountIn >= amountOutMin, "slippage");
+        titu.mint(to, amountIn); // 1:1 for test simplicity
+    }
+}
+
 contract JobFactoryTest is Test {
     AgentRegistry internal registry;
     MockERC20 internal token;
+    MockTITU internal titu;
+    MockPermit2 internal mockPermit2;
+    MockUniRouter internal uniRouter;
     Job internal jobImpl;
+    Escrow internal escrow;
+    FeeSplitter internal feeSplitter;
+    BuybackBurner internal buybackBurner;
+    HookRegistry internal hookRegistry;
     JobFactory internal factory;
 
     address internal admin = makeAddr("admin");
@@ -27,6 +92,7 @@ contract JobFactoryTest is Test {
     address internal principal = makeAddr("principal");
     address internal agentCtrl = makeAddr("agentCtrl");
     address internal evaluator = makeAddr("evaluator");
+    address internal treasury = makeAddr("treasury");
     address internal stranger = makeAddr("stranger");
 
     uint256 internal agentId0;
@@ -46,6 +112,11 @@ contract JobFactoryTest is Test {
     event ImplementationUpdated(address indexed oldImpl, address indexed newImpl);
     event DefaultArbiterUpdated(address indexed oldArbiter, address indexed newArbiter);
 
+    /// @dev Returns an empty hooks array for convenience.
+    function _noHooks() internal pure returns (address[] memory h) {
+        h = new address[](0);
+    }
+
     function setUp() public {
         // Deploy registry + agent
         registry = new AgentRegistry(admin);
@@ -53,8 +124,29 @@ contract JobFactoryTest is Test {
         agentId0 = registry.register(agentCtrl, "ipfs://QmAgent", 0x1);
 
         token = new MockERC20();
+        titu = new MockTITU();
+        mockPermit2 = new MockPermit2();
+        uniRouter = new MockUniRouter(titu);
+
+        // Deploy supporting contracts
+        escrow = new Escrow(admin, address(mockPermit2));
+        address[] memory swapPath = new address[](2);
+        swapPath[0] = address(token);
+        swapPath[1] = address(titu);
+        buybackBurner = new BuybackBurner(admin, address(uniRouter), address(token), address(titu), swapPath, 0, 300);
+        feeSplitter = new FeeSplitter(admin, treasury, address(buybackBurner));
+        hookRegistry = new HookRegistry(admin);
+
         jobImpl = new Job();
-        factory = new JobFactory(admin, address(jobImpl), registry, arbiter);
+        factory = new JobFactory(admin, address(jobImpl), registry, arbiter, escrow, feeSplitter, hookRegistry);
+
+        // Grant factory DEFAULT_ADMIN_ROLE on Escrow + FeeSplitter (so it can grant roles to clones)
+        bytes32 adminRole = escrow.DEFAULT_ADMIN_ROLE();
+        vm.prank(admin);
+        escrow.grantRole(adminRole, address(factory));
+        bytes32 splitterAdminRole = feeSplitter.DEFAULT_ADMIN_ROLE();
+        vm.prank(admin);
+        feeSplitter.grantRole(splitterAdminRole, address(factory));
 
         // Mint + approve tokens for principal
         token.mint(principal, BUDGET * 10);
@@ -70,21 +162,39 @@ contract JobFactoryTest is Test {
         assertEq(factory.jobImplementation(), address(jobImpl));
         assertEq(address(factory.registry()), address(registry));
         assertEq(factory.defaultArbiter(), arbiter);
+        assertEq(address(factory.escrow()), address(escrow));
+        assertEq(address(factory.feeSplitter()), address(feeSplitter));
+        assertEq(address(factory.hookRegistry()), address(hookRegistry));
     }
 
     function test_constructor_revert_zeroAdmin() public {
         vm.expectRevert(JobFactory.ZeroAddress.selector);
-        new JobFactory(address(0), address(jobImpl), registry, arbiter);
+        new JobFactory(address(0), address(jobImpl), registry, arbiter, escrow, feeSplitter, hookRegistry);
     }
 
     function test_constructor_revert_zeroImpl() public {
         vm.expectRevert(JobFactory.ZeroAddress.selector);
-        new JobFactory(admin, address(0), registry, arbiter);
+        new JobFactory(admin, address(0), registry, arbiter, escrow, feeSplitter, hookRegistry);
     }
 
     function test_constructor_revert_zeroArbiter() public {
         vm.expectRevert(JobFactory.ZeroAddress.selector);
-        new JobFactory(admin, address(jobImpl), registry, address(0));
+        new JobFactory(admin, address(jobImpl), registry, address(0), escrow, feeSplitter, hookRegistry);
+    }
+
+    function test_constructor_revert_zeroEscrow() public {
+        vm.expectRevert(JobFactory.ZeroAddress.selector);
+        new JobFactory(admin, address(jobImpl), registry, arbiter, Escrow(address(0)), feeSplitter, hookRegistry);
+    }
+
+    function test_constructor_revert_zeroFeeSplitter() public {
+        vm.expectRevert(JobFactory.ZeroAddress.selector);
+        new JobFactory(admin, address(jobImpl), registry, arbiter, escrow, FeeSplitter(address(0)), hookRegistry);
+    }
+
+    function test_constructor_revert_zeroHookRegistry() public {
+        vm.expectRevert(JobFactory.ZeroAddress.selector);
+        new JobFactory(admin, address(jobImpl), registry, arbiter, escrow, feeSplitter, HookRegistry(address(0)));
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -103,14 +213,18 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
 
         assertEq(jobId, 0);
         assertNotEq(clone, address(0));
         assertEq(factory.getJob(jobId), clone);
         assertEq(factory.totalJobs(), 1);
-        assertEq(token.balanceOf(clone), BUDGET);
+
+        // Budget is now in escrow, not in the clone
+        assertEq(escrow.getBalance(principal, jobId, address(token)), BUDGET);
+        assertEq(token.balanceOf(clone), 0);
 
         Job j = Job(clone);
         assertEq(j.principal(), principal);
@@ -128,7 +242,8 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Evaluated,
             evaluator,
-            address(0)
+            address(0),
+            _noHooks()
         );
         Job j = Job(clone);
         assertEq(j.evaluator(), evaluator);
@@ -145,7 +260,8 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
         assertEq(Job(clone).arbiter(), arbiter);
     }
@@ -160,7 +276,8 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            customArbiter
+            customArbiter,
+            _noHooks()
         );
         assertEq(Job(clone).arbiter(), customArbiter);
     }
@@ -174,7 +291,8 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
         vm.prank(principal);
         (uint256 id1,) = factory.createJob(
@@ -184,7 +302,8 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
         assertEq(id0, 0);
         assertEq(id1, 1);
@@ -201,7 +320,8 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
         uint256[] memory ids = factory.jobsByPrincipal(principal);
         assertEq(ids.length, 1);
@@ -216,7 +336,14 @@ contract JobFactoryTest is Test {
         vm.expectRevert(JobFactory.ZeroAddress.selector);
         vm.prank(principal);
         factory.createJob(
-            0, address(0), BUDGET, uint64(block.timestamp + DEADLINE_DELTA), IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(0),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            _noHooks()
         );
     }
 
@@ -224,7 +351,14 @@ contract JobFactoryTest is Test {
         vm.expectRevert(JobFactory.ZeroAmount.selector);
         vm.prank(principal);
         factory.createJob(
-            0, address(token), 0, uint64(block.timestamp + DEADLINE_DELTA), IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            0,
+            uint64(block.timestamp + DEADLINE_DELTA),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            _noHooks()
         );
     }
 
@@ -232,7 +366,14 @@ contract JobFactoryTest is Test {
         vm.expectRevert(JobFactory.InvalidDeadline.selector);
         vm.prank(principal);
         factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp - 1), IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp - 1),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            _noHooks()
         );
     }
 
@@ -248,7 +389,8 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
     }
 
@@ -265,7 +407,8 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
         vm.prank(principal);
         (, address clone1) = factory.createJob(
@@ -275,7 +418,8 @@ contract JobFactoryTest is Test {
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
         assertNotEq(clone0, clone1);
         // State is isolated
@@ -283,10 +427,26 @@ contract JobFactoryTest is Test {
         assertEq(Job(clone1).jobId(), 1);
     }
 
-    function test_implementation_notInitialized() public view {
-        // The implementation contract itself should be uninitialised (version = 0 / default state)
-        assertEq(Job(address(jobImpl)).budget(), 0);
-        assertEq(Job(address(jobImpl)).principal(), address(0));
+    function test_implementation_disablesInitializers() public {
+        // The implementation itself must revert on initialize (disableInitializers in constructor)
+        Job.InitParams memory p = Job.InitParams({
+            jobId: 1,
+            principal: principal,
+            registry: registry,
+            targetAgentId: 0,
+            token: address(token),
+            budget: BUDGET,
+            deadline: uint64(block.timestamp + DEADLINE_DELTA),
+            jobType: IJob.JobType.Direct,
+            evaluator: address(0),
+            arbiter: arbiter,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: _noHooks()
+        });
+        vm.expectRevert();
+        jobImpl.initialize(p);
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -345,20 +505,24 @@ contract JobFactoryTest is Test {
     }
 
     // ─────────────────────────────────────────────────────────────
-    // End-to-end: create → accept → complete
+    // End-to-end: create → accept → complete (FeeSplitter receives funds)
     // ─────────────────────────────────────────────────────────────
 
     function test_e2e_createAndComplete() public {
         vm.prank(principal);
-        (, address clone) = factory.createJob(
+        (uint256 jobId, address clone) = factory.createJob(
             agentId0,
             address(token),
             BUDGET,
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
+
+        // Budget held in escrow
+        assertEq(escrow.getBalance(principal, jobId, address(token)), BUDGET);
 
         Job j = Job(clone);
         vm.prank(agentCtrl);
@@ -369,7 +533,11 @@ contract JobFactoryTest is Test {
         j.approveResult();
 
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
-        assertEq(token.balanceOf(agentCtrl), BUDGET);
+        // 95% of BUDGET goes to agent (Schedule A)
+        uint256 expectedAgent = (BUDGET * 9500) / 10_000;
+        assertGe(token.balanceOf(agentCtrl), expectedAgent);
+        // Escrow balance drained
+        assertEq(escrow.getBalance(principal, jobId, address(token)), 0);
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -383,16 +551,17 @@ contract JobFactoryTest is Test {
         token.approve(address(factory), type(uint256).max);
 
         vm.prank(principal);
-        (, address clone) = factory.createJob(
+        (uint256 jobId,) = factory.createJob(
             0,
             address(token),
             budgetAmount,
             uint64(block.timestamp + DEADLINE_DELTA),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            _noHooks()
         );
-        assertEq(token.balanceOf(clone), budgetAmount);
-        assertEq(Job(clone).budget(), budgetAmount);
+        // Budget is in escrow now
+        assertEq(escrow.getBalance(principal, jobId, address(token)), budgetAmount);
     }
 }

--- a/contracts/evm/test/halmos/JobLifecycle.halmos.t.sol
+++ b/contracts/evm/test/halmos/JobLifecycle.halmos.t.sol
@@ -3,15 +3,20 @@ pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 
 import {IJob} from "../../src/acp/IJob.sol";
 import {Job} from "../../src/acp/Job.sol";
 import {AgentRegistry} from "../../src/acp/AgentRegistry.sol";
+import {Escrow} from "../../src/acp/Escrow.sol";
+import {FeeSplitter} from "../../src/acp/FeeSplitter.sol";
+import {HookRegistry} from "../../src/acp/HookRegistry.sol";
+import {BuybackBurner} from "../../src/acp/BuybackBurner.sol";
+import {IPermit2} from "../../src/acp/IPermit2.sol";
 
-/// @dev Tax-free ERC-20 used by the symbolic harness so the SMT solver does
-///      not have to reason about a token's transfer side-effects. Mirrors
-///      `HalToken` in the M2 symbolic suite.
+/// @dev Tax-free ERC-20 used by the symbolic harness.
 contract HalToken is ERC20 {
     constructor() ERC20("HAL", "HAL") {}
 
@@ -20,83 +25,149 @@ contract HalToken is ERC20 {
     }
 }
 
+contract HalTITU is ERC20Burnable {
+    constructor() ERC20("TITU", "TITU") {}
+
+    function mint(address to, uint256 amt) external {
+        _mint(to, amt);
+    }
+}
+
+contract HalPermit2 {
+    function permitTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+
+    function permitWitnessTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes32,
+        string calldata,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+}
+
+contract HalUniRouter {
+    HalTITU public titu;
+
+    constructor(HalTITU _titu) {
+        titu = _titu;
+    }
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256,
+        address[] calldata path,
+        address to,
+        uint256
+    ) external {
+        ERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
+        titu.mint(to, amountIn);
+    }
+}
+
 /// @title JobLifecycleSymbolic
 /// @notice Halmos symbolic execution harness for the Job state machine.
-///
-///         Issue #70 invariant — once a Job enters its initial funded state
-///         (`Phase.Open` with a non-zero budget), it eventually reaches
-///         **exactly one** terminal phase, drawn from `{Completed, Cancelled}`.
-///         "Cancelled" subsumes both the dispute-rejected and the
-///         expired-refund paths (see `IJob.Phase` and `Job._completeJob` /
-///         `Job.cancel` / `Job.expireJob` / `Job.resolveDispute(false)`).
-///
-///         The proofs below cover the safety side of that invariant:
-///           - terminal_*_isAbsorbing — once `phase ∈ {Completed, Cancelled}`,
-///             every state transition reverts.
-///           - completed_zeroesBudget_paysAgent — the only way to land in
-///             `Completed` is via approve / release / arbiter-favours-agent;
-///             `budget` is zeroed and the full original budget is paid to
-///             the agent.
-///           - rejected_zeroesBudget_refundsPrincipal — both Cancelled paths
-///             other than expiry (cancel-by-principal, dispute-rejected)
-///             refund the principal in full.
-///           - expired_zeroesBudget_refundsPrincipal — `expireJob` from
-///             {Open, Active} after deadline refunds the principal.
-///           - expire_phase_gating — `expireJob` reverts from any phase
-///             other than {Open, Active}, and reverts before deadline.
 ///
 ///         Run via:
 ///           halmos --match-contract JobLifecycle
 contract JobLifecycleSymbolic is Test {
+    Job internal jobImpl;
     Job internal job;
     AgentRegistry internal registry;
     HalToken internal token;
+    HalTITU internal titu;
+    HalPermit2 internal permit2;
+    HalUniRouter internal uniRouter;
+    Escrow internal escrow;
+    FeeSplitter internal feeSplitter;
+    BuybackBurner internal buybackBurner;
+    HookRegistry internal hookRegistry;
 
     address internal constant PRINCIPAL = address(0xA1);
     address internal constant AGENT = address(0xA2);
     address internal constant ARBITER = address(0xA3);
+    address internal constant TREASURY = address(0xA4);
+    address internal constant ADMIN = address(0xA5);
+
+    uint256 internal constant BUDGET = 1000e18;
+    uint256 internal constant JOB_ID = 1;
 
     uint256 internal agentRegId;
 
     function setUp() public {
-        registry = new AgentRegistry(address(this));
-        // Register the agent so `accept` paths are reachable in the symbolic
-        // model. The exact metadata values are immaterial to the lifecycle
-        // proofs.
+        registry = new AgentRegistry(ADMIN);
+        vm.prank(AGENT);
         agentRegId = registry.register(AGENT, "ipfs://hal", 0);
 
         token = new HalToken();
+        titu = new HalTITU();
+        permit2 = new HalPermit2();
+        uniRouter = new HalUniRouter(titu);
 
-        job = new Job();
+        escrow = new Escrow(ADMIN, address(permit2));
+        address[] memory swapPath = new address[](2);
+        swapPath[0] = address(token);
+        swapPath[1] = address(titu);
+        buybackBurner = new BuybackBurner(ADMIN, address(uniRouter), address(token), address(titu), swapPath, 0, 300);
+        feeSplitter = new FeeSplitter(ADMIN, TREASURY, address(buybackBurner));
+        hookRegistry = new HookRegistry(ADMIN);
+
+        jobImpl = new Job();
+
+        // Create a clone to initialize
+        job = Job(Clones.clone(address(jobImpl)));
+
+        // Fund escrow with budget
+        token.mint(PRINCIPAL, BUDGET);
+        vm.prank(PRINCIPAL);
+        token.approve(address(escrow), BUDGET);
+        vm.prank(PRINCIPAL);
+        escrow.fund(PRINCIPAL, JOB_ID, address(token), BUDGET);
+
+        // Grant clone RELEASER_ROLE and FeeSplitter CALLER_ROLE
+        bytes32 releaserRole = escrow.RELEASER_ROLE();
+        vm.prank(ADMIN);
+        escrow.grantRole(releaserRole, address(job));
+        bytes32 callerRole = feeSplitter.CALLER_ROLE();
+        vm.prank(ADMIN);
+        feeSplitter.grantRole(callerRole, address(job));
+
+        address[] memory hooks = new address[](0);
         job.initialize(
             Job.InitParams({
-                jobId: 1,
+                jobId: JOB_ID,
                 principal: PRINCIPAL,
                 registry: registry,
-                targetAgentId: 0, // open to any agent
+                targetAgentId: 0,
                 token: address(token),
-                budget: 1000e18,
+                budget: BUDGET,
                 deadline: uint64(block.timestamp + 7 days),
                 jobType: IJob.JobType.Direct,
                 evaluator: address(0),
-                arbiter: ARBITER
+                arbiter: ARBITER,
+                escrow: escrow,
+                feeSplitter: feeSplitter,
+                hookRegistry: hookRegistry,
+                hooks: hooks
             })
         );
-
-        // Pre-fund the Job clone so `_completeJob` / `cancel` / `expireJob` /
-        // `resolveDispute(false)` can perform their `safeTransfer` legs.
-        token.mint(address(job), 1000e18);
     }
 
     // ─────────────────────────────────────────────────────────────
-    // Terminal absorption: once Completed or Cancelled, every transition
-    // reverts. This is the central safety property of issue #70 — a job
-    // can transition to AT MOST one terminal phase.
+    // Terminal absorption
     // ─────────────────────────────────────────────────────────────
 
     /// @notice Once `phase == Completed`, every state-mutating call MUST revert.
     function check_terminal_completed_isAbsorbing() public {
-        // Drive Open → Active → Review → Completed via the Direct happy path.
         vm.prank(AGENT);
         job.accept(agentRegId);
         vm.prank(AGENT);
@@ -124,7 +195,7 @@ contract JobLifecycleSymbolic is Test {
         vm.prank(PRINCIPAL);
         job.raiseDispute();
         vm.prank(ARBITER);
-        job.resolveDispute(false); // principal favoured ⇒ Cancelled
+        job.resolveDispute(false);
         assertEq(uint8(job.phase()), uint8(IJob.Phase.Cancelled));
 
         _assertEveryTransitionReverts();
@@ -140,13 +211,10 @@ contract JobLifecycleSymbolic is Test {
     }
 
     // ─────────────────────────────────────────────────────────────
-    // Budget zeroing: each terminal-entry path zeroes budget and routes the
-    // funds correctly. Per IJob.Phase this is the second half of "exactly
-    // one of {completed, rejected, expired}" — funds must be conserved.
+    // Budget zeroing and fund conservation
     // ─────────────────────────────────────────────────────────────
 
-    /// @notice After Completed, budget storage MUST be 0 and the agent MUST
-    ///         hold the full original budget.
+    /// @notice After Completed, budget storage MUST be 0; agent received >=95%.
     function check_completed_zeroesBudget_paysAgent() public {
         uint256 origBudget = job.budget();
         vm.prank(AGENT);
@@ -157,12 +225,12 @@ contract JobLifecycleSymbolic is Test {
         job.approveResult();
 
         assertEq(job.budget(), 0);
-        assertEq(token.balanceOf(AGENT), origBudget);
-        assertEq(token.balanceOf(address(job)), 0);
+        // Agent receives >= 95% (dust goes to agent, 3% treasury, 2% buyback)
+        assertGe(token.balanceOf(AGENT), (origBudget * 9500) / 10_000);
+        assertEq(escrow.getBalance(PRINCIPAL, JOB_ID, address(token)), 0);
     }
 
-    /// @notice After Cancelled-by-rejection, budget MUST be 0 and the
-    ///         principal MUST hold the original budget refund.
+    /// @notice After Cancelled-by-rejection, budget MUST be 0 and principal refunded.
     function check_rejected_zeroesBudget_refundsPrincipal() public {
         uint256 origBudget = job.budget();
         vm.prank(AGENT);
@@ -174,11 +242,10 @@ contract JobLifecycleSymbolic is Test {
 
         assertEq(job.budget(), 0);
         assertEq(token.balanceOf(PRINCIPAL), origBudget);
-        assertEq(token.balanceOf(address(job)), 0);
+        assertEq(escrow.getBalance(PRINCIPAL, JOB_ID, address(token)), 0);
     }
 
-    /// @notice After Cancelled-by-expiry, budget MUST be 0 and the principal
-    ///         MUST hold the original budget refund.
+    /// @notice After Cancelled-by-expiry, budget MUST be 0 and principal refunded.
     function check_expired_zeroesBudget_refundsPrincipal() public {
         uint256 origBudget = job.budget();
         vm.warp(uint256(job.deadline()) + 1);
@@ -186,12 +253,11 @@ contract JobLifecycleSymbolic is Test {
 
         assertEq(job.budget(), 0);
         assertEq(token.balanceOf(PRINCIPAL), origBudget);
-        assertEq(token.balanceOf(address(job)), 0);
+        assertEq(escrow.getBalance(PRINCIPAL, JOB_ID, address(token)), 0);
     }
 
     // ─────────────────────────────────────────────────────────────
-    // expireJob phase-gating: only Open and Active may expire, and only
-    // strictly after the deadline.
+    // expireJob phase-gating
     // ─────────────────────────────────────────────────────────────
 
     /// @notice expireJob MUST revert from Review phase regardless of timestamp.
@@ -214,7 +280,6 @@ contract JobLifecycleSymbolic is Test {
 
     /// @notice expireJob MUST revert before deadline regardless of phase.
     function check_expire_revertsBeforeDeadline() public {
-        // phase still Open
         bool reverted;
         try job.expireJob() {
             reverted = false;
@@ -225,8 +290,7 @@ contract JobLifecycleSymbolic is Test {
     }
 
     // ─────────────────────────────────────────────────────────────
-    // Internal: assert every public lifecycle entrypoint reverts in the
-    // current state. Invoked from the four `terminal_*_isAbsorbing` proofs.
+    // Internal helpers
     // ─────────────────────────────────────────────────────────────
 
     function _assertEveryTransitionReverts() internal {

--- a/contracts/evm/test/integration/acp/JobLifecycle.t.sol
+++ b/contracts/evm/test/integration/acp/JobLifecycle.t.sol
@@ -3,10 +3,16 @@ pragma solidity 0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import {Job} from "../../../src/acp/Job.sol";
 import {IJob} from "../../../src/acp/IJob.sol";
 import {JobFactory} from "../../../src/acp/JobFactory.sol";
 import {AgentRegistry} from "../../../src/acp/AgentRegistry.sol";
+import {Escrow} from "../../../src/acp/Escrow.sol";
+import {FeeSplitter} from "../../../src/acp/FeeSplitter.sol";
+import {HookRegistry} from "../../../src/acp/HookRegistry.sol";
+import {BuybackBurner} from "../../../src/acp/BuybackBurner.sol";
+import {IPermit2} from "../../../src/acp/IPermit2.sol";
 
 /// @notice Full 4-phase lifecycle integration test covering both job types
 ///         (Direct and Evaluated), with and without an evaluator.
@@ -18,10 +24,66 @@ contract MockToken is ERC20 {
     }
 }
 
+contract MockTITU is ERC20Burnable {
+    constructor() ERC20("TITU", "TITU") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract MockPermit2 {
+    function permitTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+
+    function permitWitnessTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes32,
+        string calldata,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+}
+
+contract MockUniRouter {
+    MockTITU public titu;
+
+    constructor(MockTITU _titu) {
+        titu = _titu;
+    }
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256,
+        address[] calldata path,
+        address to,
+        uint256
+    ) external {
+        ERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
+        titu.mint(to, amountIn);
+    }
+}
+
 contract JobLifecycleTest is Test {
     AgentRegistry internal registry;
     MockToken internal token;
+    MockTITU internal titu;
+    MockPermit2 internal mockPermit2;
+    MockUniRouter internal uniRouter;
     Job internal jobImpl;
+    Escrow internal escrow;
+    FeeSplitter internal feeSplitter;
+    BuybackBurner internal buybackBurner;
+    HookRegistry internal hookRegistry;
     JobFactory internal factory;
 
     address internal admin = makeAddr("admin");
@@ -29,10 +91,13 @@ contract JobLifecycleTest is Test {
     address internal principal = makeAddr("principal");
     address internal agentCtrl = makeAddr("agentCtrl");
     address internal evaluator = makeAddr("evaluator");
+    address internal treasury = makeAddr("treasury");
 
     uint256 internal agentId;
     uint256 internal constant BUDGET = 2000e18;
     uint64 internal constant DEADLINE = 7 days;
+
+    address[] internal noHooks;
 
     function setUp() public {
         registry = new AgentRegistry(admin);
@@ -40,12 +105,33 @@ contract JobLifecycleTest is Test {
         agentId = registry.register(agentCtrl, "ipfs://QmAgent", 0x1);
 
         token = new MockToken();
+        titu = new MockTITU();
+        mockPermit2 = new MockPermit2();
+        uniRouter = new MockUniRouter(titu);
+
+        escrow = new Escrow(admin, address(mockPermit2));
+        address[] memory swapPath = new address[](2);
+        swapPath[0] = address(token);
+        swapPath[1] = address(titu);
+        buybackBurner = new BuybackBurner(admin, address(uniRouter), address(token), address(titu), swapPath, 0, 300);
+        feeSplitter = new FeeSplitter(admin, treasury, address(buybackBurner));
+        hookRegistry = new HookRegistry(admin);
         jobImpl = new Job();
-        factory = new JobFactory(admin, address(jobImpl), registry, arbiter);
+        factory = new JobFactory(admin, address(jobImpl), registry, arbiter, escrow, feeSplitter, hookRegistry);
+
+        // Grant factory admin rights to wire roles for clones
+        bytes32 adminRole = escrow.DEFAULT_ADMIN_ROLE();
+        vm.prank(admin);
+        escrow.grantRole(adminRole, address(factory));
+        bytes32 splitterAdminRole = feeSplitter.DEFAULT_ADMIN_ROLE();
+        vm.prank(admin);
+        feeSplitter.grantRole(splitterAdminRole, address(factory));
 
         token.mint(principal, BUDGET * 20);
         vm.prank(principal);
         token.approve(address(factory), type(uint256).max);
+
+        noHooks = new address[](0);
     }
 
     // ─── Direct Job: full Open → Active → Review → Completed ────
@@ -59,7 +145,8 @@ contract JobLifecycleTest is Test {
             uint64(block.timestamp + DEADLINE),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            noHooks
         );
         Job j = Job(clone);
 
@@ -82,7 +169,10 @@ contract JobLifecycleTest is Test {
         j.approveResult();
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
         assertEq(j.budget(), 0);
-        assertEq(token.balanceOf(agentCtrl), BUDGET);
+
+        // Agent receives 95% (Schedule A); escrow drained
+        assertGe(token.balanceOf(agentCtrl), (BUDGET * 9500) / 10_000);
+        assertEq(escrow.getBalance(principal, jobId, address(token)), 0);
 
         assertEq(jobId, 0);
     }
@@ -90,7 +180,14 @@ contract JobLifecycleTest is Test {
     function test_directJob_release_afterGracePeriod() public {
         vm.prank(principal);
         (, address clone) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE), IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
         );
         Job j = Job(clone);
 
@@ -122,7 +219,8 @@ contract JobLifecycleTest is Test {
             uint64(block.timestamp + DEADLINE),
             IJob.JobType.Evaluated,
             evaluator,
-            address(0)
+            address(0),
+            noHooks
         );
         Job j = Job(clone);
 
@@ -136,7 +234,8 @@ contract JobLifecycleTest is Test {
         vm.prank(evaluator);
         j.approveResult();
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
-        assertEq(token.balanceOf(agentCtrl), BUDGET);
+        // Agent receives 95%
+        assertGe(token.balanceOf(agentCtrl), (BUDGET * 9500) / 10_000);
     }
 
     function test_evaluatedJob_rejectAndResubmit() public {
@@ -148,7 +247,8 @@ contract JobLifecycleTest is Test {
             uint64(block.timestamp + DEADLINE),
             IJob.JobType.Evaluated,
             evaluator,
-            address(0)
+            address(0),
+            noHooks
         );
         Job j = Job(clone);
 
@@ -177,13 +277,21 @@ contract JobLifecycleTest is Test {
         uint256 before = token.balanceOf(principal);
         vm.prank(principal);
         (, address clone) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE), IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
         );
         Job j = Job(clone);
 
         vm.prank(principal);
         j.cancel("changed mind");
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Cancelled));
+        // Principal is refunded fully via escrow
         assertEq(token.balanceOf(principal), before);
     }
 
@@ -198,7 +306,8 @@ contract JobLifecycleTest is Test {
             uint64(block.timestamp + DEADLINE),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            noHooks
         );
         Job j = Job(clone);
 
@@ -211,7 +320,8 @@ contract JobLifecycleTest is Test {
         vm.prank(arbiter);
         j.resolveDispute(true);
         assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
-        assertEq(token.balanceOf(agentCtrl), BUDGET);
+        // Agent receives 95%
+        assertGe(token.balanceOf(agentCtrl), (BUDGET * 9500) / 10_000);
     }
 
     function test_dispute_principalFavoured_refunds() public {
@@ -223,7 +333,8 @@ contract JobLifecycleTest is Test {
             uint64(block.timestamp + DEADLINE),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            noHooks
         );
         Job j = Job(clone);
 
@@ -245,7 +356,14 @@ contract JobLifecycleTest is Test {
         uint256 before = token.balanceOf(principal);
         vm.prank(principal);
         (, address clone) = factory.createJob(
-            0, address(token), BUDGET, uint64(block.timestamp + DEADLINE), IJob.JobType.Direct, address(0), address(0)
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
         );
         Job j = Job(clone);
 
@@ -258,25 +376,31 @@ contract JobLifecycleTest is Test {
 
     function test_multipleJobs_isolatedState() public {
         vm.prank(principal);
-        (, address c0) = factory.createJob(
+        (uint256 id0, address c0) = factory.createJob(
             agentId,
             address(token),
             BUDGET / 2,
             uint64(block.timestamp + DEADLINE),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            noHooks
         );
         vm.prank(principal);
-        (, address c1) = factory.createJob(
+        (uint256 id1, address c1) = factory.createJob(
             agentId,
             address(token),
             BUDGET / 2,
             uint64(block.timestamp + DEADLINE),
             IJob.JobType.Direct,
             address(0),
-            address(0)
+            address(0),
+            noHooks
         );
+
+        // Both have their own escrow balances
+        assertEq(escrow.getBalance(principal, id0, address(token)), BUDGET / 2);
+        assertEq(escrow.getBalance(principal, id1, address(token)), BUDGET / 2);
 
         // Complete job 0
         vm.prank(agentCtrl);
@@ -286,8 +410,9 @@ contract JobLifecycleTest is Test {
         vm.prank(principal);
         Job(c0).approveResult();
 
-        // Job 1 still Open
+        // Job 1 still Open, escrow untouched
         assertEq(uint8(Job(c0).phase()), uint8(IJob.Phase.Completed));
         assertEq(uint8(Job(c1).phase()), uint8(IJob.Phase.Open));
+        assertEq(escrow.getBalance(principal, id1, address(token)), BUDGET / 2);
     }
 }

--- a/contracts/evm/test/integration/acp/JobLifecycleE2E.t.sol
+++ b/contracts/evm/test/integration/acp/JobLifecycleE2E.t.sol
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {Job} from "../../../src/acp/Job.sol";
+import {IJob} from "../../../src/acp/IJob.sol";
+import {JobFactory} from "../../../src/acp/JobFactory.sol";
+import {AgentRegistry} from "../../../src/acp/AgentRegistry.sol";
+import {Escrow} from "../../../src/acp/Escrow.sol";
+import {FeeSplitter} from "../../../src/acp/FeeSplitter.sol";
+import {HookRegistry} from "../../../src/acp/HookRegistry.sol";
+import {BuybackBurner} from "../../../src/acp/BuybackBurner.sol";
+import {IPermit2} from "../../../src/acp/IPermit2.sol";
+
+/// @notice End-to-end integration test for the full ACP v2 job lifecycle:
+///         factory clone → fund escrow → accept → submit result → complete →
+///         FeeSplitter splits (Schedule A) → BuybackBurner receives 2%.
+///
+///         This test covers issue #55 acceptance criteria:
+///           - JobFactory creates clone and funds Escrow
+///           - Job _completeJob releases from Escrow → FeeSplitter
+///           - FeeSplitter distributes 95% agent, 3% treasury, 2% buyback
+///           - BuybackBurner receives its 2% share
+contract MockPaymentToken is ERC20 {
+    constructor() ERC20("USDC", "USDC") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract MockTITU is ERC20Burnable {
+    constructor() ERC20("TITU", "TITU") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract MockPermit2 {
+    function permitTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+
+    function permitWitnessTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes32,
+        string calldata,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+}
+
+/// @dev Mock UniV2 router: simulates a swap by transferring in and minting TITU to recipient.
+contract MockUniRouter {
+    MockTITU public titu;
+
+    constructor(MockTITU _titu) {
+        titu = _titu;
+    }
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256,
+        address[] calldata path,
+        address to,
+        uint256
+    ) external {
+        ERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
+        // Simulate 1:1 swap for simplicity
+        titu.mint(to, amountIn);
+    }
+}
+
+/// @title JobLifecycleE2E
+/// @notice Full end-to-end test: JobFactory clone → Escrow funding → lifecycle →
+///         FeeSplitter Schedule A split → BuybackBurner receives 2%.
+contract JobLifecycleE2ETest is Test {
+    // Contracts
+    AgentRegistry internal registry;
+    MockPaymentToken internal token;
+    MockTITU internal titu;
+    MockPermit2 internal mockPermit2;
+    MockUniRouter internal uniRouter;
+    Job internal jobImpl;
+    Escrow internal escrow;
+    FeeSplitter internal feeSplitter;
+    BuybackBurner internal buybackBurner;
+    HookRegistry internal hookRegistry;
+    JobFactory internal factory;
+
+    // Actors
+    address internal admin = makeAddr("admin");
+    address internal arbiter = makeAddr("arbiter");
+    address internal principal = makeAddr("principal");
+    address internal agentCtrl = makeAddr("agentCtrl");
+    address internal treasury = makeAddr("treasury");
+
+    // Schedule A basis points
+    uint256 internal constant BPS = 10_000;
+    uint256 internal constant TREASURY_BPS = 300; // 3%
+    uint256 internal constant BUYBACK_BPS = 200; // 2%
+    uint256 internal constant AGENT_BPS = BPS - TREASURY_BPS - BUYBACK_BPS; // 95%
+
+    uint256 internal agentId;
+    uint256 internal constant BUDGET = 10_000e18; // 10,000 USDC
+    uint64 internal constant DEADLINE = 7 days;
+
+    address[] internal noHooks;
+
+    function setUp() public {
+        // 1. Registry
+        registry = new AgentRegistry(admin);
+        vm.prank(agentCtrl);
+        agentId = registry.register(agentCtrl, "ipfs://QmAgent", 0x1);
+
+        // 2. Tokens
+        token = new MockPaymentToken();
+        titu = new MockTITU();
+        mockPermit2 = new MockPermit2();
+        uniRouter = new MockUniRouter(titu);
+
+        // 3. Escrow
+        escrow = new Escrow(admin, address(mockPermit2));
+
+        // 4. BuybackBurner
+        address[] memory swapPath = new address[](2);
+        swapPath[0] = address(token);
+        swapPath[1] = address(titu);
+        buybackBurner = new BuybackBurner(admin, address(uniRouter), address(token), address(titu), swapPath, 0, 300);
+
+        // 5. FeeSplitter (references BuybackBurner)
+        feeSplitter = new FeeSplitter(admin, treasury, address(buybackBurner));
+
+        // 6. HookRegistry
+        hookRegistry = new HookRegistry(admin);
+
+        // 7. Job implementation + Factory
+        jobImpl = new Job();
+        factory = new JobFactory(admin, address(jobImpl), registry, arbiter, escrow, feeSplitter, hookRegistry);
+
+        // 8. Wire: grant factory admin rights on Escrow + FeeSplitter
+        bytes32 escrowAdmin = escrow.DEFAULT_ADMIN_ROLE();
+        vm.prank(admin);
+        escrow.grantRole(escrowAdmin, address(factory));
+        bytes32 splitterAdmin = feeSplitter.DEFAULT_ADMIN_ROLE();
+        vm.prank(admin);
+        feeSplitter.grantRole(splitterAdmin, address(factory));
+
+        // 9. Fund principal
+        token.mint(principal, BUDGET * 5);
+        vm.prank(principal);
+        token.approve(address(factory), type(uint256).max);
+
+        noHooks = new address[](0);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // E2E: factory clone → fund escrow → accept → submit → complete
+    // → FeeSplitter splits → BuybackBurner receives 2%
+    // ─────────────────────────────────────────────────────────────
+
+    function test_e2e_fullLifecycle_scheduleA_split() public {
+        // Step 1: Principal creates a job
+        uint256 principalBalanceBefore = token.balanceOf(principal);
+        vm.prank(principal);
+        (uint256 jobId, address clone) = factory.createJob(
+            agentId,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
+        );
+
+        // Budget deducted from principal, held in escrow
+        assertEq(token.balanceOf(principal), principalBalanceBefore - BUDGET);
+        assertEq(escrow.getBalance(principal, jobId, address(token)), BUDGET);
+
+        Job j = Job(clone);
+        assertEq(uint8(j.phase()), uint8(IJob.Phase.Open));
+
+        // Step 2: Agent accepts
+        vm.prank(agentCtrl);
+        j.accept(agentId);
+        assertEq(uint8(j.phase()), uint8(IJob.Phase.Active));
+
+        // Step 3: Agent submits result
+        vm.prank(agentCtrl);
+        j.submitResult("ipfs://QmE2EResult");
+        assertEq(uint8(j.phase()), uint8(IJob.Phase.Review));
+
+        // Step 4: Principal approves → _completeJob → Escrow.release → FeeSplitter.split
+        uint256 agentBalanceBefore = token.balanceOf(agentCtrl);
+        uint256 treasuryBalanceBefore = token.balanceOf(treasury);
+        uint256 buybackBalanceBefore = token.balanceOf(address(buybackBurner));
+
+        vm.prank(principal);
+        j.approveResult();
+
+        assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
+        assertEq(j.budget(), 0);
+        assertEq(escrow.getBalance(principal, jobId, address(token)), 0);
+
+        // Step 5: Verify Schedule A distribution
+        uint256 expectedTreasury = (BUDGET * TREASURY_BPS) / BPS; // 300 USDC
+        uint256 expectedBuyback = (BUDGET * BUYBACK_BPS) / BPS; // 200 USDC
+        uint256 expectedAgent = BUDGET - expectedTreasury - expectedBuyback; // 9500 USDC
+
+        assertEq(token.balanceOf(agentCtrl), agentBalanceBefore + expectedAgent, "agent did not receive 95%");
+        assertEq(token.balanceOf(treasury), treasuryBalanceBefore + expectedTreasury, "treasury did not receive 3%");
+        assertEq(
+            token.balanceOf(address(buybackBurner)),
+            buybackBalanceBefore + expectedBuyback,
+            "buybackBurner did not receive 2%"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // E2E: cancel refunds principal via Escrow
+    // ─────────────────────────────────────────────────────────────
+
+    function test_e2e_cancel_refundsPrincipalViaEscrow() public {
+        uint256 principalBefore = token.balanceOf(principal);
+        vm.prank(principal);
+        (, address clone) = factory.createJob(
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
+        );
+
+        // Budget in escrow
+        assertEq(token.balanceOf(principal), principalBefore - BUDGET);
+
+        vm.prank(principal);
+        Job(clone).cancel("changed mind");
+
+        // Full refund via Escrow.refund
+        assertEq(token.balanceOf(principal), principalBefore, "principal not refunded");
+        assertEq(token.balanceOf(agentCtrl), 0, "agent should receive nothing");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // E2E: dispute arbiter-resolved (agent wins) → FeeSplitter
+    // ─────────────────────────────────────────────────────────────
+
+    function test_e2e_dispute_agentWins_scheduleA() public {
+        vm.prank(principal);
+        (, address clone) = factory.createJob(
+            agentId,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
+        );
+        Job j = Job(clone);
+
+        vm.prank(agentCtrl);
+        j.accept(agentId);
+        vm.prank(principal);
+        j.raiseDispute();
+        assertEq(uint8(j.phase()), uint8(IJob.Phase.Disputed));
+
+        uint256 agentBefore = token.balanceOf(agentCtrl);
+        uint256 buybackBefore = token.balanceOf(address(buybackBurner));
+
+        vm.prank(arbiter);
+        j.resolveDispute(true); // agent wins
+
+        assertEq(uint8(j.phase()), uint8(IJob.Phase.Completed));
+
+        // Agent gets 95%, buyback gets 2%
+        uint256 expectedAgent = (BUDGET * AGENT_BPS) / BPS;
+        uint256 expectedBuyback = (BUDGET * BUYBACK_BPS) / BPS;
+        assertGe(token.balanceOf(agentCtrl) - agentBefore, expectedAgent);
+        assertEq(token.balanceOf(address(buybackBurner)) - buybackBefore, expectedBuyback);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // E2E: expiry refunds principal via Escrow
+    // ─────────────────────────────────────────────────────────────
+
+    function test_e2e_expiry_refundsPrincipal() public {
+        uint256 principalBefore = token.balanceOf(principal);
+        vm.prank(principal);
+        (, address clone) = factory.createJob(
+            0,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
+        );
+
+        vm.warp(block.timestamp + DEADLINE + 1);
+        Job(clone).expireJob();
+
+        assertEq(token.balanceOf(principal), principalBefore, "principal not refunded after expiry");
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // E2E: multiple independent jobs, escrow isolation
+    // ─────────────────────────────────────────────────────────────
+
+    function test_e2e_multipleJobs_escrowIsolation() public {
+        // Create two jobs
+        vm.prank(principal);
+        (uint256 id0, address c0) = factory.createJob(
+            agentId,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
+        );
+        vm.prank(principal);
+        (uint256 id1, address c1) = factory.createJob(
+            agentId,
+            address(token),
+            BUDGET,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
+        );
+
+        // Both have independent escrow balances
+        assertEq(escrow.getBalance(principal, id0, address(token)), BUDGET);
+        assertEq(escrow.getBalance(principal, id1, address(token)), BUDGET);
+
+        // Complete job 0
+        vm.prank(agentCtrl);
+        Job(c0).accept(agentId);
+        vm.prank(agentCtrl);
+        Job(c0).submitResult("ipfs://QmA");
+        vm.prank(principal);
+        Job(c0).approveResult();
+
+        // Job 1 escrow untouched
+        assertEq(escrow.getBalance(principal, id0, address(token)), 0);
+        assertEq(escrow.getBalance(principal, id1, address(token)), BUDGET);
+        assertEq(uint8(Job(c1).phase()), uint8(IJob.Phase.Open));
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Fuzz: verify conservation — total budget == agent + treasury + buyback
+    // ─────────────────────────────────────────────────────────────
+
+    function testFuzz_e2e_conservation(uint256 budget) public {
+        budget = bound(budget, 1000, type(uint128).max);
+
+        token.mint(principal, budget);
+        vm.prank(principal);
+        token.approve(address(factory), budget);
+
+        uint256 totalBefore =
+            token.balanceOf(agentCtrl) + token.balanceOf(treasury) + token.balanceOf(address(buybackBurner));
+
+        vm.prank(principal);
+        (, address clone) = factory.createJob(
+            agentId,
+            address(token),
+            budget,
+            uint64(block.timestamp + DEADLINE),
+            IJob.JobType.Direct,
+            address(0),
+            address(0),
+            noHooks
+        );
+
+        vm.prank(agentCtrl);
+        Job(clone).accept(agentId);
+        vm.prank(agentCtrl);
+        Job(clone).submitResult("ipfs://QmFuzz");
+        vm.prank(principal);
+        Job(clone).approveResult();
+
+        uint256 totalAfter =
+            token.balanceOf(agentCtrl) + token.balanceOf(treasury) + token.balanceOf(address(buybackBurner));
+
+        // Conservation: all funds distributed; total increase == budget
+        assertEq(totalAfter - totalBefore, budget, "fund conservation violated");
+    }
+}

--- a/contracts/evm/test/invariants/acp/PhaseMonotonicity.t.sol
+++ b/contracts/evm/test/invariants/acp/PhaseMonotonicity.t.sol
@@ -4,9 +4,16 @@ pragma solidity 0.8.26;
 import {Test} from "forge-std/Test.sol";
 import {StdInvariant} from "forge-std/StdInvariant.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {Job} from "../../../src/acp/Job.sol";
 import {IJob} from "../../../src/acp/IJob.sol";
 import {AgentRegistry} from "../../../src/acp/AgentRegistry.sol";
+import {Escrow} from "../../../src/acp/Escrow.sol";
+import {FeeSplitter} from "../../../src/acp/FeeSplitter.sol";
+import {HookRegistry} from "../../../src/acp/HookRegistry.sol";
+import {BuybackBurner} from "../../../src/acp/BuybackBurner.sol";
+import {IPermit2} from "../../../src/acp/IPermit2.sol";
 
 contract MockToken is ERC20 {
     constructor() ERC20("PhaseInv", "PINV") {}
@@ -16,15 +23,66 @@ contract MockToken is ERC20 {
     }
 }
 
+contract MockTITU is ERC20Burnable {
+    constructor() ERC20("TITU", "TITU") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract MockPermit2 {
+    function permitTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+
+    function permitWitnessTransferFrom(
+        IPermit2.PermitTransferFrom calldata permit,
+        IPermit2.SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes32,
+        string calldata,
+        bytes calldata
+    ) external {
+        ERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+}
+
+contract MockUniRouter {
+    MockTITU public titu;
+
+    constructor(MockTITU _titu) {
+        titu = _titu;
+    }
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256,
+        address[] calldata path,
+        address to,
+        uint256
+    ) external {
+        ERC20(path[0]).transferFrom(msg.sender, address(this), amountIn);
+        titu.mint(to, amountIn);
+    }
+}
+
 /// @dev Handler that drives a Job through valid transitions.
 contract JobPhaseHandler is Test {
     Job public job;
     AgentRegistry public registry;
+    Escrow public escrow;
     address public principal;
     address public agentCtrl;
     address public arbiter;
     uint256 public agentId;
     MockToken public token;
+    uint256 public jobId;
 
     // Track highest phase reached (monotone for non-reversible paths)
     uint8 public maxPhaseReached;
@@ -33,18 +91,22 @@ contract JobPhaseHandler is Test {
         Job _job,
         AgentRegistry _registry,
         MockToken _token,
+        Escrow _escrow,
         address _principal,
         address _agentCtrl,
         uint256 _agentId,
-        address _arbiter
+        address _arbiter,
+        uint256 _jobId
     ) {
         job = _job;
         registry = _registry;
         token = _token;
+        escrow = _escrow;
         principal = _principal;
         agentCtrl = _agentCtrl;
         agentId = _agentId;
         arbiter = _arbiter;
+        jobId = _jobId;
     }
 
     function tryAccept() public {
@@ -102,7 +164,15 @@ contract JobPhaseHandler is Test {
 contract PhaseMonotonicityInvariantTest is StdInvariant, Test {
     AgentRegistry internal registry;
     MockToken internal token;
+    MockTITU internal titu;
+    MockPermit2 internal permit2;
+    MockUniRouter internal uniRouter;
+    Job internal jobImpl;
     Job internal jobContract;
+    Escrow internal escrow;
+    FeeSplitter internal feeSplitter;
+    BuybackBurner internal buybackBurner;
+    HookRegistry internal hookRegistry;
     JobPhaseHandler internal handler;
 
     address internal admin = makeAddr("admin");
@@ -110,8 +180,10 @@ contract PhaseMonotonicityInvariantTest is StdInvariant, Test {
     address internal principal = makeAddr("principal");
     address internal agentCtrl = makeAddr("agentCtrl");
     address internal arbiter = makeAddr("arbiter");
+    address internal treasury = makeAddr("treasury");
     uint256 internal agentId;
     uint256 internal constant BUDGET = 1000e18;
+    uint256 internal constant JOB_ID = 0;
 
     function setUp() public {
         registry = new AgentRegistry(admin);
@@ -119,13 +191,39 @@ contract PhaseMonotonicityInvariantTest is StdInvariant, Test {
         agentId = registry.register(agentCtrl, "ipfs://QmAgent", 0x1);
 
         token = new MockToken();
+        titu = new MockTITU();
+        permit2 = new MockPermit2();
+        uniRouter = new MockUniRouter(titu);
+
+        escrow = new Escrow(admin, address(permit2));
+        address[] memory swapPath = new address[](2);
+        swapPath[0] = address(token);
+        swapPath[1] = address(titu);
+        buybackBurner = new BuybackBurner(admin, address(uniRouter), address(token), address(titu), swapPath, 0, 300);
+        feeSplitter = new FeeSplitter(admin, treasury, address(buybackBurner));
+        hookRegistry = new HookRegistry(admin);
+
+        jobImpl = new Job();
+        jobContract = Job(Clones.clone(address(jobImpl)));
+
+        // Fund escrow with budget
         token.mint(principal, BUDGET * 100);
+        vm.prank(principal);
+        token.approve(address(escrow), BUDGET);
+        vm.prank(principal);
+        escrow.fund(principal, JOB_ID, address(token), BUDGET);
 
-        jobContract = new Job();
-        token.mint(address(jobContract), BUDGET);
+        // Grant clone RELEASER_ROLE and FeeSplitter CALLER_ROLE
+        bytes32 releaserRole = escrow.RELEASER_ROLE();
+        vm.prank(admin);
+        escrow.grantRole(releaserRole, address(jobContract));
+        bytes32 callerRole = feeSplitter.CALLER_ROLE();
+        vm.prank(admin);
+        feeSplitter.grantRole(callerRole, address(jobContract));
 
+        address[] memory hooks = new address[](0);
         Job.InitParams memory p = Job.InitParams({
-            jobId: 0,
+            jobId: JOB_ID,
             principal: principal,
             registry: registry,
             targetAgentId: 0,
@@ -134,11 +232,16 @@ contract PhaseMonotonicityInvariantTest is StdInvariant, Test {
             deadline: uint64(block.timestamp + 30 days),
             jobType: IJob.JobType.Direct,
             evaluator: address(0),
-            arbiter: arbiter
+            arbiter: arbiter,
+            escrow: escrow,
+            feeSplitter: feeSplitter,
+            hookRegistry: hookRegistry,
+            hooks: hooks
         });
         jobContract.initialize(p);
 
-        handler = new JobPhaseHandler(jobContract, registry, token, principal, agentCtrl, agentId, arbiter);
+        handler =
+            new JobPhaseHandler(jobContract, registry, token, escrow, principal, agentCtrl, agentId, arbiter, JOB_ID);
         targetContract(address(handler));
     }
 
@@ -151,11 +254,20 @@ contract PhaseMonotonicityInvariantTest is StdInvariant, Test {
         }
     }
 
-    /// @notice Budget only decreases (no token minting from the job).
-    function invariant_budgetNeverIncreases() public view {
-        uint256 jobBalance = token.balanceOf(address(jobContract));
-        uint256 contractBudget = jobContract.budget();
-        // Token balance must equal tracked budget (no phantom tokens)
-        assertEq(jobBalance, contractBudget, "job token balance differs from budget field");
+    /// @notice Escrow balance mirrors job budget until terminal phase.
+    function invariant_escrowBalanceMirrorsJobBudget() public view {
+        IJob.Phase p = jobContract.phase();
+        if (p == IJob.Phase.Completed || p == IJob.Phase.Cancelled) {
+            // After terminal: both should be 0
+            assertEq(escrow.getBalance(principal, JOB_ID, address(token)), 0, "escrow not drained at terminal");
+            assertEq(jobContract.budget(), 0, "budget not zeroed at terminal");
+        } else {
+            // Before terminal: escrow balance must equal job budget
+            assertEq(
+                escrow.getBalance(principal, JOB_ID, address(token)),
+                jobContract.budget(),
+                "escrow balance differs from job budget"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR resolves three HIGH/MEDIUM security blockers from the tier-2 review of milestone PR #284.

### #56 HIGH — Escrow.fundWithPermit2 cross-token drain

- Switches `permitTransferFrom` → `permitWitnessTransferFrom` binding `(depositor, jobId, token, amount)` into the EIP-712 witness so the signature cannot be replayed across jobs or used to drain a different token.
- Adds pre-flight checks: `permit.permitted.token == token` (new `Permit2TokenMismatch` error) and `permit.permitted.amount == amount` (new `Permit2AmountMismatch` error).
- Adds `ESCROW_WITNESS_TYPE` / `ESCROW_WITNESS_TYPEHASH` public constants.
- Extends `IPermit2` with `permitWitnessTransferFrom`.
- New tests: `test_fundWithPermit2_revert_tokenMismatch`, `test_fundWithPermit2_revert_amountMismatch`, `test_witnessTypeHash_isCorrect`.

### #55 MEDIUM+ARCHITECTURE — Job/JobFactory bypass of Escrow+FeeSplitter+HookRegistry

- Job constructor calls `_disableInitializers()` to prevent direct initialization of the implementation contract.
- `Job.InitParams` extended with `escrow`, `feeSplitter`, `hookRegistry`, `hooks[]`; validation in `initialize` rejects unapproved hooks.
- `Job._completeJob` now: releases budget from Escrow to the clone, approves FeeSplitter, calls `FeeSplitter.split(Schedule.A)` — agent 95%, treasury 3%, buyback 2%.
- All cancel/expire/dispute-refund paths call `Escrow.refund` instead of direct `IERC20.safeTransfer`.
- Lifecycle hooks fired at `accept`, `submitResult`, `approveResult`, `rejectResult`, `cancel`/`expireJob`/`resolveDispute(false)`.
- `JobFactory` constructor extended with `escrow`, `feeSplitter`, `hookRegistry` immutables; `createJob` funds Escrow, grants clone `RELEASER_ROLE` on Escrow and `CALLER_ROLE` on FeeSplitter, forwards params to `Job.initialize`.
- `DeployPhase3.s.sol` updated to deploy Escrow first, then BuybackBurner, then FeeSplitter, then HookRegistry, then Job impl, then JobFactory with all wiring; grants factory `DEFAULT_ADMIN_ROLE` on Escrow and FeeSplitter.
- New integration test: `JobLifecycleE2E.t.sol` — full path: factory clone → fund escrow → accept → submit result → complete → FeeSplitter splits → BuybackBurner receives 2%.
- All existing tests updated for new InitParams/createJob signatures and escrow-centric fund custody.

### #58 MEDIUM — BuybackBurner dimensional mismatch + rescueTokens

- Replaces `minOutBps` (BPS of paymentToken input — wrong dimension) with `minTituOut` (absolute TITU units). Floor is `max(amountOutMin, minTituOut)`, both TITU-denominated.
- Renames `setMinOutBps` → `setMinTituOut`; removes `BPS` constant and `InvalidBps` error.
- `rescueTokens` reverts with `RescuePaymentTokenForbidden` when `tokenAddr == paymentToken`, enforcing the existing NatSpec claim.
- New tests: `test_rescueTokens_revert_paymentToken`, `test_rescueTokens_allowsOtherToken`, `test_setMinTituOut_*`.

closes #56
closes #55
closes #58

## Test plan

- [x] 222 ACP unit tests (`test/acp/**`) pass
- [x] 89 integration tests (`test/integration/**`) pass — including new `JobLifecycleE2E.t.sol` (6 tests)
- [x] 33 invariant tests (`test/invariants/**`) pass
- [x] `testFuzz_e2e_conservation` verifies total funds == agent + treasury + buyback across all fuzz runs

> Note: `slither src/acp` cannot run in this environment due to nightly Foundry `forge config --json` SIGABRT (pre-existing infrastructure issue, see commit de16765). 344 tests pass locally.