### PR TITLE
feat(M4): EVM subscriber w/ reconnect + reorg handling (12-block confirm)

### DIFF
--- a/services/indexer-go/internal/subscriber/README.md
+++ b/services/indexer-go/internal/subscriber/README.md
@@ -1,0 +1,64 @@
+# indexer-go / subscriber
+
+EVM block-head subscriber for the Titular indexer.
+
+## What it does
+
+Subscribes to `newHeads` over a WebSocket RPC connection (typically
+Alchemy / Base Sepolia), waits for blocks to age past a configurable
+confirmation depth (default 12), detects reorgs at the confirmed tip, and
+emits canonical headers to a downstream `Sink` in monotonic order.
+
+## API
+
+```go
+client, err := ethclient.DialContext(ctx, wsURL)
+// ...
+sub, err := subscriber.New(client, mySink, subscriber.Config{
+    Confirmations:  12,
+    ReorgWindow:    64,
+    InitialBackoff: time.Second,
+    MaxBackoff:     30 * time.Second,
+    Logger:         slog.Default(),
+})
+// Run blocks until ctx is cancelled or a fatal error occurs.
+err = sub.Run(ctx)
+```
+
+`Sink` is a single-method interface:
+
+```go
+type Sink interface {
+    Emit(ctx context.Context, b ConfirmedBlock) error
+}
+```
+
+`ConfirmedBlock.Reorged == true` signals that the same `Number` has been
+emitted before with a different `Hash`; the sink must roll back any state
+derived from the previous hash.
+
+## Behaviour
+
+| concern             | how                                                  |
+|---------------------|------------------------------------------------------|
+| connection drops    | exponential backoff (`InitialBackoff` → `MaxBackoff`) and resubscribe |
+| skipped heads       | always backfilled via `HeaderByNumber` so no height is ever silently dropped |
+| reorg detection     | walks `[tip-ReorgWindow .. tip]` after every head; first matching hash terminates |
+| reorg deeper than window | fatal — `Run` returns; operator must drain and resync |
+| sink error          | fatal — `Run` returns                                |
+| context cancel      | clean shutdown — `Run` returns `ctx.Err()`           |
+
+## Health gauges
+
+Three atomic counters are exposed for liveness probes / Prometheus:
+
+- `LastSeenBlock()` — most recent head observed on the subscription.
+- `LastConfirmedBlock()` — most recent block successfully emitted.
+- `LastReorgAt()` — unix timestamp of the most recent reorg (0 if never).
+
+## Testing
+
+The `EthClient` interface is intentionally minimal so tests can drive the
+loop with a mock — see `subscriber_test.go`. There is no integration test
+in this package; chain-level integration belongs in a follow-up phase that
+wires the subscriber into `cmd/indexer/main.go`.

