### PR TITLE
feat(M4): SIWS auth (Solana signature verify)

### DIFF
--- a/services/gateway-go/README.md
+++ b/services/gateway-go/README.md
@@ -36,6 +36,8 @@ flags:
 | `GATEWAY_REDIS_URL` | Redis connection URL (`redis://host:port/db`). Required when `GATEWAY_JWT_SECRET` is set. |
 | `GATEWAY_SIWE_DOMAIN` | The value the SIWE message MUST declare in its `domain` line. Pinned server-side to prevent cross-site replay. |
 | `GATEWAY_SIWE_CHAIN_ID` | The chain id the SIWE message MUST declare. Defaults to `84532` (Base Sepolia). |
+| `GATEWAY_SIWS_DOMAIN` | The value the SIWS (Sign-In With Solana) message MUST declare. Falls back to `GATEWAY_SIWE_DOMAIN` when unset so single-domain deployments configure once. |
+| `GATEWAY_SIWS_CLUSTER` | Solana cluster the SIWS message MUST declare. One of `devnet`, `mainnet-beta`, `testnet`. Setting this enables `/auth/siws/*`. No default — operators must opt in explicitly. |
 
 ### SIWE auth (`/auth/*`)
 
@@ -51,6 +53,28 @@ When `GATEWAY_JWT_SECRET` is set the gateway exposes:
 Protected routes can opt in to authentication via `auth.RequireAuth(handlers)`.
 The middleware double-checks the JWT signature **and** the Redis session, so
 deleting a session immediately revokes every token it backs.
+
+### SIWS auth (`/auth/siws/*`)
+
+When `GATEWAY_JWT_SECRET` and `GATEWAY_SIWS_CLUSTER` are both set, the gateway
+additionally exposes the Sign-In-With-Solana flow:
+
+- `POST /auth/siws/nonce` — same shape and TTL as the SIWE nonce. The nonce
+  namespace is shared between SIWE and SIWS so a single nonce is single-use
+  across both paths.
+- `POST /auth/siws/verify` — accepts `{ "message": "<SIWS>", "signature":
+  "<base58>" }`, validates domain, cluster (`devnet`/`mainnet-beta`/`testnet`),
+  time window and the ed25519 signature, atomically consumes the nonce, mints a
+  JWT and seeds a Redis session. Verification uses Go's stdlib
+  `crypto/ed25519`, which is constant-time per the language contract.
+- Logout is shared with the SIWE path (`POST /auth/logout`); a SIWS-minted token
+  logs out via the same endpoint.
+
+The SIWS message format is a port of EIP-4361 with a `Chain ID` (or `Cluster`)
+field naming a Solana network instead of an EVM chain id; the handler accepts
+either field name. Phantom and Backpack clients can be wired in directly: their
+`signMessage` returns base58, which is the format the verify endpoint
+expects.
 
 ### `GATEWAY_TRUSTED_PROXIES` — required when behind an L7 proxy
 

--- a/services/gateway-go/cmd/gateway/main.go
+++ b/services/gateway-go/cmd/gateway/main.go
@@ -34,6 +34,18 @@
 //	                              prevent cross-site replay.
 //	GATEWAY_SIWE_CHAIN_ID         the chain id the SIWE message MUST declare.
 //	                              Defaults to 84532 (Base Sepolia).
+//	GATEWAY_SIWS_DOMAIN           the value the SIWS (Sign-In With Solana)
+//	                              message MUST declare in its header line.
+//	                              Pinned server-side to prevent cross-site
+//	                              replay. Falls back to GATEWAY_SIWE_DOMAIN
+//	                              when unset so single-domain deployments
+//	                              don't need to configure twice.
+//	GATEWAY_SIWS_CLUSTER          the Solana cluster the SIWS message MUST
+//	                              declare. One of "devnet", "mainnet-beta",
+//	                              "testnet". Defaults to "devnet". Setting
+//	                              this enables the /auth/siws/* endpoints
+//	                              (provided JWT_SECRET + REDIS_URL are also
+//	                              set).
 package main
 
 import (
@@ -87,6 +99,10 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("invalid auth configuration")
 	}
+	siwsHandlers, err := buildSIWSHandlers(authHandlers, redisClient)
+	if err != nil {
+		log.Fatal().Err(err).Msg("invalid SIWS configuration")
+	}
 
 	cfg := router.Config{
 		Logger:         log.Logger,
@@ -95,6 +111,7 @@ func main() {
 		RateLimit:      buildRateLimitConfig(),
 		TrustedProxies: parseList(os.Getenv("GATEWAY_TRUSTED_PROXIES")),
 		Auth:           authHandlers,
+		SIWS:           siwsHandlers,
 	}
 
 	built := router.NewWithConfigLifecycle(cfg, agentHandlers, jobHandlers)
@@ -221,6 +238,49 @@ func buildAuthHandlers(ctx context.Context) (*auth.Handlers, *redis.Client, erro
 		return nil, nil, err
 	}
 	return h, client, nil
+}
+
+// buildSIWSHandlers assembles the Sign-In-With-Solana handler bundle on top
+// of the existing SIWE infrastructure. We deliberately reuse the signer
+// and session store so:
+//
+//   - There is only one JWT secret in memory (no fan-out of HMAC keys).
+//   - Logout is a single endpoint that revokes either flow's tokens.
+//   - The nonce namespace is shared, which is correct: the chain binding
+//     happens via the signed message, not the nonce.
+//
+// SIWS is enabled when SIWE is enabled AND GATEWAY_SIWS_CLUSTER is set.
+// We accept GATEWAY_SIWS_DOMAIN as an explicit override for deployments
+// where the SIWS-facing domain differs from the SIWE-facing domain;
+// otherwise we inherit GATEWAY_SIWE_DOMAIN.
+func buildSIWSHandlers(siwe *auth.Handlers, client *redis.Client) (*auth.SIWSHandlers, error) {
+	if siwe == nil || client == nil {
+		// SIWE not configured — SIWS cannot be either, since they share
+		// the signer/store. Caller treats nil as "feature off".
+		return nil, nil
+	}
+	cluster := strings.TrimSpace(os.Getenv("GATEWAY_SIWS_CLUSTER"))
+	if cluster == "" {
+		// SIWS opt-in: explicitly require the operator to declare a
+		// cluster. We refuse to default to mainnet — getting that
+		// silently wrong is the worst possible failure mode.
+		return nil, nil
+	}
+
+	domain := strings.TrimSpace(os.Getenv("GATEWAY_SIWS_DOMAIN"))
+	if domain == "" {
+		domain = strings.TrimSpace(os.Getenv("GATEWAY_SIWE_DOMAIN"))
+	}
+	if domain == "" {
+		return nil, errors.New("GATEWAY_SIWS_DOMAIN or GATEWAY_SIWE_DOMAIN required when SIWS enabled")
+	}
+
+	return auth.NewSIWSHandlers(auth.SIWSHandlerConfig{
+		Store:   siwe.Store(),
+		Signer:  siwe.Signer(),
+		Domain:  domain,
+		Cluster: cluster,
+	})
 }
 
 // envOr returns the value of the named env var, falling back to def when

--- a/services/gateway-go/go.mod
+++ b/services/gateway-go/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mr-tron/base58 v1.3.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect

--- a/services/gateway-go/go.sum
+++ b/services/gateway-go/go.sum
@@ -75,6 +75,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mr-tron/base58 v1.3.0 h1:K6Y13R2h+dku0wOqKtecgRnBUBPrZzLZy5aIj8lCcJI=
+github.com/mr-tron/base58 v1.3.0/go.mod h1:2BuubE67DCSWwVfx37JWNG8emOC0sHEU4/HpcYgCLX8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/services/gateway-go/internal/auth/siwe.go
+++ b/services/gateway-go/internal/auth/siwe.go
@@ -52,6 +52,16 @@ type Handlers struct {
 	now func() time.Time // overridable in tests for ValidAt assertions
 }
 
+// Signer returns the JWT signer this handler bundle was constructed with.
+// Exposed so adjacent auth flows (SIWS) can be wired off the same signer
+// without re-reading env or duplicating secrets in memory.
+func (h *Handlers) Signer() *JWTSigner { return h.cfg.Signer }
+
+// Store returns the session store this handler bundle was constructed
+// with. Same rationale as Signer — SIWS reuses the SIWE store so a single
+// nonce namespace and a single session namespace span both flows.
+func (h *Handlers) Store() SessionStore { return h.cfg.Store }
+
 // NewHandlers wires the handler dependencies after validating that all the
 // required fields are present. Failing here at startup is preferable to
 // failing on the first request.