--- a/services/indexer-go/internal/subscriber/subscriber.go
+++ b/services/indexer-go/internal/subscriber/subscriber.go
@@ -1,0 +1,489 @@
+// Package subscriber tails an EVM chain head over a WebSocket connection,
+// confirms blocks at a configurable depth, detects reorgs at the confirmed
+// tip, and emits canonical headers downstream in monotonic order.
+//
+// Design goals (from M4 indexer requirements):
+//
+//   - WebSocket subscription via ethclient.SubscribeNewHead (typically an
+//     Alchemy / Base Sepolia endpoint).
+//   - Auto-reconnect with exponential backoff on transient failures
+//     (subscription drop, ws hangup, RPC error). The loop only exits when
+//     the caller cancels the parent context.
+//   - 12-block confirmation: only emit a header at height H once the chain
+//     tip has reached H + Confirmations. Default is 12.
+//   - Reorg handling: when the canonical block at a confirmed height changes
+//     hash, emit it again with the new hash. Re-emission is bounded by the
+//     ReorgWindow so a malicious peer cannot force unbounded rewinds.
+//   - Health gauge: LastSeenBlock returns the most recent head observed
+//     (NOT yet confirmed). LastConfirmedBlock returns the last height that
+//     was emitted to the sink. Both are atomically readable from any
+//     goroutine and intended to back a Prometheus gauge or /healthz check.
+//
+// The package exposes only an EthClient interface (a minimal subset of
+// ethclient.Client) so unit tests can drive the loop with a mock. The
+// production wiring lives at the call site (e.g. cmd/indexer/main.go).
+package subscriber
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"sync/atomic"
+	"time"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// DefaultConfirmations is the canonical confirmation depth used by the
+// indexer when Config.Confirmations is left at zero. 12 blocks is the
+// historical Ethereum/Base default for "safe" finality on PoS chains; the
+// numbers we publish downstream are documented against this value.
+const DefaultConfirmations = 12
+
+// DefaultReorgWindow caps how far back the subscriber will rescan when it
+// observes a hash change at a previously confirmed height. A reorg deeper
+// than this is treated as operator-level corruption and surfaced as a
+// fatal error rather than silently rewound.
+const DefaultReorgWindow = 64
+
+// EthClient is the minimal slice of *ethclient.Client used by Subscriber.
+// Defining it as an interface lets unit tests inject a deterministic mock
+// without touching network code.
+//
+// The signatures match go-ethereum's *ethclient.Client exactly so the
+// production binding is simply:
+//
+//	c, err := ethclient.DialContext(ctx, wsURL)
+//	sub, err := subscriber.New(c, sink, cfg)
+type EthClient interface {
+	// SubscribeNewHead opens a "newHeads" WebSocket subscription. The
+	// returned ethereum.Subscription closes its Err() channel on
+	// disconnect; the subscriber treats any non-nil error as a transient
+	// disconnect and reconnects with backoff.
+	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+
+	// HeaderByNumber fetches the canonical header at a given height. Used
+	// to (a) backfill confirmed blocks when a new head jumps the queue
+	// and (b) re-fetch blocks whose hash may have changed under a reorg.
+	// Pass nil to fetch the latest head.
+	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
+}
+
+// ConfirmedBlock is the canonical, confirmation-aged block emitted to the
+// sink. It carries enough information for downstream consumers to detect a
+// re-emission (Reorged == true) without re-deriving canonical state on
+// their own.
+type ConfirmedBlock struct {
+	// Number is the block height.
+	Number uint64
+
+	// Hash is the canonical block hash at Number after the configured
+	// number of confirmations.
+	Hash common.Hash
+
+	// ParentHash is the parent block hash, useful for downstream consumers
+	// that maintain their own canonical chain pointer.
+	ParentHash common.Hash
+
+	// Timestamp is the block timestamp (seconds since the unix epoch).
+	Timestamp uint64
+
+	// Reorged is true when this block has been emitted before with a
+	// different Hash. The caller must treat the new (Number, Hash) pair as
+	// canonical and unwind any state derived from the prior hash.
+	Reorged bool
+}
+
+// Sink is the downstream consumer of confirmed blocks. Implementations MUST
+// be safe for synchronous calls from a single goroutine and MUST be fast:
+// the subscriber's main loop blocks on Emit, so a slow sink directly delays
+// reorg detection.
+type Sink interface {
+	// Emit is called once per confirmed block in monotonic Number order,
+	// except across a reorg window where the same Number may be emitted
+	// twice (the second time with Reorged == true and a different Hash).
+	// A non-nil error from Emit terminates the subscriber loop.
+	Emit(ctx context.Context, block ConfirmedBlock) error
+}
+
+// Config controls subscriber behaviour. The zero value is valid and uses
+// the documented defaults; callers typically set only Logger and the
+// reconnect knobs.
+type Config struct {
+	// Confirmations is the number of blocks the subscriber waits before
+	// emitting a header. Defaults to DefaultConfirmations (12).
+	Confirmations uint64
+
+	// ReorgWindow caps how far back the subscriber will rescan when a
+	// hash change is observed at a previously confirmed height. Defaults
+	// to DefaultReorgWindow (64).
+	ReorgWindow uint64
+
+	// InitialBackoff is the first sleep on reconnect failure. Doubles up
+	// to MaxBackoff. Defaults to 1s.
+	InitialBackoff time.Duration
+
+	// MaxBackoff caps the reconnect sleep. Defaults to 30s.
+	MaxBackoff time.Duration
+
+	// HeaderFetchTimeout caps each HeaderByNumber call. Defaults to 10s.
+	// Tests that drive the mock with synchronous returns may set this to
+	// something tiny.
+	HeaderFetchTimeout time.Duration
+
+	// Logger receives structured progress events. nil disables logging.
+	Logger *slog.Logger
+
+	// now is overridable for tests. Production code leaves this nil; the
+	// subscriber falls back to time.Now.
+	now func() time.Time
+}
+
+func (c *Config) defaults() {
+	if c.Confirmations == 0 {
+		c.Confirmations = DefaultConfirmations
+	}
+	if c.ReorgWindow == 0 {
+		c.ReorgWindow = DefaultReorgWindow
+	}
+	if c.InitialBackoff <= 0 {
+		c.InitialBackoff = time.Second
+	}
+	if c.MaxBackoff <= 0 {
+		c.MaxBackoff = 30 * time.Second
+	}
+	if c.HeaderFetchTimeout <= 0 {
+		c.HeaderFetchTimeout = 10 * time.Second
+	}
+	if c.now == nil {
+		c.now = time.Now
+	}
+}
+
+// Subscriber tails an EVM chain head and emits confirmed blocks to a sink.
+// Construct with New, drive with Run, observe with the LastSeen* / Last
+// Confirmed* accessors.
+type Subscriber struct {
+	client EthClient
+	sink   Sink
+	cfg    Config
+
+	// confirmedHashes tracks the hash we last emitted at each confirmed
+	// height inside [tip-ReorgWindow, tip]. Used to detect reorgs.
+	confirmedHashes map[uint64]common.Hash
+
+	// nextEmit is the next height the subscriber will try to confirm.
+	// Initialised on the first observed head as max(0, head-Confirmations).
+	nextEmit uint64
+
+	// initialised is set to true after the first head is processed; until
+	// then nextEmit is unset and we cannot start emitting.
+	initialised bool
+
+	// Health gauges (atomic so callers can read without holding any lock).
+	lastSeenBlock      atomic.Uint64
+	lastConfirmedBlock atomic.Uint64
+	lastReorgAt        atomic.Int64 // unix seconds; 0 means "never"
+}
+
+// New constructs a Subscriber. It does not open any network connection;
+// call Run to start the loop.
+//
+// client and sink MUST be non-nil. Returns an error otherwise so the
+// failure surfaces at boot rather than as a nil-deref deep in the loop.
+func New(client EthClient, sink Sink, cfg Config) (*Subscriber, error) {
+	if client == nil {
+		return nil, errors.New("subscriber.New: client is nil")
+	}
+	if sink == nil {
+		return nil, errors.New("subscriber.New: sink is nil")
+	}
+	cfg.defaults()
+	return &Subscriber{
+		client:          client,
+		sink:            sink,
+		cfg:             cfg,
+		confirmedHashes: make(map[uint64]common.Hash),
+	}, nil
+}
+
+// LastSeenBlock returns the height of the most recent head observed on the
+// subscription, regardless of whether it has been confirmed yet. Suitable
+// for a "is the websocket alive" liveness probe.
+func (s *Subscriber) LastSeenBlock() uint64 {
+	return s.lastSeenBlock.Load()
+}
+
+// LastConfirmedBlock returns the height of the most recent block emitted
+// to the sink. A widening gap between this and LastSeenBlock indicates the
+// sink is falling behind.
+func (s *Subscriber) LastConfirmedBlock() uint64 {
+	return s.lastConfirmedBlock.Load()
+}
+
+// LastReorgAt returns the unix timestamp (seconds) of the most recent
+// reorg observed, or zero if none has been seen. Suitable for a reorg
+// counter / alert in operator dashboards.
+func (s *Subscriber) LastReorgAt() int64 {
+	return s.lastReorgAt.Load()
+}
+
+// Run drives the subscription loop until ctx is cancelled or a fatal error
+// occurs (sink failure, reorg deeper than the window). Transient errors —
+// subscription drops, RPC hiccups — trigger an exponential-backoff
+// reconnect and never return from Run.
+//
+// On clean ctx cancellation Run returns ctx.Err().
+func (s *Subscriber) Run(ctx context.Context) error {
+	backoff := s.cfg.InitialBackoff
+	for {
+		err := s.runOnce(ctx)
+		switch {
+		case err == nil:
+			// runOnce only returns nil when ctx is done; surface that.
+			return ctx.Err()
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			return err
+		case errors.Is(err, errFatal):
+			return err
+		default:
+			s.logf("subscriber: transient error, will reconnect", "err", err, "backoff", backoff)
+		}
+
+		// Sleep with cancellation support before retrying.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > s.cfg.MaxBackoff {
+			backoff = s.cfg.MaxBackoff
+		}
+	}
+}
+
+// errFatal wraps an error that should NOT trigger a reconnect; the loop
+// exits and the caller is expected to crash or alert.
+var errFatal = errors.New("subscriber: fatal")
+
+// fatal annotates an error so Run treats it as terminal rather than
+// transient. Used for sink errors (downstream is broken) and reorgs deeper
+// than the window (we cannot reconcile).
+func fatal(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %v", errFatal, err)
+}
+
+// runOnce opens a single subscription and processes headers until the
+// connection drops, the context is cancelled, or a fatal error occurs.
+// Returns nil only when ctx is done; otherwise returns the error that
+// terminated the inner loop so Run can decide to reconnect or exit.
+func (s *Subscriber) runOnce(ctx context.Context) error {
+	headers := make(chan *types.Header, 16)
+
+	sub, err := s.client.SubscribeNewHead(ctx, headers)
+	if err != nil {
+		return fmt.Errorf("subscribe newHeads: %w", err)
+	}
+	defer sub.Unsubscribe()
+
+	s.logf("subscriber: subscription open")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-sub.Err():
+			if err == nil {
+				// nil on Err() means the subscription closed cleanly
+				// (server shut down). Treat as transient.
+				return errors.New("subscription closed by server")
+			}
+			return fmt.Errorf("subscription error: %w", err)
+		case h, ok := <-headers:
+			if !ok {
+				return errors.New("headers channel closed")
+			}
+			if err := s.onHead(ctx, h); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// onHead processes a single head header: updates the liveness gauge and
+// drains the confirmed-block backlog up to head-Confirmations. Returns a
+// fatal error if the sink fails or a reorg exceeds the window.
+func (s *Subscriber) onHead(ctx context.Context, h *types.Header) error {
+	if h == nil || h.Number == nil {
+		// Defensive: a malformed payload is a transient RPC issue, not
+		// fatal. Drop and wait for the next head.
+		return nil
+	}
+	headNum := h.Number.Uint64()
+	s.lastSeenBlock.Store(headNum)
+
+	// First head ever: anchor nextEmit at the deepest still-confirmable
+	// block (head - Confirmations). For very fresh chains where the head
+	// is shallower than Confirmations, start at 0.
+	if !s.initialised {
+		var start uint64
+		if headNum >= s.cfg.Confirmations {
+			start = headNum - s.cfg.Confirmations + 1
+		}
+		s.nextEmit = start
+		s.initialised = true
+		s.logf("subscriber: anchored", "head", headNum, "next_emit", s.nextEmit)
+	}
+
+	// Drain everything that has now aged past the confirmation depth.
+	if headNum < s.cfg.Confirmations {
+		return nil
+	}
+	confirmedTip := headNum - s.cfg.Confirmations + 1
+
+	// First, walk forward through any never-emitted heights up to
+	// confirmedTip. WebSocket newHeads can skip numbers when the client
+	// is briefly disconnected, so we always backfill via HeaderByNumber.
+	for s.nextEmit <= confirmedTip {
+		hdr, err := s.fetchHeader(ctx, s.nextEmit)
+		if err != nil {
+			return fmt.Errorf("fetch confirmed header %d: %w", s.nextEmit, err)
+		}
+		blk := ConfirmedBlock{
+			Number:     hdr.Number.Uint64(),
+			Hash:       hdr.Hash(),
+			ParentHash: hdr.ParentHash,
+			Timestamp:  hdr.Time,
+			Reorged:    false,
+		}
+		if err := s.sink.Emit(ctx, blk); err != nil {
+			return fatal(fmt.Errorf("sink emit %d: %w", blk.Number, err))
+		}
+		s.recordConfirmed(blk.Number, blk.Hash)
+		s.nextEmit++
+	}
+
+	// Then re-check the trailing window for reorgs. We compare the hash
+	// we previously emitted against the canonical hash at the same
+	// height; any mismatch is a reorg and we re-emit with Reorged=true.
+	if err := s.detectReorgs(ctx, confirmedTip); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// fetchHeader wraps HeaderByNumber with the configured per-call timeout so
+// a hung RPC does not stall the subscription loop.
+func (s *Subscriber) fetchHeader(ctx context.Context, number uint64) (*types.Header, error) {
+	cctx, cancel := context.WithTimeout(ctx, s.cfg.HeaderFetchTimeout)
+	defer cancel()
+	return s.client.HeaderByNumber(cctx, new(big.Int).SetUint64(number))
+}
+
+// recordConfirmed updates the liveness gauge and the in-memory hash cache
+// used for reorg detection. The cache is trimmed to ReorgWindow entries
+// behind the current tip; older confirmations are considered final and a
+// reorg deeper than the window is fatal.
+func (s *Subscriber) recordConfirmed(num uint64, hash common.Hash) {
+	s.confirmedHashes[num] = hash
+	s.lastConfirmedBlock.Store(num)
+
+	// Trim entries older than tip - ReorgWindow. We bound the map so a
+	// long-running indexer does not leak memory.
+	if num <= s.cfg.ReorgWindow {
+		return
+	}
+	cutoff := num - s.cfg.ReorgWindow
+	for k := range s.confirmedHashes {
+		if k < cutoff {
+			delete(s.confirmedHashes, k)
+		}
+	}
+}
+
+// detectReorgs walks the trailing ReorgWindow and re-emits any block whose
+// canonical hash now differs from the one we stored. Returns a fatal error
+// if a mismatch is observed at the very edge of the window (depth ==
+// ReorgWindow), because the subscriber cannot prove the reorg did not go
+// deeper than its memory.
+func (s *Subscriber) detectReorgs(ctx context.Context, confirmedTip uint64) error {
+	if confirmedTip == 0 {
+		return nil
+	}
+
+	// We have already emitted heights [..., nextEmit-1]. The most recent
+	// emission is at nextEmit-1, which equals confirmedTip after the
+	// forward drain above. Walk backwards across the window.
+	last := s.nextEmit - 1
+	var oldest uint64
+	if last >= s.cfg.ReorgWindow {
+		oldest = last - s.cfg.ReorgWindow + 1
+	}
+
+	// Walk every cached height in [oldest..last]. We do not early-exit on
+	// a match because a reorg can leave the canonical hash at a recent
+	// height untouched while rewriting an earlier block (e.g. an
+	// uncle-aunt swap that the new tip happens to graft over). Window is
+	// bounded (default 64) so the O(window) scan is cheap.
+	//
+	// Loop is written with an explicit terminator so `oldest==0` does not
+	// underflow uint64 when we decrement past zero.
+	for height := last; ; height-- {
+		want, known := s.confirmedHashes[height]
+		if !known {
+			// Either pre-anchor or already trimmed. Stop scanning.
+			break
+		}
+		hdr, err := s.fetchHeader(ctx, height)
+		if err != nil {
+			return fmt.Errorf("reorg recheck %d: %w", height, err)
+		}
+		got := hdr.Hash()
+		if got != want {
+			// Hash changed at this height: a reorg.
+			if height == oldest && oldest > 0 {
+				// Mismatch at the very edge of what we remember, so the
+				// reorg may be deeper. Refuse to silently rewind state
+				// the downstream sink cannot reconstruct.
+				return fatal(fmt.Errorf("reorg deeper than window at height %d", height))
+			}
+
+			blk := ConfirmedBlock{
+				Number:     hdr.Number.Uint64(),
+				Hash:       got,
+				ParentHash: hdr.ParentHash,
+				Timestamp:  hdr.Time,
+				Reorged:    true,
+			}
+			if err := s.sink.Emit(ctx, blk); err != nil {
+				return fatal(fmt.Errorf("sink reorg-emit %d: %w", height, err))
+			}
+			s.confirmedHashes[height] = got
+			s.lastReorgAt.Store(s.cfg.now().Unix())
+			s.logf("subscriber: reorg observed", "height", height, "old", want, "new", got)
+		}
+
+		if height == oldest {
+			break
+		}
+	}
+	return nil
+}
+
+// logf is a nil-safe wrapper over the optional structured logger.
+func (s *Subscriber) logf(msg string, kv ...any) {
+	if s.cfg.Logger == nil {
+		return
+	}
+	s.cfg.Logger.Info(msg, kv...)
+}

--- a/services/indexer-go/internal/subscriber/subscriber_test.go
+++ b/services/indexer-go/internal/subscriber/subscriber_test.go
@@ -1,0 +1,684 @@
+package subscriber_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/0xDevNinja/titular/services/indexer-go/internal/subscriber"
+)
+
+// ----------------------------------------------------------------------------
+// Test doubles
+// ----------------------------------------------------------------------------
+
+// mockSub satisfies ethereum.Subscription for tests. The err channel lets a
+// test simulate a websocket disconnect by sending a non-nil error.
+type mockSub struct {
+	err  chan error
+	once sync.Once
+}
+
+func newMockSub() *mockSub           { return &mockSub{err: make(chan error, 1)} }
+func (m *mockSub) Err() <-chan error { return m.err }
+func (m *mockSub) Unsubscribe()      { m.once.Do(func() { close(m.err) }) }
+func (m *mockSub) fail(e error)      { m.err <- e }
+
+// mockClient implements subscriber.EthClient. Tests push headers onto the
+// subscription channel via pushHead and seed canonical hashes for
+// HeaderByNumber via setHeader. Concurrency-safe so a test goroutine can
+// drive the subscriber from outside the Run loop.
+type mockClient struct {
+	mu sync.Mutex
+
+	headers   map[uint64]*types.Header
+	subCh     chan<- *types.Header
+	sub       *mockSub
+	subscribe func() (*mockSub, error) // override for SubscribeNewHead
+}
+
+func newMockClient() *mockClient {
+	return &mockClient{headers: make(map[uint64]*types.Header)}
+}
+
+func (m *mockClient) SubscribeNewHead(_ context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.subscribe != nil {
+		s, err := m.subscribe()
+		if err != nil {
+			return nil, err
+		}
+		m.subCh = ch
+		m.sub = s
+		return s, nil
+	}
+	s := newMockSub()
+	m.subCh = ch
+	m.sub = s
+	return s, nil
+}
+
+func (m *mockClient) HeaderByNumber(_ context.Context, number *big.Int) (*types.Header, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if number == nil {
+		return nil, errors.New("mock: HeaderByNumber(nil) not supported in tests")
+	}
+	h, ok := m.headers[number.Uint64()]
+	if !ok {
+		return nil, fmt.Errorf("mock: no header at %d", number.Uint64())
+	}
+	// Return a copy so a later mutation in the test (reorg) does not
+	// retroactively change a previously returned header.
+	cp := *h
+	return &cp, nil
+}
+
+// setHeader registers the canonical header at a given height. To simulate
+// a reorg, call setHeader again with a different ParentHash / nonce.
+func (m *mockClient) setHeader(number uint64, parentHash common.Hash, nonce uint64) common.Hash {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	h := &types.Header{
+		Number:     new(big.Int).SetUint64(number),
+		ParentHash: parentHash,
+		Time:       1_700_000_000 + number,
+		// Nonce is only used here to perturb the hash so test reorgs
+		// produce a deterministic-but-different Hash().
+		Nonce: types.EncodeNonce(nonce),
+	}
+	m.headers[number] = h
+	return h.Hash()
+}
+
+// hasSub returns true once the subscriber has registered a subscription.
+// Lock-protected so concurrent waitFor probes don't race with
+// SubscribeNewHead.
+func (m *mockClient) hasSub() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sub != nil
+}
+
+// pushHead delivers a head header to the subscriber. Blocks until the
+// subscriber drains it (channel buffer = 16).
+func (m *mockClient) pushHead(t *testing.T, number uint64) {
+	t.Helper()
+	m.mu.Lock()
+	h, ok := m.headers[number]
+	ch := m.subCh
+	m.mu.Unlock()
+	if !ok {
+		t.Fatalf("pushHead: no header registered at %d", number)
+	}
+	cp := *h
+	select {
+	case ch <- &cp:
+	case <-time.After(time.Second):
+		t.Fatalf("pushHead: timeout pushing head %d", number)
+	}
+}
+
+// chanSink captures every emitted ConfirmedBlock so tests can assert on
+// the exact sequence and reorg flag.
+type chanSink struct {
+	mu     sync.Mutex
+	blocks []subscriber.ConfirmedBlock
+	emitFn func(subscriber.ConfirmedBlock) error // optional override
+}
+
+func newChanSink() *chanSink { return &chanSink{} }
+
+func (s *chanSink) Emit(_ context.Context, b subscriber.ConfirmedBlock) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.emitFn != nil {
+		if err := s.emitFn(b); err != nil {
+			return err
+		}
+	}
+	s.blocks = append(s.blocks, b)
+	return nil
+}
+
+func (s *chanSink) snapshot() []subscriber.ConfirmedBlock {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]subscriber.ConfirmedBlock, len(s.blocks))
+	copy(out, s.blocks)
+	return out
+}
+
+// waitFor polls until pred returns true or the deadline passes. Used to
+// synchronise against the subscriber's internal goroutine without sleeps.
+func waitFor(t *testing.T, timeout time.Duration, pred func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pred() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("waitFor: condition not met within %s", timeout)
+}
+
+// ----------------------------------------------------------------------------
+// New() validates inputs
+// ----------------------------------------------------------------------------
+
+func TestNewRejectsNilDependencies(t *testing.T) {
+	t.Parallel()
+	if _, err := subscriber.New(nil, newChanSink(), subscriber.Config{}); err == nil {
+		t.Fatal("expected error for nil client")
+	}
+	if _, err := subscriber.New(newMockClient(), nil, subscriber.Config{}); err == nil {
+		t.Fatal("expected error for nil sink")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Confirmation depth: only emit at head - Confirmations + 1
+// ----------------------------------------------------------------------------
+
+func TestEmitsOnlyAfterConfirmationDepth(t *testing.T) {
+	t.Parallel()
+
+	const depth = 3
+	mc := newMockClient()
+	sink := newChanSink()
+
+	// Build a 10-block linear chain.
+	var prev common.Hash
+	for n := uint64(1); n <= 10; n++ {
+		prev = mc.setHeader(n, prev, n)
+	}
+
+	s, err := subscriber.New(mc, sink, subscriber.Config{
+		Confirmations:      depth,
+		HeaderFetchTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	// Wait for subscription to open.
+	waitFor(t, time.Second, func() bool { return mc.hasSub() })
+
+	// Push head=5: anchor latches at confirmedTip = 5 - 3 + 1 = 3, so on
+	// the first head only block 3 emits (no backfill from genesis — that
+	// is a different module's job).
+	mc.pushHead(t, 5)
+	waitFor(t, time.Second, func() bool { return s.LastConfirmedBlock() == 3 })
+
+	got := sink.snapshot()
+	if len(got) != 1 || got[0].Number != 3 {
+		t.Fatalf("first emit: got %+v, want [#3]", emitSummary(got))
+	}
+	if got[0].Reorged {
+		t.Errorf("block 3 emitted with Reorged=true on initial emit")
+	}
+	if s.LastSeenBlock() != 5 {
+		t.Errorf("LastSeenBlock = %d, want 5", s.LastSeenBlock())
+	}
+
+	// Head=6 → confirmedTip=4, emit just block 4.
+	mc.pushHead(t, 6)
+	waitFor(t, time.Second, func() bool { return s.LastConfirmedBlock() == 4 })
+	got = sink.snapshot()
+	if len(got) != 2 || got[1].Number != 4 {
+		t.Fatalf("after head=6: got %+v, want [#3, #4]", emitSummary(got))
+	}
+
+	// Head=8 → confirmedTip=6, emit blocks 5 and 6 (forward catch-up
+	// when newHeads jumped a number).
+	mc.pushHead(t, 8)
+	waitFor(t, time.Second, func() bool { return s.LastConfirmedBlock() == 6 })
+	got = sink.snapshot()
+	if len(got) != 4 {
+		t.Fatalf("after head=8: emitted %d, want 4", len(got))
+	}
+
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Errorf("Run returned %v, want context.Canceled", err)
+	}
+}
+
+// TestSkipsBeforeDepthReached ensures we never emit when the head is
+// shallower than the confirmation depth.
+func TestSkipsBeforeDepthReached(t *testing.T) {
+	t.Parallel()
+
+	mc := newMockClient()
+	sink := newChanSink()
+
+	var prev common.Hash
+	for n := uint64(1); n <= 5; n++ {
+		prev = mc.setHeader(n, prev, n)
+	}
+
+	s, err := subscriber.New(mc, sink, subscriber.Config{
+		Confirmations:      12,
+		HeaderFetchTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	waitFor(t, time.Second, func() bool { return mc.hasSub() })
+
+	// Head=5, depth=12: confirmedTip would be -7. Nothing should emit.
+	mc.pushHead(t, 5)
+
+	// Give the loop a tick to process. We expect zero emissions and the
+	// liveness gauge to have moved.
+	waitFor(t, time.Second, func() bool { return s.LastSeenBlock() == 5 })
+	if got := sink.snapshot(); len(got) != 0 {
+		t.Errorf("emitted %d blocks before depth, want 0", len(got))
+	}
+	if s.LastConfirmedBlock() != 0 {
+		t.Errorf("LastConfirmedBlock = %d, want 0", s.LastConfirmedBlock())
+	}
+
+	cancel()
+	<-done
+}
+
+// ----------------------------------------------------------------------------
+// Reorg detection: same height, different hash
+// ----------------------------------------------------------------------------
+
+func TestDetectsReorgWithinWindow(t *testing.T) {
+	t.Parallel()
+
+	const depth = 2
+	mc := newMockClient()
+	sink := newChanSink()
+
+	// Initial chain: 1..6, all confirmed at head=6 (confirmedTip=5).
+	var prev common.Hash
+	for n := uint64(1); n <= 6; n++ {
+		prev = mc.setHeader(n, prev, n)
+	}
+	hash5Old := mc.headers[5].Hash()
+
+	s, err := subscriber.New(mc, sink, subscriber.Config{
+		Confirmations:      depth,
+		ReorgWindow:        4,
+		HeaderFetchTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	waitFor(t, time.Second, func() bool { return mc.hasSub() })
+
+	mc.pushHead(t, 6)
+	waitFor(t, time.Second, func() bool { return s.LastConfirmedBlock() == 5 })
+
+	// Anchor latches at the first confirmable height, so only block 5
+	// emits initially (not 1..5).
+	if got := sink.snapshot(); len(got) != 1 || got[0].Number != 5 {
+		t.Fatalf("initial emit: got %+v, want [#5]", emitSummary(sink.snapshot()))
+	}
+
+	// Reorg: replace block 5 with a different nonce so its hash changes.
+	// Parent (block 4) stays the same so the "first match from tip
+	// downward" walk lands on height 5.
+	parent4 := mc.headers[4].Hash()
+	hash5New := mc.setHeader(5, parent4, 999)
+	if hash5New == hash5Old {
+		t.Fatal("test setup: forced reorg produced identical hash")
+	}
+
+	// Push head=7 (also a fresh canonical block) to trigger another
+	// drain. ConfirmedTip = 6, which forces a reorg recheck of [3..6].
+	mc.setHeader(7, hash5New, 7) // 7 is now a child of the new 5
+	// Re-bind block 6 onto the new 5 so the canonical chain at 6 reflects
+	// the reorg, otherwise our "is the tip stable" loop would not see a
+	// mismatch at 6 either.
+	mc.setHeader(6, hash5New, 6)
+	mc.pushHead(t, 7)
+
+	waitFor(t, 2*time.Second, func() bool {
+		got := sink.snapshot()
+		// Expect 1 original (#5) + at least 1 reorg emission for #5 +
+		// 1 fresh confirmation at #6.
+		return len(got) >= 3
+	})
+
+	got := sink.snapshot()
+	// Find the first reorg emission and assert it is for height 5.
+	var sawReorgAt5 bool
+	var sawFreshAt6 bool
+	for _, b := range got {
+		if b.Reorged && b.Number == 5 {
+			sawReorgAt5 = true
+			if b.Hash != hash5New {
+				t.Errorf("reorg emit hash = %x, want %x", b.Hash, hash5New)
+			}
+		}
+		if !b.Reorged && b.Number == 6 {
+			sawFreshAt6 = true
+		}
+	}
+	if !sawReorgAt5 {
+		t.Errorf("no Reorged=true emission at height 5; got %+v", emitSummary(got))
+	}
+	if !sawFreshAt6 {
+		t.Errorf("no fresh emit at height 6; got %+v", emitSummary(got))
+	}
+	if s.LastReorgAt() == 0 {
+		t.Errorf("LastReorgAt not updated after reorg")
+	}
+
+	cancel()
+	<-done
+}
+
+// emitSummary renders a sequence of ConfirmedBlocks compactly for failure
+// messages.
+func emitSummary(bs []subscriber.ConfirmedBlock) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		flag := ""
+		if b.Reorged {
+			flag = " (reorg)"
+		}
+		out[i] = fmt.Sprintf("#%d %s%s", b.Number, b.Hash.Hex()[:10], flag)
+	}
+	return out
+}
+
+// TestReorgDeeperThanWindowIsFatal: if the reorg edge of the window
+// disagrees with the canonical chain, Run must return rather than rewind
+// silently.
+//
+// Setup: depth=1, window=3. We confirm a long sequence so the in-memory
+// hash cache is fully populated across the window. Then we replace the
+// hashes at every height in the window AND at the edge boundary so that
+// the recheck walk hits a mismatch at its oldest scanned height.
+func TestReorgDeeperThanWindowIsFatal(t *testing.T) {
+	t.Parallel()
+
+	const depth = 1
+	const window = 3
+	mc := newMockClient()
+	sink := newChanSink()
+
+	// Build chain 1..15, then walk the head forward one block at a time
+	// so the subscriber populates its hash cache for every height.
+	var prev common.Hash
+	for n := uint64(1); n <= 15; n++ {
+		prev = mc.setHeader(n, prev, n)
+	}
+
+	s, err := subscriber.New(mc, sink, subscriber.Config{
+		Confirmations:      depth,
+		ReorgWindow:        window,
+		HeaderFetchTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	waitFor(t, time.Second, func() bool { return mc.hasSub() })
+
+	// Walk the head from 5 → 12, one push at a time. After each push the
+	// subscriber emits one new block, so by head=12 the cache holds
+	// hashes for #5..#12 (window-trim culls older entries).
+	mc.pushHead(t, 5)
+	waitFor(t, time.Second, func() bool { return s.LastConfirmedBlock() == 5 })
+	for h := uint64(6); h <= 12; h++ {
+		mc.pushHead(t, h)
+		hh := h
+		waitFor(t, time.Second, func() bool { return s.LastConfirmedBlock() == hh })
+	}
+
+	// At this point: nextEmit=13, last=12, oldest=12-3+1=10. The cache
+	// has {10,11,12,...} (window-trim keeps 4 entries: 9,10,11,12).
+	// Replace every height from 10 upward so the entire scanned window
+	// mismatches; the loop emits reorgs at 12, 11, 10, then hits oldest
+	// (10) and returns fatal because oldest > 0.
+	parent9 := mc.headers[9].Hash()
+	mc.setHeader(10, parent9, 9999)
+	h10 := mc.headers[10].Hash()
+	mc.setHeader(11, h10, 9998)
+	h11 := mc.headers[11].Hash()
+	mc.setHeader(12, h11, 9997)
+	h12 := mc.headers[12].Hash()
+	mc.setHeader(13, h12, 13)
+
+	mc.pushHead(t, 13)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run returned nil; expected fatal reorg error")
+		}
+		if errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned context.Canceled; expected fatal reorg")
+		}
+		// Good: any non-nil non-cancel error from Run on a deep reorg.
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after deep reorg")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Reconnect on subscription failure
+// ----------------------------------------------------------------------------
+
+func TestReconnectsAfterSubscriptionDrop(t *testing.T) {
+	t.Parallel()
+
+	const depth = 1
+	mc := newMockClient()
+	sink := newChanSink()
+
+	var prev common.Hash
+	for n := uint64(1); n <= 10; n++ {
+		prev = mc.setHeader(n, prev, n)
+	}
+
+	// First Subscribe call returns a subscription that fails immediately;
+	// second Subscribe call returns a healthy one. After this the test
+	// pushes a head and verifies confirmation continued past the reconnect.
+	calls := 0
+	mc.subscribe = func() (*mockSub, error) {
+		calls++
+		s := newMockSub()
+		if calls == 1 {
+			// Fail asynchronously so SubscribeNewHead returns first.
+			go func() {
+				time.Sleep(5 * time.Millisecond)
+				s.fail(errors.New("simulated ws disconnect"))
+			}()
+		}
+		return s, nil
+	}
+
+	s, err := subscriber.New(mc, sink, subscriber.Config{
+		Confirmations:      depth,
+		InitialBackoff:     5 * time.Millisecond,
+		MaxBackoff:         20 * time.Millisecond,
+		HeaderFetchTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	// Wait for the second Subscribe call (i.e. the reconnect).
+	waitFor(t, 2*time.Second, func() bool {
+		mc.mu.Lock()
+		defer mc.mu.Unlock()
+		return calls >= 2
+	})
+
+	// Push head=5 → confirmedTip=5 (depth=1). First head after reconnect
+	// anchors at #5 and emits just that block.
+	mc.pushHead(t, 5)
+	waitFor(t, 2*time.Second, func() bool { return s.LastConfirmedBlock() == 5 })
+
+	if got := sink.snapshot(); len(got) != 1 || got[0].Number != 5 {
+		t.Errorf("after reconnect: got %+v, want [#5]", emitSummary(sink.snapshot()))
+	}
+
+	cancel()
+	<-done
+}
+
+// ----------------------------------------------------------------------------
+// Sink errors are fatal — Run returns without infinite reconnect.
+// ----------------------------------------------------------------------------
+
+func TestSinkErrorIsFatal(t *testing.T) {
+	t.Parallel()
+
+	mc := newMockClient()
+	sink := newChanSink()
+	sink.emitFn = func(_ subscriber.ConfirmedBlock) error {
+		return errors.New("boom: db down")
+	}
+
+	var prev common.Hash
+	for n := uint64(1); n <= 5; n++ {
+		prev = mc.setHeader(n, prev, n)
+	}
+
+	s, err := subscriber.New(mc, sink, subscriber.Config{
+		Confirmations:      1,
+		InitialBackoff:     time.Millisecond,
+		HeaderFetchTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	waitFor(t, time.Second, func() bool { return mc.hasSub() })
+	mc.pushHead(t, 3)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run returned nil; expected fatal sink error")
+		}
+		if errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned context.Canceled; expected fatal sink error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after sink error")
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Cancellation
+// ----------------------------------------------------------------------------
+
+func TestRunReturnsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	mc := newMockClient()
+	sink := newChanSink()
+	s, err := subscriber.New(mc, sink, subscriber.Config{Confirmations: 1})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	waitFor(t, time.Second, func() bool { return mc.hasSub() })
+
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Run returned %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// TestNilHeaderTolerated: a malformed payload (header with nil Number)
+// must not crash the loop.
+func TestNilHeaderTolerated(t *testing.T) {
+	t.Parallel()
+
+	mc := newMockClient()
+	sink := newChanSink()
+	s, err := subscriber.New(mc, sink, subscriber.Config{Confirmations: 1})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	waitFor(t, time.Second, func() bool { return mc.hasSub() })
+
+	// Push a header with a nil Number — should be silently dropped.
+	mc.mu.Lock()
+	ch := mc.subCh
+	mc.mu.Unlock()
+	select {
+	case ch <- &types.Header{}:
+	case <-time.After(time.Second):
+		t.Fatal("could not push nil-number header")
+	}
+
+	// Subscriber should still be alive: register a real header and push it.
+	var prev common.Hash
+	for n := uint64(1); n <= 3; n++ {
+		prev = mc.setHeader(n, prev, n)
+	}
+	mc.pushHead(t, 3)
+	waitFor(t, time.Second, func() bool { return s.LastConfirmedBlock() == 3 })
+
+	cancel()
+	<-done
+}


### PR DESCRIPTION
## Summary

Phase `M4-evm-subscriber` for milestone M4. Closes #79.

## Test plan

- [ ] `forge test` green
- [ ] `slither` clean (Critical/High/Medium = 0)
- [ ] `go test ./services/...` green where touched
- [ ] reviewer signs off

## Verify

log: `.claude/cron/last-verify-M4-evm-subscriber.log`

```
--- go vet ./... ---
vet exit=0

--- gofmt -l ./... ---

--- go build ./... ---
build exit=0

--- go test ./... ---
?   	github.com/0xDevNinja/titular/services/indexer-go	[no test files]
ok  	github.com/0xDevNinja/titular/services/indexer-go/cmd/migrate	(cached)
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/abi	(cached)
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/db	(cached)
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/handlers	(cached)
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/subscriber	0.761s
test exit=0

--- go test -race ./internal/subscriber/... ---
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/subscriber	1.584s
race exit=0
```