--- a/services/gateway-go/internal/auth/siws.go
+++ b/services/gateway-go/internal/auth/siws.go
@@ -1,0 +1,421 @@
+package auth
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mr-tron/base58"
+)
+
+// SIWS (Sign-In With Solana) parallels the SIWE flow but with ed25519
+// signatures and base58 Solana addresses. The wire format is intentionally
+// kept symmetric to EIP-4361 so a single client implementation can target
+// both chains by swapping the cluster/chain identifier.
+//
+// We do NOT pull in the heavy github.com/gagliardetto/solana-go SDK: the
+// auth path needs only base58 + ed25519, both of which are available from
+// stdlib (crypto/ed25519, which is constant-time) and a tiny base58
+// package (github.com/mr-tron/base58, the canonical Solana base58 lib).
+// Adding the full SDK would drag in dozens of indirect deps for zero
+// security benefit.
+
+// Cluster identifies a Solana network. We pin it server-side (parallel to
+// SIWE's chain id) so a message signed against devnet cannot be replayed
+// against mainnet, or vice versa.
+const (
+	ClusterDevnet      = "devnet"
+	ClusterMainnetBeta = "mainnet-beta"
+	ClusterTestnet     = "testnet"
+)
+
+// solanaPubKeyLen is the byte length of an ed25519 public key, which is
+// also the byte length of a Solana wallet address before base58 encoding.
+const solanaPubKeyLen = ed25519.PublicKeySize // 32
+
+// SIWSHandlerConfig holds the request-time dependencies for the SIWS
+// handlers. It mirrors HandlerConfig so the wiring code in cmd/gateway is
+// symmetric.
+//
+// Domain is the value the SIWS message MUST declare. We pin it server-side
+// rather than echoing whatever the message contained so a SIWS message
+// signed for some-other-app.example cannot be replayed against this
+// gateway.
+//
+// Cluster is the Solana network the message MUST declare. Devnet messages
+// MUST NOT validate against a mainnet deployment, and vice versa.
+//
+// NonceTTL controls how long an issued nonce stays valid. Defaults to
+// DefaultNonceTTL when zero.
+//
+// Store / Signer are reused from the SIWE flow so a logout against either
+// path invalidates the same JWT, and so RequireAuth can stay
+// chain-agnostic.
+type SIWSHandlerConfig struct {
+	Store    SessionStore
+	Signer   *JWTSigner
+	Domain   string
+	Cluster  string
+	NonceTTL time.Duration
+}
+
+// SIWSHandlers exposes the SIWS HTTP handlers as Gin handler funcs.
+// Construct via NewSIWSHandlers — the zero value is unsafe.
+type SIWSHandlers struct {
+	cfg SIWSHandlerConfig
+	now func() time.Time // overridable in tests
+}
+
+// NewSIWSHandlers wires the handler dependencies after validating that all
+// required fields are present. Failing here at startup is preferable to
+// failing on the first request.
+func NewSIWSHandlers(cfg SIWSHandlerConfig) (*SIWSHandlers, error) {
+	if cfg.Store == nil {
+		return nil, errors.New("auth: nil session store")
+	}
+	if cfg.Signer == nil {
+		return nil, errors.New("auth: nil jwt signer")
+	}
+	if strings.TrimSpace(cfg.Domain) == "" {
+		return nil, errors.New("auth: domain required")
+	}
+	switch cfg.Cluster {
+	case ClusterDevnet, ClusterMainnetBeta, ClusterTestnet:
+		// ok
+	default:
+		return nil, fmt.Errorf("auth: cluster must be one of %q/%q/%q, got %q",
+			ClusterDevnet, ClusterMainnetBeta, ClusterTestnet, cfg.Cluster)
+	}
+	if cfg.NonceTTL <= 0 {
+		cfg.NonceTTL = DefaultNonceTTL
+	}
+	return &SIWSHandlers{cfg: cfg, now: time.Now}, nil
+}
+
+// Nonce issues a fresh nonce and stores it in the session store with the
+// configured TTL. The endpoint is intended to be hit unauthenticated, so
+// callers SHOULD wire it behind the existing rate-limit middleware.
+//
+// The nonce namespace is shared with SIWE: a single nonce issued via
+// /auth/siws/nonce can only be consumed once across BOTH paths. This is
+// the right call because the nonce is just an entropy token; the chain
+// binding happens via the signed message, not the nonce.
+func (h *SIWSHandlers) Nonce(c *gin.Context) {
+	nonce, err := RandomNonce(nonceByteLen)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "internal_error", "failed to issue nonce")
+		return
+	}
+	if err := h.cfg.Store.PutNonce(c.Request.Context(), nonce, h.cfg.NonceTTL); err != nil {
+		writeError(c, http.StatusInternalServerError, "internal_error", "failed to issue nonce")
+		return
+	}
+	c.JSON(http.StatusOK, nonceResponse{
+		Nonce:     nonce,
+		ExpiresAt: h.now().Add(h.cfg.NonceTTL).Unix(),
+	})
+}
+
+// siwsVerifyRequest is the wire shape of POST /auth/siws/verify. We accept
+// the raw SIWS message string verbatim and parse it server-side; clients
+// MUST NOT send the parsed fields, otherwise we'd have two sources of
+// truth and a reliable channel for clients to confuse the verifier.
+//
+// Signature is a base58-encoded ed25519 signature (64 bytes). Phantom and
+// Backpack both return base58 from signMessage.
+type siwsVerifyRequest struct {
+	Message   string `json:"message"   binding:"required"`
+	Signature string `json:"signature" binding:"required"`
+}
+
+// Verify parses, validates, consumes the nonce, recovers the signer and
+// (on success) issues the JWT + Redis session. The order matches the SIWE
+// flow:
+//
+//  1. Decode JSON body.
+//  2. Parse SIWS message.
+//  3. Static checks: domain, cluster, time window, address well-formed.
+//  4. Atomic ConsumeNonce — single-use guarantee.
+//  5. ed25519 verify (constant-time, stdlib).
+//  6. Mint JWT, persist session, return.
+//
+// On step 5 we DO consume the nonce before signature verification (same
+// rationale as SIWE: a successful recovery against a stale-but-not-yet
+// deleted nonce cannot mint two sessions).
+func (h *SIWSHandlers) Verify(c *gin.Context) {
+	var req siwsVerifyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_request", "invalid request body")
+		return
+	}
+
+	msg, err := ParseSIWSMessage(req.Message)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "invalid_message", "could not parse SIWS message")
+		return
+	}
+
+	// 3a. Domain pin: the message MUST be addressed to us.
+	if msg.Domain != h.cfg.Domain {
+		writeError(c, http.StatusBadRequest, "domain_mismatch", "message domain mismatch")
+		return
+	}
+	// 3b. Cluster pin: the message MUST be on our network.
+	if msg.Cluster != h.cfg.Cluster {
+		writeError(c, http.StatusBadRequest, "cluster_mismatch", "message cluster mismatch")
+		return
+	}
+	// 3c. Time window: covers expirationTime (and notBefore if present).
+	if err := msg.ValidAt(h.now()); err != nil {
+		writeError(c, http.StatusBadRequest, "expired_message", "message outside validity window")
+		return
+	}
+
+	// 3d. Decode the address eagerly so a malformed address never reaches
+	// nonce consumption. base58 of an ed25519 pubkey is exactly 32 bytes.
+	pubkey, err := base58.Decode(msg.Address)
+	if err != nil || len(pubkey) != solanaPubKeyLen {
+		writeError(c, http.StatusBadRequest, "invalid_address", "address is not a valid Solana pubkey")
+		return
+	}
+
+	// 4. Atomic single-use consume. If this fails the nonce was either
+	//    forged, expired, or already used. We cannot — and must not —
+	//    distinguish, so the response is generic.
+	if err := h.cfg.Store.ConsumeNonce(c.Request.Context(), msg.Nonce); err != nil {
+		writeError(c, http.StatusUnauthorized, "invalid_nonce", "invalid or expired nonce")
+		return
+	}
+
+	// 5. Signature verify. ed25519.Verify is constant-time per the stdlib
+	//    contract. We surface a single generic code on failure so the
+	//    "valid sig wrong signer" / "invalid sig" distinction is not a
+	//    side channel.
+	sig, err := base58.Decode(req.Signature)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		writeError(c, http.StatusUnauthorized, "invalid_signature", "signature did not verify")
+		return
+	}
+	if !ed25519.Verify(ed25519.PublicKey(pubkey), []byte(req.Message), sig) {
+		writeError(c, http.StatusUnauthorized, "invalid_signature", "signature did not verify")
+		return
+	}
+
+	// 6. Mint + persist. Address is taken FROM the message (which is now
+	//    proven to be signed by it). Solana addresses are case-sensitive
+	//    base58 — we keep the original casing so claim/session keys round-
+	//    trip exactly.
+	address := msg.Address
+	token, jti, err := h.cfg.Signer.Sign(address)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, "internal_error", "failed to issue session")
+		return
+	}
+	if err := h.cfg.Store.PutSession(c.Request.Context(), jti, address, h.cfg.Signer.ttl); err != nil {
+		writeError(c, http.StatusInternalServerError, "internal_error", "failed to persist session")
+		return
+	}
+
+	c.JSON(http.StatusOK, verifyResponse{
+		Token:     token,
+		Address:   address,
+		ExpiresAt: h.now().Add(h.cfg.Signer.ttl).Unix(),
+	})
+}
+
+// SIWSMessage is the parsed form of a SIWS message. Field semantics mirror
+// EIP-4361 with one substitution: ChainID becomes Cluster ("devnet" /
+// "mainnet-beta" / "testnet"), reflecting how Solana names its networks.
+//
+// We hold the raw text (Raw) so the verifier signs exactly the bytes that
+// were sent — there is no field-by-field re-serialisation step that could
+// canonicalise differences between parser and signer.
+type SIWSMessage struct {
+	Domain         string
+	Address        string
+	Statement      string
+	URI            string
+	Version        string
+	Cluster        string
+	Nonce          string
+	IssuedAt       time.Time
+	ExpirationTime time.Time // zero if absent
+	NotBefore      time.Time // zero if absent
+	RequestID      string    // optional
+	Raw            string
+}
+
+// ValidAt returns nil iff the message's time window includes t. A message
+// without expiration and not-before fields is considered always-valid by
+// time alone (the nonce TTL is the real upper bound).
+func (m *SIWSMessage) ValidAt(t time.Time) error {
+	if !m.NotBefore.IsZero() && t.Before(m.NotBefore) {
+		return errors.New("message not yet valid")
+	}
+	if !m.ExpirationTime.IsZero() && !t.Before(m.ExpirationTime) {
+		return errors.New("message expired")
+	}
+	return nil
+}
+
+// ParseSIWSMessage parses an EIP-4361-shaped message that uses Solana
+// conventions. The grammar is intentionally strict — we refuse anything
+// that does not match the canonical layout so a tolerant parser cannot be
+// used as a confusion vector.
+//
+// Canonical layout (line-separated):
+//
+//	<domain> wants you to sign in with your Solana account:
+//	<address>
+//	[empty line]
+//	[<statement>]
+//	[empty line]
+//	URI: <uri>
+//	Version: <version>
+//	Chain ID: <cluster>
+//	Nonce: <nonce>
+//	Issued At: <RFC3339 timestamp>
+//	[Expiration Time: <RFC3339 timestamp>]
+//	[Not Before: <RFC3339 timestamp>]
+//	[Request ID: <opaque>]
+//
+// We tolerate the cluster being declared as either "Chain ID" (matching
+// the SIWE field name; what most port-of-SIWE clients emit) or the
+// alternate "Cluster" key. We do NOT accept arbitrary trailing fields:
+// resources/scopes are explicitly out of scope until we have a use case.
+func ParseSIWSMessage(raw string) (*SIWSMessage, error) {
+	if raw == "" {
+		return nil, errors.New("empty message")
+	}
+	lines := strings.Split(raw, "\n")
+	if len(lines) < 7 {
+		return nil, errors.New("message too short")
+	}
+
+	m := &SIWSMessage{Raw: raw}
+
+	// Header: "<domain> wants you to sign in with your Solana account:"
+	const headerSuffix = " wants you to sign in with your Solana account:"
+	header := lines[0]
+	if !strings.HasSuffix(header, headerSuffix) {
+		return nil, errors.New("missing or malformed header")
+	}
+	m.Domain = strings.TrimSuffix(header, headerSuffix)
+	if m.Domain == "" {
+		return nil, errors.New("empty domain")
+	}
+
+	// Address line.
+	m.Address = strings.TrimSpace(lines[1])
+	if m.Address == "" {
+		return nil, errors.New("empty address")
+	}
+
+	// After the address there is an empty line. If a statement is
+	// present, it follows; if absent, the URI block follows directly.
+	idx := 2
+	if idx >= len(lines) || lines[idx] != "" {
+		return nil, errors.New("missing blank line after address")
+	}
+	idx++
+	// Optional statement: a single line followed by a blank line. We
+	// detect by looking ahead for the URI marker; if the next line starts
+	// with "URI:" there is no statement.
+	if idx < len(lines) && !strings.HasPrefix(lines[idx], "URI:") {
+		m.Statement = lines[idx]
+		idx++
+		if idx >= len(lines) || lines[idx] != "" {
+			return nil, errors.New("missing blank line after statement")
+		}
+		idx++
+	}
+
+	// From here we expect the keyed block. Each remaining line must be
+	// "<key>: <value>" or empty (terminator). Unknown keys are refused.
+	seen := map[string]bool{}
+	for ; idx < len(lines); idx++ {
+		ln := lines[idx]
+		if ln == "" {
+			continue
+		}
+		colon := strings.Index(ln, ":")
+		if colon < 0 {
+			return nil, fmt.Errorf("line %d missing colon", idx)
+		}
+		key := strings.TrimSpace(ln[:colon])
+		val := strings.TrimSpace(ln[colon+1:])
+		if seen[key] {
+			return nil, fmt.Errorf("duplicate field %q", key)
+		}
+		seen[key] = true
+		switch key {
+		case "URI":
+			m.URI = val
+		case "Version":
+			m.Version = val
+		case "Chain ID", "Cluster":
+			// Either spelling lands in the same field — see grammar
+			// note above. Refuse if both appear.
+			if m.Cluster != "" {
+				return nil, errors.New("cluster declared twice")
+			}
+			m.Cluster = val
+		case "Nonce":
+			m.Nonce = val
+		case "Issued At":
+			t, err := time.Parse(time.RFC3339, val)
+			if err != nil {
+				return nil, fmt.Errorf("issued at: %w", err)
+			}
+			m.IssuedAt = t
+		case "Expiration Time":
+			t, err := time.Parse(time.RFC3339, val)
+			if err != nil {
+				return nil, fmt.Errorf("expiration time: %w", err)
+			}
+			m.ExpirationTime = t
+		case "Not Before":
+			t, err := time.Parse(time.RFC3339, val)
+			if err != nil {
+				return nil, fmt.Errorf("not before: %w", err)
+			}
+			m.NotBefore = t
+		case "Request ID":
+			m.RequestID = val
+		default:
+			return nil, fmt.Errorf("unknown field %q", key)
+		}
+	}
+
+	// Required-field invariants.
+	if m.URI == "" {
+		return nil, errors.New("missing URI")
+	}
+	if m.Version == "" {
+		return nil, errors.New("missing Version")
+	}
+	if m.Cluster == "" {
+		return nil, errors.New("missing Chain ID/Cluster")
+	}
+	if m.Nonce == "" {
+		return nil, errors.New("missing Nonce")
+	}
+	if m.IssuedAt.IsZero() {
+		return nil, errors.New("missing Issued At")
+	}
+	// Defence-in-depth: refuse a nonce containing anything that isn't a
+	// printable ASCII byte. Our own nonces are hex; a crafted message
+	// with control characters in the nonce should never round-trip
+	// through Redis as a sane key.
+	for i := 0; i < len(m.Nonce); i++ {
+		c := m.Nonce[i]
+		if c < 0x21 || c > 0x7e {
+			return nil, errors.New("nonce contains non-printable byte")
+		}
+	}
+	return m, nil
+}

--- a/services/gateway-go/internal/auth/siws_test.go
+++ b/services/gateway-go/internal/auth/siws_test.go
@@ -1,0 +1,589 @@
+package auth_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mr-tron/base58"
+
+	"github.com/0xDevNinja/titular/services/gateway-go/internal/auth"
+)
+
+// signedSIWS returns a canonical SIWS message string, a base58 ed25519
+// signature over it, and the signer's pubkey (base58, == Solana address).
+// We synthesise rather than hard-coding fixtures so the keys are opaque to
+// the rest of the suite.
+func signedSIWS(t *testing.T, domain, cluster, nonce string) (msg, sig, addr string, priv ed25519.PrivateKey) {
+	t.Helper()
+	pub, p, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	priv = p
+	addr = base58.Encode(pub)
+
+	issuedAt := time.Now().UTC().Format(time.RFC3339)
+	msg = fmt.Sprintf(
+		"%s wants you to sign in with your Solana account:\n%s\n\nSign in to Titular\n\nURI: https://%s\nVersion: 1\nChain ID: %s\nNonce: %s\nIssued At: %s",
+		domain, addr, domain, cluster, nonce, issuedAt,
+	)
+	sigBytes := ed25519.Sign(priv, []byte(msg))
+	sig = base58.Encode(sigBytes)
+	return
+}
+
+// newSIWSHandlers wires a fresh SIWS handler bundle backed by miniredis.
+func newSIWSHandlers(t *testing.T, domain, cluster string) (*auth.SIWSHandlers, auth.SessionStore, *auth.JWTSigner) {
+	t.Helper()
+	_, c := newRedis(t)
+	store := auth.NewRedisStore(c)
+	signer, err := auth.NewJWTSigner(auth.SignerConfig{
+		Secret: []byte(strings.Repeat("k", 32)),
+		Issuer: "gateway-test",
+		TTL:    time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewJWTSigner: %v", err)
+	}
+	h, err := auth.NewSIWSHandlers(auth.SIWSHandlerConfig{
+		Store:    store,
+		Signer:   signer,
+		Domain:   domain,
+		Cluster:  cluster,
+		NonceTTL: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewSIWSHandlers: %v", err)
+	}
+	return h, store, signer
+}
+
+func siwsRoute(h *auth.SIWSHandlers) *gin.Engine {
+	r := gin.New()
+	g := r.Group("/auth")
+	g.POST("/siws/nonce", h.Nonce)
+	g.POST("/siws/verify", h.Verify)
+	return r
+}
+
+func TestSIWS_NewHandlers_Validation(t *testing.T) {
+	signer, _ := auth.NewJWTSigner(auth.SignerConfig{
+		Secret: []byte(strings.Repeat("k", 32)),
+		Issuer: "gateway-test",
+		TTL:    time.Hour,
+	})
+	_, c := newRedis(t)
+	store := auth.NewRedisStore(c)
+
+	cases := []struct {
+		name string
+		cfg  auth.SIWSHandlerConfig
+	}{
+		{"nil store", auth.SIWSHandlerConfig{Signer: signer, Domain: "d", Cluster: auth.ClusterDevnet}},
+		{"nil signer", auth.SIWSHandlerConfig{Store: store, Domain: "d", Cluster: auth.ClusterDevnet}},
+		{"empty domain", auth.SIWSHandlerConfig{Store: store, Signer: signer, Cluster: auth.ClusterDevnet}},
+		{"empty cluster", auth.SIWSHandlerConfig{Store: store, Signer: signer, Domain: "d"}},
+		{"bad cluster", auth.SIWSHandlerConfig{Store: store, Signer: signer, Domain: "d", Cluster: "polkadot"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := auth.NewSIWSHandlers(tc.cfg); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestSIWS_Nonce_IssuesAndStores(t *testing.T) {
+	h, _, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/nonce", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var body struct {
+		Nonce     string `json:"nonce"`
+		ExpiresAt int64  `json:"expires_at"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Nonce) == 0 {
+		t.Fatal("empty nonce returned")
+	}
+	if body.ExpiresAt <= time.Now().Unix() {
+		t.Fatalf("expires_at %d is in the past", body.ExpiresAt)
+	}
+}
+
+func TestSIWS_Verify_HappyPath_IssuesJWTAndConsumesNonce(t *testing.T) {
+	h, store, signer := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	if err := store.PutNonce(t.Context(), nonce, time.Minute); err != nil {
+		t.Fatalf("seed nonce: %v", err)
+	}
+
+	msg, sig, addr, _ := signedSIWS(t, "titular.test", auth.ClusterDevnet, nonce)
+
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": sig})
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Token   string `json:"token"`
+		Address string `json:"address"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Address != addr {
+		t.Fatalf("address: got %q, want %q", resp.Address, addr)
+	}
+	// Token must parse back to a session bound to the same lowercased address.
+	claims, err := signer.Parse(resp.Token)
+	if err != nil {
+		t.Fatalf("parse issued token: %v", err)
+	}
+	if !strings.EqualFold(claims.Address, addr) {
+		t.Fatalf("token addr: got %q, want %q", claims.Address, addr)
+	}
+	if _, err := store.SessionExists(t.Context(), claims.ID); err != nil {
+		t.Fatalf("session not present: %v", err)
+	}
+	// Nonce must be gone — single-use.
+	if err := store.ConsumeNonce(t.Context(), nonce); err == nil {
+		t.Fatal("nonce was not consumed by verify")
+	}
+}
+
+func TestSIWS_Verify_ReplayNonce_RefusedOnSecondCall(t *testing.T) {
+	h, store, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+	msg, sig, _, _ := signedSIWS(t, "titular.test", auth.ClusterDevnet, nonce)
+
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": sig})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first verify: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("replay: got %d, want 401, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid_nonce") {
+		t.Fatalf("replay body: %s", rec.Body.String())
+	}
+}
+
+func TestSIWS_Verify_DomainMismatch(t *testing.T) {
+	h, store, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+
+	msg, sig, _, _ := signedSIWS(t, "evil.test", auth.ClusterDevnet, nonce)
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": sig})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "domain_mismatch") {
+		t.Fatalf("expected domain_mismatch, got %s", rec.Body.String())
+	}
+	// Nonce must NOT have been consumed (we reject before ConsumeNonce).
+	msgGood, sigGood, _, _ := signedSIWS(t, "titular.test", auth.ClusterDevnet, nonce)
+	body, _ = json.Marshal(map[string]string{"message": msgGood, "signature": sigGood})
+	req = httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("retry after domain reject: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSIWS_Verify_ClusterMismatch(t *testing.T) {
+	h, store, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+
+	// Sign for mainnet-beta when the gateway is pinned to devnet.
+	msg, sig, _, _ := signedSIWS(t, "titular.test", auth.ClusterMainnetBeta, nonce)
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": sig})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "cluster_mismatch") {
+		t.Fatalf("expected cluster_mismatch, got %s", rec.Body.String())
+	}
+}
+
+func TestSIWS_Verify_BadSignature_ConsumesNonceAnyway(t *testing.T) {
+	// Once static checks pass, ConsumeNonce runs BEFORE signature verify
+	// so a single nonce can never service two attempts — even one with a
+	// bad sig. This test pins that behaviour.
+	h, store, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+
+	msg, _, _, _ := signedSIWS(t, "titular.test", auth.ClusterDevnet, nonce)
+	// Forge a sig: 64 bytes of zeros, base58 encoded — wrong shape but
+	// passes the size check after decode (still won't verify).
+	badSig := base58.Encode(make([]byte, ed25519.SignatureSize))
+
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": badSig})
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid_signature") {
+		t.Fatalf("expected invalid_signature, got %s", rec.Body.String())
+	}
+	// Nonce must be gone.
+	if err := store.ConsumeNonce(t.Context(), nonce); err == nil {
+		t.Fatal("bad-sig verify left the nonce intact; that allows brute force")
+	}
+}
+
+func TestSIWS_Verify_WrongSignerForeignKey(t *testing.T) {
+	// Sig is well-formed but produced by a different key than the message
+	// claims. Must fail with invalid_signature.
+	h, store, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+
+	msg, _, _, _ := signedSIWS(t, "titular.test", auth.ClusterDevnet, nonce)
+	// Re-sign the message bytes with a foreign key.
+	_, foreign, _ := ed25519.GenerateKey(rand.Reader)
+	foreignSigBytes := ed25519.Sign(foreign, []byte(msg))
+	foreignSig := base58.Encode(foreignSigBytes)
+
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": foreignSig})
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid_signature") {
+		t.Fatalf("expected invalid_signature, got %s", rec.Body.String())
+	}
+}
+
+func TestSIWS_Verify_TamperedMessage(t *testing.T) {
+	// Sig is valid for the original message but the message we POST is
+	// modified by one byte. ed25519.Verify must fail.
+	h, store, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+
+	msg, sig, _, _ := signedSIWS(t, "titular.test", auth.ClusterDevnet, nonce)
+	tampered := strings.Replace(msg, "Sign in to Titular", "Sign in to Evil   ", 1)
+
+	body, _ := json.Marshal(map[string]string{"message": tampered, "signature": sig})
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid_signature") {
+		t.Fatalf("expected invalid_signature, got %s", rec.Body.String())
+	}
+}
+
+func TestSIWS_Verify_MalformedJSON(t *testing.T) {
+	h, _, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", strings.NewReader("{not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSIWS_Verify_UnparseableMessage(t *testing.T) {
+	h, _, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	body, _ := json.Marshal(map[string]string{"message": "definitely not siws", "signature": base58.Encode(make([]byte, 64))})
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid_message") {
+		t.Fatalf("expected invalid_message, got %s", rec.Body.String())
+	}
+}
+
+func TestSIWS_Verify_InvalidAddress_NotBase58(t *testing.T) {
+	h, store, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+
+	// Hand-craft a message with a malformed address (contains '0' which
+	// is not a valid base58 char — base58 alphabet skips 0OIl).
+	msg := fmt.Sprintf(
+		"titular.test wants you to sign in with your Solana account:\n0badaddress\n\nSign in to Titular\n\nURI: https://titular.test\nVersion: 1\nChain ID: %s\nNonce: %s\nIssued At: %s",
+		auth.ClusterDevnet, nonce, time.Now().UTC().Format(time.RFC3339),
+	)
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": base58.Encode(make([]byte, 64))})
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "invalid_address") {
+		t.Fatalf("expected invalid_address, got %s", rec.Body.String())
+	}
+	// Nonce must NOT have been consumed.
+	if err := store.ConsumeNonce(t.Context(), nonce); err != nil {
+		t.Fatalf("invalid_address path consumed the nonce: %v", err)
+	}
+}
+
+func TestSIWS_Verify_ExpiredMessage(t *testing.T) {
+	h, store, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	addr := base58.Encode(pub)
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	msg := fmt.Sprintf(
+		"titular.test wants you to sign in with your Solana account:\n%s\n\nSign in to Titular\n\nURI: https://titular.test\nVersion: 1\nChain ID: %s\nNonce: %s\nIssued At: %s\nExpiration Time: %s",
+		addr, auth.ClusterDevnet, nonce, past, past,
+	)
+	sig := base58.Encode(ed25519.Sign(priv, []byte(msg)))
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": sig})
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "expired_message") {
+		t.Fatalf("expected expired_message, got %s", rec.Body.String())
+	}
+}
+
+func TestSIWS_Verify_ResponseBodyDoesNotLeakSignerKey(t *testing.T) {
+	// Defence-in-depth: the response envelope must contain exactly the
+	// documented fields and never serialise the HMAC secret.
+	h, store, _ := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+	msg, sig, _, _ := signedSIWS(t, "titular.test", auth.ClusterDevnet, nonce)
+
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": sig})
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), strings.Repeat("k", 32)) {
+		t.Fatal("verify response body leaked the HMAC secret")
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	allowed := map[string]bool{"token": true, "address": true, "expires_at": true}
+	for k := range raw {
+		if !allowed[k] {
+			t.Errorf("unexpected response field %q", k)
+		}
+	}
+}
+
+// TestSIWS_AuthMiddleware_AcceptsSIWSToken proves the existing RequireAuth
+// middleware accepts a JWT minted by the SIWS path. The two flows MUST be
+// indistinguishable at the protected-route layer.
+func TestSIWS_AuthMiddleware_AcceptsSIWSToken(t *testing.T) {
+	h, store, signer := newSIWSHandlers(t, "titular.test", auth.ClusterDevnet)
+	r := siwsRoute(h)
+
+	nonce, _ := auth.RandomNonce(16)
+	_ = store.PutNonce(t.Context(), nonce, time.Minute)
+	msg, sig, addr, _ := signedSIWS(t, "titular.test", auth.ClusterDevnet, nonce)
+
+	body, _ := json.Marshal(map[string]string{"message": msg, "signature": sig})
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("verify failed: %d %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Token string `json:"token"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	// Build a SIWE Handlers bound to the SAME store and signer so the
+	// shared RequireAuth path can be exercised. This mirrors the runtime
+	// wiring where one *auth.Handlers governs logout for both flows.
+	siwe, err := auth.NewHandlers(auth.HandlerConfig{
+		Store:   store,
+		Signer:  signer,
+		Domain:  "titular.test",
+		ChainID: 84532,
+	})
+	if err != nil {
+		t.Fatalf("NewHandlers: %v", err)
+	}
+	guarded := gin.New()
+	guarded.GET("/me", auth.RequireAuth(siwe), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"address": auth.AddressFromContext(c)})
+	})
+
+	req = httptest.NewRequest(http.MethodGet, "/me", nil)
+	req.Header.Set("Authorization", "Bearer "+resp.Token)
+	rec = httptest.NewRecorder()
+	guarded.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("RequireAuth rejected SIWS token: %d %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), addr) {
+		t.Fatalf("address not propagated: %s", rec.Body.String())
+	}
+}
+
+// TestParseSIWSMessage_RoundTrip exercises the parser directly with both
+// the SIWE-style "Chain ID:" key and the alternate "Cluster:" key, plus
+// optional fields.
+func TestParseSIWSMessage_RoundTrip(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "chain id key minimal",
+			raw: fmt.Sprintf(
+				"titular.test wants you to sign in with your Solana account:\n4Nd1m5dJfMaPjV4z9LhPwbqoGSoMpQ6gPYwJoT3KQA8q\n\nURI: https://titular.test\nVersion: 1\nChain ID: devnet\nNonce: aabbcc\nIssued At: %s",
+				now.Format(time.RFC3339),
+			),
+		},
+		{
+			name: "cluster key with statement and expiration",
+			raw: fmt.Sprintf(
+				"titular.test wants you to sign in with your Solana account:\n4Nd1m5dJfMaPjV4z9LhPwbqoGSoMpQ6gPYwJoT3KQA8q\n\nWelcome to Titular\n\nURI: https://titular.test\nVersion: 1\nCluster: mainnet-beta\nNonce: aabbcc\nIssued At: %s\nExpiration Time: %s\nRequest ID: req-1",
+				now.Format(time.RFC3339), now.Add(time.Hour).Format(time.RFC3339),
+			),
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := auth.ParseSIWSMessage(tc.raw)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if m.Domain != "titular.test" {
+				t.Errorf("domain: %q", m.Domain)
+			}
+			if m.Nonce != "aabbcc" {
+				t.Errorf("nonce: %q", m.Nonce)
+			}
+			if m.Version != "1" {
+				t.Errorf("version: %q", m.Version)
+			}
+		})
+	}
+}
+
+func TestParseSIWSMessage_RejectsBadShape(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"empty", ""},
+		{"missing header", "not-titular wants...\naddr\n\nURI: x\nVersion: 1\nChain ID: devnet\nNonce: n\nIssued At: 2026-01-01T00:00:00Z"},
+		{"missing required", "titular.test wants you to sign in with your Solana account:\naddr\n\nURI: x\nVersion: 1\nNonce: n\nIssued At: 2026-01-01T00:00:00Z"},
+		{"bad time", "titular.test wants you to sign in with your Solana account:\naddr\n\nURI: x\nVersion: 1\nChain ID: devnet\nNonce: n\nIssued At: not-a-time"},
+		{"unknown field", "titular.test wants you to sign in with your Solana account:\naddr\n\nURI: x\nVersion: 1\nChain ID: devnet\nNonce: n\nIssued At: 2026-01-01T00:00:00Z\nFavourite Colour: blue"},
+		{"duplicate field", "titular.test wants you to sign in with your Solana account:\naddr\n\nURI: x\nVersion: 1\nChain ID: devnet\nChain ID: testnet\nNonce: n\nIssued At: 2026-01-01T00:00:00Z"},
+		{"control char in nonce", "titular.test wants you to sign in with your Solana account:\naddr\n\nURI: x\nVersion: 1\nChain ID: devnet\nNonce: \x01bad\nIssued At: 2026-01-01T00:00:00Z"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := auth.ParseSIWSMessage(tc.raw); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/services/gateway-go/internal/router/router.go
+++ b/services/gateway-go/internal/router/router.go
@@ -47,6 +47,12 @@ import (
 // /auth/siwe/nonce, /auth/siwe/verify and /auth/logout when present. When
 // nil, the auth endpoints are simply absent — useful in tests that don't
 // want to spin up Redis.
+//
+// SIWS, when non-nil, is the Sign-In-With-Solana handler bundle. The
+// router mounts /auth/siws/nonce and /auth/siws/verify when present. The
+// SIWS path reuses the SIWE /auth/logout endpoint via the shared JWT
+// signer and session store, so a SIWS-minted token logs out through the
+// same handler as a SIWE-minted one.
 type Config struct {
 	Logger         zerolog.Logger
 	Service        string
@@ -54,6 +60,7 @@ type Config struct {
 	RateLimit      middleware.RateLimitConfig
 	TrustedProxies []string
 	Auth           *auth.Handlers
+	SIWS           *auth.SIWSHandlers
 }
 
 // DefaultConfig returns a Config suitable for local development.
@@ -172,15 +179,25 @@ func NewWithConfigLifecycle(
 		c.String(http.StatusOK, `{"status":"ok"}`)
 	})
 
-	// SIWE auth — mounted before /v1 so the routes can never be accidentally
-	// shadowed by a /v1/* catch-all. The /auth group inherits the rate
-	// limiter (#86 OWASP gate) but, by design, NOT RequireAuth — the verify
-	// endpoint is what bootstraps the session in the first place.
-	if cfg.Auth != nil {
+	// SIWE/SIWS auth — mounted before /v1 so the routes can never be
+	// accidentally shadowed by a /v1/* catch-all. The /auth group inherits
+	// the rate limiter (#86 OWASP gate) but, by design, NOT RequireAuth —
+	// the verify endpoints are what bootstrap the session in the first
+	// place.
+	//
+	// SIWS reuses the SIWE Logout handler (cfg.Auth.Logout) because the
+	// JWT signer + Redis session store are shared across both paths.
+	if cfg.Auth != nil || cfg.SIWS != nil {
 		authGroup := engine.Group("/auth")
-		authGroup.POST("/siwe/nonce", cfg.Auth.Nonce)
-		authGroup.POST("/siwe/verify", cfg.Auth.Verify)
-		authGroup.POST("/logout", cfg.Auth.Logout)
+		if cfg.Auth != nil {
+			authGroup.POST("/siwe/nonce", cfg.Auth.Nonce)
+			authGroup.POST("/siwe/verify", cfg.Auth.Verify)
+			authGroup.POST("/logout", cfg.Auth.Logout)
+		}
+		if cfg.SIWS != nil {
+			authGroup.POST("/siws/nonce", cfg.SIWS.Nonce)
+			authGroup.POST("/siws/verify", cfg.SIWS.Verify)
+		}
 	}
 
 	// Mount chi for the legacy /v1 fixture endpoints. We bind under a

--- a/services/gateway-go/internal/router/router_siws_test.go
+++ b/services/gateway-go/internal/router/router_siws_test.go
@@ -1,0 +1,158 @@
+package router_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/0xDevNinja/titular/services/gateway-go/internal/auth"
+	"github.com/0xDevNinja/titular/services/gateway-go/internal/handlers"
+	"github.com/0xDevNinja/titular/services/gateway-go/internal/router"
+)
+
+// siwsFixtureRouter wires the production router with both SIWE and SIWS
+// handler bundles backed by miniredis. Mirrors authFixtureRouter so the
+// SIWS tests don't depend on production env wiring.
+func siwsFixtureRouter(t *testing.T) (http.Handler, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	c := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = c.Close() })
+
+	signer, err := auth.NewJWTSigner(auth.SignerConfig{
+		Secret: []byte(strings.Repeat("k", 32)),
+		Issuer: "gateway-test",
+		TTL:    time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewJWTSigner: %v", err)
+	}
+	store := auth.NewRedisStore(c)
+	siwe, err := auth.NewHandlers(auth.HandlerConfig{
+		Store:   store,
+		Signer:  signer,
+		Domain:  "titular.test",
+		ChainID: 84532,
+	})
+	if err != nil {
+		t.Fatalf("NewHandlers: %v", err)
+	}
+	siws, err := auth.NewSIWSHandlers(auth.SIWSHandlerConfig{
+		Store:   store,
+		Signer:  signer,
+		Domain:  "titular.test",
+		Cluster: auth.ClusterDevnet,
+	})
+	if err != nil {
+		t.Fatalf("NewSIWSHandlers: %v", err)
+	}
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Join(filepath.Dir(file), "..", "handlers", "fixtures")
+	hs, err := handlers.NewStoreFromDir(dir)
+	if err != nil {
+		t.Fatalf("load fixture store: %v", err)
+	}
+	ah := handlers.NewAgentHandlersWithStore(hs)
+	jh := handlers.NewJobHandlersWithStore(hs)
+
+	cfg := router.DefaultConfig()
+	cfg.Auth = siwe
+	cfg.SIWS = siws
+	return router.NewWithConfig(cfg, ah, jh), mr
+}
+
+func TestRouter_SIWSNonceMounted(t *testing.T) {
+	h, _ := siwsFixtureRouter(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/siws/nonce", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := body["nonce"].(string); !ok {
+		t.Fatalf("response missing nonce: %v", body)
+	}
+}
+
+// SIWS routes must coexist with SIWE routes. A regression where one mount
+// shadowed the other would surface as a 404.
+func TestRouter_SIWSRoutesNotShadowed(t *testing.T) {
+	h, _ := siwsFixtureRouter(t)
+
+	for _, p := range []string{
+		"/auth/siwe/nonce", "/auth/siwe/verify", "/auth/logout",
+		"/auth/siws/nonce", "/auth/siws/verify",
+	} {
+		req := httptest.NewRequest(http.MethodPost, p, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code == http.StatusNotFound {
+			t.Errorf("path %s returned 404; mount regressed", p)
+		}
+	}
+}
+
+// When SIWS is unset, /auth/siws/* must NOT be mounted, even if SIWE is
+// enabled. This pins the additive nature of the new flag.
+func TestRouter_SIWSOptional(t *testing.T) {
+	mr := miniredis.RunT(t)
+	c := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = c.Close() })
+
+	signer, _ := auth.NewJWTSigner(auth.SignerConfig{
+		Secret: []byte(strings.Repeat("k", 32)),
+		Issuer: "gateway-test",
+		TTL:    time.Hour,
+	})
+	siwe, _ := auth.NewHandlers(auth.HandlerConfig{
+		Store:   auth.NewRedisStore(c),
+		Signer:  signer,
+		Domain:  "titular.test",
+		ChainID: 84532,
+	})
+
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Join(filepath.Dir(file), "..", "handlers", "fixtures")
+	hs, _ := handlers.NewStoreFromDir(dir)
+
+	cfg := router.DefaultConfig()
+	cfg.Auth = siwe
+	cfg.SIWS = nil
+
+	h := router.NewWithConfig(
+		cfg,
+		handlers.NewAgentHandlersWithStore(hs),
+		handlers.NewJobHandlersWithStore(hs),
+	)
+
+	// SIWE present.
+	req := httptest.NewRequest(http.MethodPost, "/auth/siwe/nonce", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("siwe nonce regressed: %d", rec.Code)
+	}
+
+	// SIWS absent.
+	req = httptest.NewRequest(http.MethodPost, "/auth/siws/nonce", nil)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("siws unset must 404 on /auth/siws/*: got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Phase `M4-siws-auth` for milestone M4. Closes #87.

## Test plan

- [ ] `forge test` green
- [ ] `slither` clean (Critical/High/Medium = 0)
- [ ] `go test ./services/...` green where touched
- [ ] reviewer signs off

## Verify

log: `.claude/cron/last-verify-M4-siws-auth.log`

```
	github.com/0xDevNinja/titular/services/gateway-go		coverage: 0.0% of statements
	github.com/0xDevNinja/titular/services/gateway-go/cmd/gateway		coverage: 0.0% of statements
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/auth	(cached)	coverage: 82.0% of statements
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/handlers	1.366s	coverage: 95.4% of statements
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/middleware	0.665s	coverage: 91.5% of statements
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/router	1.862s	coverage: 80.0% of statements
?   	github.com/0xDevNinja/titular/services/gateway-go/internal/types	[no test files]
```