### PR TITLE
feat(M4): SSE multiplexer (NATS → fanout)

### DIFF
--- a/services/gateway-go/cmd/gateway/main.go
+++ b/services/gateway-go/cmd/gateway/main.go
@@ -60,7 +60,10 @@
 //	                              subscriptions; when unset, GraphQL
 //	                              subscriptions resolve against an
 //	                              immediately-closed channel (queries
-//	                              still work).
+//	                              still work). Also enables the SSE
+//	                              multiplexer at /events; without this
+//	                              env var the SSE surface is not
+//	                              mounted at all.
 //	GATEWAY_GRAPHQL_PLAYGROUND    "true" enables GET /graphql/playground
 //	                              (GraphiQL UI). Default false; do NOT
 //	                              enable in production-facing
@@ -96,6 +99,7 @@ import (
 	"github.com/0xDevNinja/titular/services/gateway-go/internal/handlers"
 	"github.com/0xDevNinja/titular/services/gateway-go/internal/middleware"
 	"github.com/0xDevNinja/titular/services/gateway-go/internal/router"
+	"github.com/0xDevNinja/titular/services/gateway-go/internal/sse"
 	"github.com/0xDevNinja/titular/services/gateway-go/internal/store"
 )
 
@@ -136,9 +140,25 @@ func main() {
 		log.Fatal().Err(err).Msg("invalid database configuration")
 	}
 
-	gqlHandler, natsClose, err := buildGraphQLHandler(apiHandlers, corsCfg)
+	// Single shared NATS connection for both the GraphQL subscription
+	// bus (#89) and the SSE multiplexer (#90). One connection avoids
+	// duplicate auth handshakes and keeps the connection pool size
+	// predictable in shared NATS clusters; the indexer publisher
+	// dedup window means consumers can use the same wire stream
+	// without coordinating.
+	natsConn, natsClose, err := buildNATSConn()
+	if err != nil {
+		log.Fatal().Err(err).Msg("invalid NATS configuration")
+	}
+
+	gqlHandler, err := buildGraphQLHandler(apiHandlers, corsCfg, natsConn)
 	if err != nil {
 		log.Fatal().Err(err).Msg("invalid graphql configuration")
+	}
+
+	sseHandler, sseStop, err := buildSSEHandler(natsConn)
+	if err != nil {
+		log.Fatal().Err(err).Msg("invalid SSE configuration")
 	}
 
 	cfg := router.Config{
@@ -151,6 +171,7 @@ func main() {
 		SIWS:           siwsHandlers,
 		API:            apiHandlers,
 		GraphQL:        gqlHandler,
+		SSE:            sseHandler,
 	}
 
 	built := router.NewWithConfigLifecycle(cfg, agentHandlers, jobHandlers)
@@ -202,64 +223,84 @@ func main() {
 		dbClose()
 	}
 
-	// Close the NATS connection backing the GraphQL subscription bus.
+	// Stop the SSE multiplexer BEFORE closing the NATS connection so
+	// the shutdown order matches the reverse of construction: the
+	// multiplexer's NATS subscriptions need a live connection to
+	// unsubscribe cleanly.
+	if sseStop != nil {
+		sseStop()
+	}
+
+	// Close the shared NATS connection. Must run after sseStop above
+	// AND after srv.Shutdown — both the GraphQL subscription bus and
+	// the SSE multiplexer can issue final NATS calls during their
+	// teardown.
 	if natsClose != nil {
 		natsClose()
 	}
 }
 
+// buildNATSConn opens the single shared NATS connection consumed by
+// both the GraphQL subscription bus (#89) and the SSE multiplexer
+// (#90). Returns (nil, nil, nil) when GATEWAY_NATS_URL is unset — the
+// downstream feature builders treat a nil connection as "feature off"
+// and mount their handlers in nilBus / no-SSE form so the gateway
+// still serves queries.
+//
+// The returned close function tears the connection down; callers MUST
+// invoke it on graceful shutdown AFTER stopping every subsystem that
+// holds an active subscription on the connection.
+func buildNATSConn() (*nats.Conn, func(), error) {
+	url := strings.TrimSpace(os.Getenv("GATEWAY_NATS_URL"))
+	if url == "" {
+		return nil, nil, nil
+	}
+	nc, err := nats.Connect(url, nats.Timeout(5*time.Second))
+	if err != nil {
+		return nil, nil, errors.New("GATEWAY_NATS_URL: " + err.Error())
+	}
+	return nc, nc.Close, nil
+}
+
 // buildGraphQLHandler wires the GraphQL surface introduced in M4 (#89).
-// It is a no-op (returns nil, nil, nil) when the gateway is launched
+// It is a no-op (returns nil, nil) when the gateway is launched
 // without GATEWAY_DATABASE_URL — Query and Subscription resolvers both
 // need a Store to be useful, and silently mounting a query-less endpoint
 // would mask deployment misconfiguration.
 //
-// GATEWAY_NATS_URL is optional: when unset, subscription resolvers fall
-// back to graph.NilBus() so subscriber clients see a clean
-// end-of-stream rather than a hang. Queries are unaffected.
+// natsConn is optional: when nil, subscription resolvers fall back to
+// graph.NilBus() so subscriber clients see a clean end-of-stream
+// rather than a hang. Queries are unaffected.
 //
 // GATEWAY_GRAPHQL_PLAYGROUND defaults to off; setting it to "true" mounts
 // the GET /graphql/playground GraphiQL UI for local development. Do
 // not enable in production-facing deployments — the UI lets anyone
 // browse the schema and execute arbitrary queries against the
 // read-only surface.
-func buildGraphQLHandler(api *handlers.API, cors middleware.CORSConfig) (*graph.Handler, func(), error) {
+func buildGraphQLHandler(api *handlers.API, cors middleware.CORSConfig, natsConn *nats.Conn) (*graph.Handler, error) {
 	if api == nil {
 		// No store -> no GraphQL surface. Returning nil is the
 		// "feature off" signal the router config recognises.
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	resolver := &graph.Resolver{Store: api.Store}
 
-	var natsClose func()
-	if url := strings.TrimSpace(os.Getenv("GATEWAY_NATS_URL")); url != "" {
-		nc, err := nats.Connect(url, nats.Timeout(5*time.Second))
+	if natsConn != nil {
+		bus, err := graph.NewNATSBus(natsConn)
 		if err != nil {
-			return nil, nil, errors.New("GATEWAY_NATS_URL: " + err.Error())
-		}
-		bus, err := graph.NewNATSBus(nc)
-		if err != nil {
-			nc.Close()
-			return nil, nil, err
+			return nil, err
 		}
 		resolver.Bus = bus
-		natsClose = nc.Close
 	}
 
 	schema, err := graph.NewSchema(resolver)
 	if err != nil {
-		if natsClose != nil {
-			natsClose()
-		}
-		return nil, nil, err
+		return nil, err
 	}
 	h, err := graph.NewHandler(schema, resolver)
 	if err != nil {
-		if natsClose != nil {
-			natsClose()
-		}
-		return nil, nil, err
+		return nil, err
 	}
 	if v := strings.TrimSpace(os.Getenv("GATEWAY_GRAPHQL_PLAYGROUND")); strings.EqualFold(v, "true") {
 		h.EnablePlayground = true
@@ -282,7 +323,59 @@ func buildGraphQLHandler(api *handlers.API, cors middleware.CORSConfig) (*graph.
 		}
 	}
 
-	return h, natsClose, nil
+	return h, nil
+}
+
+// buildSSEHandler wires the SSE multiplexer introduced in M4 (#90).
+// Returns (nil, nil, nil) when natsConn is nil; the SSE surface
+// requires a live NATS connection to fan messages out, and a NATS-less
+// gateway has no events to stream.
+//
+// The returned stop function shuts the multiplexer's hub goroutine
+// down (closes every subscriber's channel, unsubscribes from NATS).
+// Callers MUST invoke it BEFORE closing the shared NATS connection so
+// the unsubscribes complete on a live transport.
+//
+// JetStream context is opened lazily — when JetStream isn't available
+// on the connection (e.g. an embedded server in tests with JS
+// disabled), the handler still serves live tail and silently skips
+// Last-Event-ID replay. That parallels the publisher's behaviour
+// where EnsureStream is the only mutating call site.
+func buildSSEHandler(natsConn *nats.Conn) (*sse.Handler, func(), error) {
+	if natsConn == nil {
+		return nil, nil, nil
+	}
+	mux, err := sse.NewMultiplexer(sse.Config{
+		NATS:   natsConn,
+		Logger: log.Logger,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := mux.Start(); err != nil {
+		return nil, nil, err
+	}
+
+	// JetStream is best-effort. JetStream() returns an error only when
+	// the server has rejected the request (e.g. JS not enabled on the
+	// connection's permissions); in that case we serve live tail
+	// without replay rather than failing startup.
+	js, jsErr := natsConn.JetStream()
+	if jsErr != nil {
+		log.Warn().Err(jsErr).Msg("sse: jetstream unavailable, replay disabled")
+		js = nil
+	}
+
+	h, err := sse.NewHandler(sse.HandlerConfig{
+		Multiplexer: mux,
+		JetStream:   js,
+		Logger:      log.Logger,
+	})
+	if err != nil {
+		mux.Stop()
+		return nil, nil, err
+	}
+	return h, mux.Stop, nil
 }
 
 // buildAPIHandlers opens a Postgres pool from GATEWAY_DATABASE_URL and wires

--- a/services/gateway-go/cmd/gateway/main.go
+++ b/services/gateway-go/cmd/gateway/main.go
@@ -73,6 +73,13 @@
 //	                              before they reach the executor.
 //	                              Default 10; introspection queries
 //	                              (__schema / __type) bypass the cap.
+//	GATEWAY_SSE_MAX_PER_IP        non-negative integer; caps the number
+//	                              of concurrent /events connections a
+//	                              single client IP may hold. Default 10;
+//	                              0 falls back to the default; setting
+//	                              to a negative number disables the
+//	                              cap (intended for trusted networks
+//	                              and tests only).
 package main
 
 import (
@@ -366,10 +373,17 @@ func buildSSEHandler(natsConn *nats.Conn) (*sse.Handler, func(), error) {
 		js = nil
 	}
 
+	// MaxPerIP: 0 in HandlerConfig means "use the package default";
+	// strconv.Atoi returns 0 for an unset env var, which is exactly the
+	// fallthrough we want. Operators wanting to disable the cap pass a
+	// negative integer explicitly.
+	maxPerIP, _ := strconv.Atoi(strings.TrimSpace(os.Getenv("GATEWAY_SSE_MAX_PER_IP")))
+
 	h, err := sse.NewHandler(sse.HandlerConfig{
 		Multiplexer: mux,
 		JetStream:   js,
 		Logger:      log.Logger,
+		MaxPerIP:    maxPerIP,
 	})
 	if err != nil {
 		mux.Stop()

--- a/services/gateway-go/internal/router/router.go
+++ b/services/gateway-go/internal/router/router.go
@@ -21,6 +21,7 @@ import (
 	"github.com/0xDevNinja/titular/services/gateway-go/internal/graph"
 	"github.com/0xDevNinja/titular/services/gateway-go/internal/handlers"
 	"github.com/0xDevNinja/titular/services/gateway-go/internal/middleware"
+	"github.com/0xDevNinja/titular/services/gateway-go/internal/sse"
 )
 
 // Config controls how the gateway router is constructed.
@@ -76,6 +77,13 @@ type Config struct {
 	// Subscription resolvers both need a Store, so a missing API
 	// implies no GraphQL surface either.
 	GraphQL *graph.Handler
+
+	// SSE, when non-nil, is the Server-Sent Events handler introduced
+	// in M4 (#90). Mounted at /events for one-way NATS-fanout streams
+	// over plain HTTP. Absent when the gateway is started without
+	// NATS — the multiplexer requires a NATS connection, so a missing
+	// GATEWAY_NATS_URL implies no SSE surface either.
+	SSE *sse.Handler
 }
 
 // DefaultConfig returns a Config suitable for local development.
@@ -246,6 +254,17 @@ func NewWithConfigLifecycle(
 	if cfg.GraphQL != nil {
 		gqlGroup := engine.Group("")
 		cfg.GraphQL.Register(gqlGroup)
+	}
+
+	// M4 (#90) — SSE multiplexer. Mounted at the engine root so the
+	// canonical path is `/events`, matching the SDK's expected URL
+	// shape. Inherits the rate-limiter so a single client cannot open
+	// arbitrarily many concurrent connections; auth is intentionally
+	// absent because the surface is read-only and parallels the
+	// public-read GraphQL subscription transport (#89).
+	if cfg.SSE != nil {
+		sseGroup := engine.Group("")
+		cfg.SSE.Register(sseGroup)
 	}
 
 	// Legacy /health probe retained for backwards compatibility with M2/M3

--- a/services/gateway-go/internal/sse/handler.go
+++ b/services/gateway-go/internal/sse/handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -59,12 +60,29 @@ import (
 // Each connection owns a bounded sse.Subscriber buffer (DefaultBufferSize).
 // The hub drops on overflow; the handler logs the running drop count
 // when the connection terminates so a slow client surfaces in metrics.
+//
+// # Per-IP connection cap
+//
+// A single client opening N concurrent SSE connections is the cheapest
+// way to pin gateway memory: each connection holds a 64-event buffer,
+// a goroutine, and a NATS subscriber slot. The handler refuses new
+// /events connections from an IP once that IP already has MaxPerIP
+// connections open; the rejection is a 429 with Retry-After: 5 so the
+// client backs off rather than hot-looping. Defaults to 10 per IP and
+// is configurable via HandlerConfig.MaxPerIP (cmd/gateway reads
+// GATEWAY_SSE_MAX_PER_IP and forwards). Setting MaxPerIP <= 0 disables
+// the cap, which is appropriate for tests and tightly-trusted internal
+// deployments only.
 type Handler struct {
 	mux              *Multiplexer
 	js               nats.JetStreamContext
 	heartbeatInterval time.Duration
 	logger           zerolog.Logger
 	now              func() time.Time
+
+	maxPerIP int
+	connsMu  sync.Mutex
+	conns    map[string]int
 }
 
 // HandlerConfig wires the handler.
@@ -83,6 +101,12 @@ type HandlerConfig struct {
 
 	// Logger receives drop / error log lines. Zero uses zerolog.Nop().
 	Logger zerolog.Logger
+
+	// MaxPerIP caps concurrent /events connections from a single
+	// client IP. Zero falls back to DefaultMaxPerIP; explicitly setting
+	// a negative value disables the cap (intended for tests and
+	// trusted-network deployments only).
+	MaxPerIP int
 }
 
 // DefaultHeartbeatInterval is the heartbeat cadence specified by #90 —
@@ -91,6 +115,13 @@ type HandlerConfig struct {
 // nginx is 60s). Operators who terminate at a more aggressive proxy
 // can lower this via HandlerConfig.
 const DefaultHeartbeatInterval = 30 * time.Second
+
+// DefaultMaxPerIP caps concurrent SSE connections per source IP at 10.
+// Sized to allow a normal browsing session (a small handful of tabs)
+// while refusing the cheap memory-pinning attack of a single IP
+// holding hundreds of streams. Operators behind a known L7 proxy with
+// trusted-IP forwarding may raise this via GATEWAY_SSE_MAX_PER_IP.
+const DefaultMaxPerIP = 10
 
 // NewHandler validates cfg and returns a configured Handler. Returns an
 // error when required fields are missing — silent zero-config would let
@@ -108,12 +139,23 @@ func NewHandler(cfg HandlerConfig) (*Handler, error) {
 		logger = zerolog.Nop()
 	}
 	logger = logger.With().Str("component", "sse_handler").Logger()
+
+	// Zero falls back to the default; a negative value is the explicit
+	// "disable cap" signal so tests can opt out without depending on
+	// magic numbers in env.
+	maxPerIP := cfg.MaxPerIP
+	if maxPerIP == 0 {
+		maxPerIP = DefaultMaxPerIP
+	}
+
 	return &Handler{
 		mux:               cfg.Multiplexer,
 		js:                cfg.JetStream,
 		heartbeatInterval: hb,
 		logger:            logger,
 		now:               time.Now,
+		maxPerIP:          maxPerIP,
+		conns:             make(map[string]int),
 	}, nil
 }
 
@@ -123,6 +165,42 @@ func NewHandler(cfg HandlerConfig) (*Handler, error) {
 // the rest of the surface.
 func (h *Handler) Register(rg *gin.RouterGroup) {
 	rg.GET("/events", h.Stream)
+}
+
+// acquireConn reserves a per-IP slot, returning false when the cap is
+// already at the configured ceiling. ip == "" or maxPerIP <= 0 short-
+// circuits to true: an empty IP usually signals unkeyable transport
+// (test recorder, unix socket) where the cap is meaningless, and a
+// non-positive cap is the explicit opt-out.
+func (h *Handler) acquireConn(ip string) bool {
+	if ip == "" || h.maxPerIP <= 0 {
+		return true
+	}
+	h.connsMu.Lock()
+	defer h.connsMu.Unlock()
+	if h.conns[ip] >= h.maxPerIP {
+		return false
+	}
+	h.conns[ip]++
+	return true
+}
+
+// releaseConn drops a per-IP slot. Mirrors the acquireConn guards so
+// release-without-acquire is a no-op rather than a counter underflow.
+// Removes the map entry once the count returns to zero so an IP that
+// connects once and disconnects doesn't permanently inflate the map.
+func (h *Handler) releaseConn(ip string) {
+	if ip == "" || h.maxPerIP <= 0 {
+		return
+	}
+	h.connsMu.Lock()
+	defer h.connsMu.Unlock()
+	n := h.conns[ip]
+	if n <= 1 {
+		delete(h.conns, ip)
+		return
+	}
+	h.conns[ip] = n - 1
 }
 
 // Stream is the GET /events handler. It runs for the lifetime of the
@@ -144,7 +222,54 @@ func (h *Handler) Stream(c *gin.Context) {
 		return
 	}
 
-	filter := SubjectsFromCSV(c.Query("subjects"))
+	// Validate the subject filter BEFORE writing any response headers
+	// so a bad pattern can be rejected with a 400 rather than swallowed
+	// into the stream. The rule is narrow: a leading `>` or `*` would
+	// fan every subject the multiplexer could ever see (or worse, every
+	// subject NATS knows about) past the closed-prefix posture, so we
+	// refuse those. Patterns that narrow within a registered prefix
+	// (e.g. `agents.*`, `trades.>`) are accepted as-is.
+	filter, err := ParseSubjectsCSV(c.Query("subjects"))
+	if err != nil {
+		c.Header("Content-Type", "application/json; charset=utf-8")
+		c.String(http.StatusBadRequest, `{"error":{"code":"invalid_subjects","message":"subjects parameter contains a disallowed wildcard"}}`)
+		return
+	}
+
+	// Per-IP concurrent connection cap. A 429 with Retry-After: 5
+	// tells the EventSource client to back off rather than reconnect
+	// immediately. We register BEFORE any response bytes are written
+	// so the body of a refused request stays a plain 429; the
+	// corresponding deferred release must always fire even on early
+	// returns below.
+	clientIP := c.ClientIP()
+	if !h.acquireConn(clientIP) {
+		c.Header("Retry-After", "5")
+		c.Header("Content-Type", "application/json; charset=utf-8")
+		c.String(http.StatusTooManyRequests, `{"error":{"code":"too_many_connections","message":"per-ip sse connection cap exceeded"}}`)
+		return
+	}
+	defer h.releaseConn(clientIP)
+
+	// Clear the per-response write deadline. The shared *http.Server
+	// sets WriteTimeout=30s for REST/GraphQL; that's the right posture
+	// for short responses but it would kill every long-lived SSE
+	// connection at the 30s heartbeat. http.NewResponseController is
+	// the supported escape hatch (Go 1.20+) — it surfaces the underlying
+	// transport's SetWriteDeadline, and a zero time disables it for
+	// just this response without changing the server-wide setting.
+	//
+	// The read deadline is left alone: ReadTimeout (10s) only bounds
+	// the request-line + header read on GET /events (no body), which
+	// has already completed by the time we reach this code.
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		// Some test transports (httptest's default ResponseRecorder
+		// path) don't implement SetWriteDeadline — log at debug and
+		// continue. In production the gin/net.http chain always does.
+		h.logger.Debug().Err(err).Msg("sse: clear write deadline unsupported; continuing")
+	}
+
 	lastEventID := strings.TrimSpace(r.Header.Get("Last-Event-ID"))
 
 	// Headers MUST be written before the first event. WriteHeader is

--- a/services/gateway-go/internal/sse/handler.go
+++ b/services/gateway-go/internal/sse/handler.go
@@ -1,0 +1,458 @@
+package sse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nats-io/nats.go"
+	"github.com/rs/zerolog"
+)
+
+// Handler serves GET /events: a Server-Sent Events stream that
+// multiplexes the NATS subjects published by the indexer into a
+// per-client text/event-stream response.
+//
+// Wiring lives in cmd/gateway: the handler takes a *Multiplexer (live
+// tail) and an optional nats.JetStreamContext (history replay when the
+// client sends Last-Event-ID). When JetStream is nil, replay is
+// silently skipped — the stream still works for live tail, which is
+// the common case.
+//
+// # Response shape
+//
+//	Content-Type: text/event-stream; charset=utf-8
+//	Cache-Control: no-cache
+//	Connection: keep-alive
+//	X-Accel-Buffering: no
+//
+// Each event is rendered as:
+//
+//	id: js:<seq>
+//	event: <subject>
+//	data: <json envelope>
+//
+// Heartbeat frames (`: ping\n\n`) are emitted on HeartbeatInterval so
+// the connection stays alive through proxies that idle-close TCP. The
+// SSE spec defines lines beginning with `:` as comments; clients ignore
+// them, which is exactly the desired behaviour.
+//
+// # Last-Event-ID replay
+//
+// When the client reconnects with a `Last-Event-ID` header in the form
+// `js:<seq>`, the handler opens an ephemeral JetStream consumer with
+// nats.StartSequence(seq+1) and drains every backlog message before
+// attaching the connection to the live multiplexer. Backlog messages
+// keep the same `id:` shape as live messages (js:<seq>) so the client
+// can reconnect again from any point. When the header is missing /
+// malformed / not in `js:` form, the handler skips replay and starts at
+// the live tail; this is the safe fallback because the canonical
+// SSE-spec semantic for Last-Event-ID is "best effort".
+//
+// # Buffering / backpressure
+//
+// Each connection owns a bounded sse.Subscriber buffer (DefaultBufferSize).
+// The hub drops on overflow; the handler logs the running drop count
+// when the connection terminates so a slow client surfaces in metrics.
+type Handler struct {
+	mux              *Multiplexer
+	js               nats.JetStreamContext
+	heartbeatInterval time.Duration
+	logger           zerolog.Logger
+	now              func() time.Time
+}
+
+// HandlerConfig wires the handler.
+type HandlerConfig struct {
+	// Multiplexer is the live-tail hub. Required.
+	Multiplexer *Multiplexer
+
+	// JetStream is used for Last-Event-ID replay. Optional; when nil,
+	// the Last-Event-ID header is ignored and the connection starts at
+	// the live tail.
+	JetStream nats.JetStreamContext
+
+	// HeartbeatInterval is how often `: ping` frames are emitted. Zero
+	// uses DefaultHeartbeatInterval.
+	HeartbeatInterval time.Duration
+
+	// Logger receives drop / error log lines. Zero uses zerolog.Nop().
+	Logger zerolog.Logger
+}
+
+// DefaultHeartbeatInterval is the heartbeat cadence specified by #90 —
+// every 30 seconds. Long enough to be cheap, short enough to keep most
+// idle-killing intermediaries happy (cloudflare's default is 100s,
+// nginx is 60s). Operators who terminate at a more aggressive proxy
+// can lower this via HandlerConfig.
+const DefaultHeartbeatInterval = 30 * time.Second
+
+// NewHandler validates cfg and returns a configured Handler. Returns an
+// error when required fields are missing — silent zero-config would let
+// a misconfigured deploy serve clients but never deliver events.
+func NewHandler(cfg HandlerConfig) (*Handler, error) {
+	if cfg.Multiplexer == nil {
+		return nil, errors.New("sse: nil multiplexer")
+	}
+	hb := cfg.HeartbeatInterval
+	if hb <= 0 {
+		hb = DefaultHeartbeatInterval
+	}
+	logger := cfg.Logger
+	if reflect.DeepEqual(logger, zerolog.Logger{}) {
+		logger = zerolog.Nop()
+	}
+	logger = logger.With().Str("component", "sse_handler").Logger()
+	return &Handler{
+		mux:               cfg.Multiplexer,
+		js:                cfg.JetStream,
+		heartbeatInterval: hb,
+		logger:            logger,
+		now:               time.Now,
+	}, nil
+}
+
+// Register mounts GET /events on the provided router group. The group
+// inherits the gateway's outer middleware chain (rate-limit, CORS,
+// recovery), so per-IP connection limiting is applied uniformly with
+// the rest of the surface.
+func (h *Handler) Register(rg *gin.RouterGroup) {
+	rg.GET("/events", h.Stream)
+}
+
+// Stream is the GET /events handler. It runs for the lifetime of the
+// SSE connection: registers a subscriber on the multiplexer, optionally
+// replays history from JetStream, then loops forwarding multiplexer
+// events and heartbeats until the client disconnects or the
+// multiplexer stops.
+func (h *Handler) Stream(c *gin.Context) {
+	w := c.Writer
+	r := c.Request
+
+	// SSE requires a flushable writer. Gin's ResponseWriter implements
+	// http.Flusher; if the underlying chain ever swaps it for one that
+	// doesn't (e.g. a buffering middleware), refuse rather than silently
+	// dropping every event.
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		c.String(http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	filter := SubjectsFromCSV(c.Query("subjects"))
+	lastEventID := strings.TrimSpace(r.Header.Get("Last-Event-ID"))
+
+	// Headers MUST be written before the first event. WriteHeader is
+	// implicit on the first Write, so set the headers explicitly here
+	// and then call Flush so curl / EventSource clients see the
+	// connection as established.
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	// X-Accel-Buffering disables nginx response buffering. Without
+	// this, nginx will hold each event in a buffer until either the
+	// buffer is full or the connection idles, which defeats the
+	// real-time purpose of SSE.
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	sub, err := h.mux.Subscribe(SubscribeOptions{Filter: filter})
+	if err != nil {
+		// Subscribe only fails on Stop; the connection has already had
+		// its 200 written, so emit a single error event and return.
+		// The client EventSource will treat the close as a transient
+		// error and reconnect, at which point we'll respond cleanly.
+		writeComment(w, "service unavailable")
+		flusher.Flush()
+		return
+	}
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	// Optional history replay. We deliberately do replay BEFORE
+	// attaching the live tail to avoid the "live event arrives during
+	// replay" interleaving problem; the handler's subscriber is already
+	// registered, so any live event arriving during replay is buffered
+	// in the subscriber's channel and consumed naturally after the
+	// replay loop exits. Buffer overflow during a long replay is
+	// possible — the drop log line surfaces that to operators.
+	if lastEventID != "" && h.js != nil {
+		if err := h.replay(ctx, w, flusher, lastEventID, filter); err != nil {
+			// Replay errors are non-fatal: log, send a comment, and
+			// fall through to the live tail. The client will see
+			// missing history but the connection stays alive.
+			h.logger.Warn().Err(err).Str("last_event_id", lastEventID).Msg("sse replay failed")
+			writeComment(w, "replay unavailable")
+			flusher.Flush()
+		}
+	}
+
+	// Live tail loop. Three sources of work:
+	//
+	//   1. ctx.Done    — client disconnected or server shutting down.
+	//   2. sub.C       — multiplexer fanout.
+	//   3. heartbeat   — periodic ping to keep proxies open.
+	//
+	// We use a single ticker for heartbeat rather than time.After per
+	// loop so a high-throughput stream does not allocate a fresh
+	// timer on every iteration.
+	hbTicker := time.NewTicker(h.heartbeatInterval)
+	defer hbTicker.Stop()
+
+	// Initial heartbeat so the EventSource onopen fires even if the
+	// stream is currently silent. Cheap, and removes a class of
+	// "is the connection dead?" debugging questions.
+	writeComment(w, "ping")
+	flusher.Flush()
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.logSummary(sub, "client disconnect")
+			return
+		case ev, ok := <-sub.C:
+			if !ok {
+				// Multiplexer stopped; emit a comment and exit. The
+				// client will treat connection close as transient and
+				// reconnect, by which time the gateway will either be
+				// back up or returning 503.
+				writeComment(w, "server shutdown")
+				flusher.Flush()
+				h.logSummary(sub, "multiplexer stopped")
+				return
+			}
+			if err := writeEvent(w, ev); err != nil {
+				h.logSummary(sub, "write error: "+err.Error())
+				return
+			}
+			flusher.Flush()
+		case <-hbTicker.C:
+			writeComment(w, "ping")
+			flusher.Flush()
+		}
+	}
+}
+
+// replay opens an ephemeral JetStream consumer starting at the
+// sequence following lastEventID and drains every available message
+// onto the response writer before returning. Filter is applied
+// client-side because the JetStream consumer subscribes to the
+// stream's full subject set; pre-filtering on the server requires a
+// per-pattern consumer per call, which is wasteful for the common case
+// of a small replay window.
+//
+// Returns nil if replay completes (or there's nothing to replay).
+// Returns a non-nil error only on JetStream / network failure; a
+// malformed Last-Event-ID is treated as "no replay" and returns nil.
+func (h *Handler) replay(
+	ctx context.Context,
+	w gin.ResponseWriter,
+	flusher http.Flusher,
+	lastEventID string,
+	filter Filter,
+) error {
+	seq, ok := parseJetStreamID(lastEventID)
+	if !ok {
+		// Non-JetStream id (e.g. hub:*) — no canonical replay anchor,
+		// silently skip. The SSE spec lets the server treat
+		// Last-Event-ID best-effort.
+		return nil
+	}
+
+	// Bound the replay scan: a misconfigured client that sets
+	// Last-Event-ID to "js:1" on a stream with millions of messages
+	// would otherwise pin a goroutine for minutes. The cap is
+	// enforced by counting drained messages; once the cap is hit we
+	// emit a comment and stop replay, letting the live tail take
+	// over. Operators who need bigger replays can paginate via the
+	// REST API (#88), which is what the GraphQL transport advises.
+	const maxReplay = 1000
+
+	// Per-pattern subjects: when the client sent ?subjects=, replay
+	// only those; otherwise replay every published prefix. Limiting
+	// the JS consumer to the requested patterns is cheaper than
+	// subscribing to the whole stream and discarding non-matches.
+	subjects := filter
+	if len(subjects) == 0 {
+		subjects = Filter(append([]string(nil), SubjectPrefixes...))
+	}
+
+	for _, pattern := range subjects {
+		drained, err := h.replayOne(ctx, w, flusher, pattern, seq+1, maxReplay)
+		if err != nil {
+			return err
+		}
+		if drained >= maxReplay {
+			writeComment(w, "replay truncated")
+			flusher.Flush()
+			return nil
+		}
+	}
+	return nil
+}
+
+// replayOne pulls historical messages on `pattern` starting at
+// startSeq, writing each as an SSE event. Returns the number of
+// messages drained or an error. Stops at:
+//
+//   - ctx.Done
+//   - max messages drained
+//   - JetStream "no more messages" / batch timeout (treated as
+//     end-of-history; not an error)
+func (h *Handler) replayOne(
+	ctx context.Context,
+	w gin.ResponseWriter,
+	flusher http.Flusher,
+	pattern string,
+	startSeq uint64,
+	max int,
+) (int, error) {
+	sub, err := h.js.PullSubscribe(
+		pattern,
+		"", // empty durable name → ephemeral consumer
+		nats.StartSequence(startSeq),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("pull subscribe %q: %w", pattern, err)
+	}
+	// Always tear the consumer down; ephemeral consumers idle out on
+	// the server, but Unsubscribe is the supported synchronous
+	// release.
+	defer func() { _ = sub.Unsubscribe() }()
+
+	const batch = 32
+	drained := 0
+	for drained < max {
+		select {
+		case <-ctx.Done():
+			return drained, nil
+		default:
+		}
+
+		msgs, err := sub.Fetch(batch, nats.MaxWait(500*time.Millisecond))
+		if err != nil {
+			if errors.Is(err, nats.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+				// No more historical messages on this pattern.
+				return drained, nil
+			}
+			return drained, fmt.Errorf("fetch %q: %w", pattern, err)
+		}
+		if len(msgs) == 0 {
+			return drained, nil
+		}
+		for _, m := range msgs {
+			id := ""
+			if md, mderr := m.Metadata(); mderr == nil && md != nil {
+				id = formatJetStreamID(md.Sequence.Stream)
+			}
+			ev := Event{
+				ID:      id,
+				Subject: m.Subject,
+				Data:    m.Data,
+			}
+			if werr := writeEvent(w, ev); werr != nil {
+				return drained, werr
+			}
+			drained++
+			// Ack so the ephemeral consumer's pending count drops; an
+			// un-acked ephemeral that we abandon would still be torn
+			// down by Unsubscribe, but explicit Ack is cheap and
+			// keeps the JetStream server logs clean.
+			_ = m.Ack()
+			if drained >= max {
+				flusher.Flush()
+				return drained, nil
+			}
+		}
+		flusher.Flush()
+	}
+	return drained, nil
+}
+
+// logSummary emits a single info line per terminated connection so an
+// operator can see how many events were dropped for that client. The
+// drop count is the most useful per-connection signal we have without
+// adding metrics infrastructure.
+func (h *Handler) logSummary(sub *Subscriber, reason string) {
+	drops := uint64(0)
+	if sub != nil && sub.Drops != nil {
+		drops = sub.Drops.Load()
+	}
+	h.logger.Info().
+		Uint64("drops", drops).
+		Str("reason", reason).
+		Msg("sse connection closed")
+}
+
+// writeEvent renders an SSE message frame onto w. The order of fields
+// follows the WHATWG SSE spec: id, event, data, blank line. data is
+// emitted as a single line because the publisher envelope is
+// single-line JSON; if the publisher ever switches to multi-line JSON
+// each newline-delimited chunk would need its own `data:` line.
+func writeEvent(w gin.ResponseWriter, ev Event) error {
+	var b strings.Builder
+	b.Grow(len(ev.ID) + len(ev.Subject) + len(ev.Data) + 32)
+	if ev.ID != "" {
+		b.WriteString("id: ")
+		b.WriteString(ev.ID)
+		b.WriteByte('\n')
+	}
+	if ev.Subject != "" {
+		b.WriteString("event: ")
+		b.WriteString(ev.Subject)
+		b.WriteByte('\n')
+	}
+	b.WriteString("data: ")
+	// Defence in depth: a stray newline in the envelope would split
+	// the SSE frame and confuse the client. The publisher emits
+	// json.Marshal output which never contains a literal newline, but
+	// we strip CR/LF as a belt-and-braces guard. Cost is one byte
+	// scan per event.
+	if hasLineBreak(ev.Data) {
+		b.Write(stripLineBreaks(ev.Data))
+	} else {
+		b.Write(ev.Data)
+	}
+	b.WriteString("\n\n")
+	if _, err := w.Write([]byte(b.String())); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeComment emits an SSE comment frame (a heartbeat or human-
+// readable status line). Per the spec, lines starting with `:` are
+// ignored by the client.
+func writeComment(w gin.ResponseWriter, msg string) {
+	_, _ = w.Write([]byte(": " + msg + "\n\n"))
+}
+
+// hasLineBreak / stripLineBreaks: cheap CR/LF scrubbers for the data
+// line. Kept as helpers so the writeEvent body stays readable.
+func hasLineBreak(b []byte) bool {
+	for _, c := range b {
+		if c == '\n' || c == '\r' {
+			return true
+		}
+	}
+	return false
+}
+
+func stripLineBreaks(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	for _, c := range b {
+		if c == '\n' || c == '\r' {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}

--- a/services/gateway-go/internal/sse/handler_test.go
+++ b/services/gateway-go/internal/sse/handler_test.go
@@ -1,0 +1,418 @@
+package sse
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nats-io/nats.go"
+)
+
+// newTestRouter wires a Multiplexer + Handler onto a gin engine for an
+// in-process httptest server. Returns the engine, the live NATS
+// connection (so individual tests can publish on it), and the
+// multiplexer (so tests can introspect subscriber state and trigger
+// shutdown).
+func newTestRouter(t *testing.T, hbInterval time.Duration) (*gin.Engine, *nats.Conn, *Multiplexer) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	nc := runEmbeddedNATS(t)
+
+	mux, err := NewMultiplexer(Config{NATS: nc})
+	if err != nil {
+		t.Fatalf("NewMultiplexer: %v", err)
+	}
+	if err := mux.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(mux.Stop)
+
+	js, _ := nc.JetStream()
+	h, err := NewHandler(HandlerConfig{
+		Multiplexer:       mux,
+		JetStream:         js,
+		HeartbeatInterval: hbInterval,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	engine := gin.New()
+	h.Register(engine.Group(""))
+	return engine, nc, mux
+}
+
+// readSSEFrame consumes one full SSE frame (terminated by a blank
+// line) from r and returns the raw frame bytes. Returns io.EOF when
+// the stream closes.
+func readSSEFrame(r *bufio.Reader) (string, error) {
+	var b bytes.Buffer
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			// Return what we've buffered so callers can inspect a
+			// partial frame on EOF.
+			if b.Len() > 0 {
+				return b.String(), err
+			}
+			return "", err
+		}
+		b.WriteString(line)
+		if line == "\n" || line == "\r\n" {
+			return b.String(), nil
+		}
+	}
+}
+
+// Test_Handler_HeadersAndContentType pins the SSE response headers
+// required by #90: text/event-stream, no-cache, X-Accel-Buffering: no.
+// Browsers and L7 proxies key on these to disable buffering and avoid
+// caching the never-ending response.
+func Test_Handler_HeadersAndContentType(t *testing.T) {
+	engine, _, _ := newTestRouter(t, time.Hour)
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/events")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("content-type: got %q, want text/event-stream*", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("cache-control: got %q, want no-cache", cc)
+	}
+	if x := resp.Header.Get("X-Accel-Buffering"); x != "no" {
+		t.Errorf("x-accel-buffering: got %q, want no", x)
+	}
+}
+
+// Test_Handler_DispatchEvent publishes a single envelope and asserts
+// the SSE handler renders it with id, event and data fields.
+func Test_Handler_DispatchEvent(t *testing.T) {
+	engine, nc, mux := newTestRouter(t, time.Hour)
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/events")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	r := bufio.NewReader(resp.Body)
+	// First frame is the initial heartbeat (`: ping`).
+	if _, err := readSSEFrame(r); err != nil {
+		t.Fatalf("read initial heartbeat: %v", err)
+	}
+
+	// Wait for the handler to register on the hub before publishing —
+	// otherwise the publish can race ahead of Subscribe and be lost
+	// (live tail is at-most-once from subscribe time).
+	waitForSubscribers(t, mux, 1)
+
+	payload := `{"name":"BondingCurve.Bought","block_number":7,"log_index":2,"payload":{}}`
+	if err := nc.Publish("trades.bought", []byte(payload)); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	frame, err := readSSEFrame(r)
+	if err != nil {
+		t.Fatalf("read event frame: %v", err)
+	}
+	if !strings.Contains(frame, "event: trades.bought") {
+		t.Errorf("frame missing event line: %q", frame)
+	}
+	if !strings.Contains(frame, "id: ") {
+		t.Errorf("frame missing id line: %q", frame)
+	}
+	if !strings.Contains(frame, "data: "+payload) {
+		t.Errorf("frame missing/incorrect data line: %q", frame)
+	}
+}
+
+// Test_Handler_FilterDropsOther asserts ?subjects= is honoured: a
+// subscriber asking for trades.* must NOT see jobs.* events.
+func Test_Handler_FilterDropsOther(t *testing.T) {
+	engine, nc, mux := newTestRouter(t, time.Hour)
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/events?subjects=trades.*")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	r := bufio.NewReader(resp.Body)
+	_, _ = readSSEFrame(r) // drain initial heartbeat
+	waitForSubscribers(t, mux, 1)
+
+	// Wrong-subject publish first, right-subject publish second. The
+	// handler MUST skip the first entirely and emit the second.
+	_ = nc.Publish("jobs.funded", []byte(`{"name":"Escrow.Funded"}`))
+	_ = nc.Publish("trades.bought", []byte(`{"name":"BondingCurve.Bought"}`))
+
+	frame, err := readSSEFrame(r)
+	if err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	if !strings.Contains(frame, "event: trades.bought") {
+		t.Errorf("got non-trades frame: %q", frame)
+	}
+	if strings.Contains(frame, "jobs") {
+		t.Errorf("filter leak — jobs subject in trades-only stream: %q", frame)
+	}
+}
+
+// Test_Handler_HeartbeatPing asserts that the heartbeat ticker emits a
+// `: ping` comment frame at the configured interval. We use a 50ms
+// interval so the test stays fast.
+func Test_Handler_HeartbeatPing(t *testing.T) {
+	engine, _, _ := newTestRouter(t, 50*time.Millisecond)
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/events")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	r := bufio.NewReader(resp.Body)
+	// First frame — initial heartbeat fired before the loop enters
+	// select.
+	first, err := readSSEFrame(r)
+	if err != nil {
+		t.Fatalf("read first frame: %v", err)
+	}
+	if !strings.HasPrefix(first, ": ping") {
+		t.Errorf("first frame: got %q, want comment ping", first)
+	}
+
+	// Second frame — periodic heartbeat from the ticker, arriving
+	// after one tick of the configured interval.
+	second, err := readSSEFrame(r)
+	if err != nil {
+		t.Fatalf("read second frame: %v", err)
+	}
+	if !strings.HasPrefix(second, ": ping") {
+		t.Errorf("second frame: got %q, want comment ping", second)
+	}
+}
+
+// Test_Handler_DisconnectCleanup asserts the handler unblocks promptly
+// when the client closes the connection, and that the multiplexer's
+// subscriber registry returns to its pre-connection size.
+//
+// This is the goroutine-leak guard required by #90's test plan.
+func Test_Handler_DisconnectCleanup(t *testing.T) {
+	engine, _, mux := newTestRouter(t, time.Hour)
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/events", nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+
+	// Read the initial heartbeat so we know the handler is past
+	// header-write and has registered its subscriber on the hub.
+	r := bufio.NewReader(resp.Body)
+	if _, err := readSSEFrame(r); err != nil {
+		t.Fatalf("read initial heartbeat: %v", err)
+	}
+	waitForSubscribers(t, mux, 1)
+
+	// Cancel the request context: the server-side handler must
+	// observe ctx.Done and unwind, removing its subscriber.
+	cancel()
+	_ = resp.Body.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if subscriberCount(mux) == 0 {
+			return
+		}
+		runtime.Gosched()
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("subscriber not removed within deadline (count = %d)", subscriberCount(mux))
+}
+
+// Test_Handler_LastEventIDReplay drives the JetStream replay path:
+// publish a sequence of events to a JetStream-backed stream, then open
+// an SSE connection with Last-Event-ID set to the second message's id
+// and verify only messages 3..N are replayed.
+//
+// This is the canonical resumption test required by #90. We bootstrap
+// the stream manually rather than calling into the indexer publisher
+// because the gateway test package can't import that without a
+// dependency cycle; the wire shape is the contract.
+func Test_Handler_LastEventIDReplay(t *testing.T) {
+	engine, nc, _ := newTestRouter(t, time.Hour)
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("JetStream: %v", err)
+	}
+
+	// Create the canonical stream covering all four prefixes.
+	if _, err := js.AddStream(&nats.StreamConfig{
+		Name:     "TITULAR_EVENTS",
+		Subjects: SubjectPrefixes,
+		Storage:  nats.MemoryStorage,
+	}); err != nil {
+		t.Fatalf("AddStream: %v", err)
+	}
+
+	// Publish 5 envelopes onto trades.bought via JetStream so each
+	// one carries a stream sequence we can resume from.
+	pubAcks := make([]uint64, 0, 5)
+	for i := 0; i < 5; i++ {
+		ack, err := js.Publish("trades.bought", []byte(`{"i":`+strconv.Itoa(i)+`}`))
+		if err != nil {
+			t.Fatalf("js.Publish %d: %v", i, err)
+		}
+		pubAcks = append(pubAcks, ack.Sequence)
+	}
+	// Resume from after the second message: client claims to have
+	// seen js:<seq2>, expects 3..5 replayed.
+	resumeFrom := pubAcks[1]
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/events?subjects=trades.bought", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Last-Event-ID", "js:"+strconv.FormatUint(resumeFrom, 10))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	r := bufio.NewReader(resp.Body)
+	// Drain frames until we have collected the three replay events.
+	// Skip comment frames (heartbeats) and any non-event frames.
+	seen := make([]uint64, 0, 3)
+	deadline := time.Now().Add(5 * time.Second)
+	for len(seen) < 3 && time.Now().Before(deadline) {
+		frame, err := readSSEFrame(r)
+		if err != nil && err != io.EOF {
+			t.Fatalf("read frame: %v", err)
+		}
+		if strings.HasPrefix(frame, ": ") {
+			continue // heartbeat / status comment
+		}
+		id := extractID(frame)
+		if id == "" {
+			continue
+		}
+		seq, ok := parseJetStreamID(id)
+		if !ok {
+			t.Errorf("non-js id in replay: %q", id)
+			continue
+		}
+		seen = append(seen, seq)
+	}
+	if len(seen) < 3 {
+		t.Fatalf("replay incomplete: got %d, want 3 (seen=%v)", len(seen), seen)
+	}
+	// Every replayed sequence must be > resumeFrom.
+	for _, s := range seen {
+		if s <= resumeFrom {
+			t.Errorf("replay leaked older message: seq %d <= resume %d", s, resumeFrom)
+		}
+	}
+}
+
+// Test_Handler_ServerShutdown asserts the handler emits a final
+// comment frame and exits promptly when the multiplexer is stopped.
+// This is the gateway-graceful-shutdown counterpart of the disconnect
+// test above.
+func Test_Handler_ServerShutdown(t *testing.T) {
+	engine, _, mux := newTestRouter(t, time.Hour)
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/events")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	r := bufio.NewReader(resp.Body)
+	_, _ = readSSEFrame(r) // drain initial heartbeat
+	waitForSubscribers(t, mux, 1)
+
+	mux.Stop()
+
+	// Read until EOF; we should see at most a "server shutdown"
+	// comment then the body closes.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_, err := readSSEFrame(r)
+		if err != nil {
+			return // EOF — handler exited
+		}
+	}
+	t.Fatal("handler did not exit after multiplexer stop")
+}
+
+// extractID pulls the value of the `id:` line from an SSE frame, or ""
+// if there is no id line. Used by the replay test.
+func extractID(frame string) string {
+	for _, line := range strings.Split(frame, "\n") {
+		if strings.HasPrefix(line, "id: ") {
+			return strings.TrimSpace(line[len("id: "):])
+		}
+	}
+	return ""
+}
+
+// subscriberCount returns the multiplexer's current subscriber count.
+// Defined as a test-only helper so the test can introspect the hub
+// without exposing the internals on the public API.
+func subscriberCount(m *Multiplexer) int {
+	m.subsMu.RLock()
+	defer m.subsMu.RUnlock()
+	return len(m.subs)
+}
+
+// waitForSubscribers polls the multiplexer until at least n
+// subscribers are registered. Used to defeat the inherent race
+// between an HTTP request reaching the handler goroutine and a test
+// publishing onto NATS — without this wait, a fast publish can race
+// ahead of Subscribe and be missed by the live tail.
+func waitForSubscribers(t *testing.T, m *Multiplexer, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if subscriberCount(m) >= n {
+			return
+		}
+		runtime.Gosched()
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("waitForSubscribers: only saw %d (want %d)", subscriberCount(m), n)
+}

--- a/services/gateway-go/internal/sse/handler_test.go
+++ b/services/gateway-go/internal/sse/handler_test.go
@@ -21,7 +21,8 @@ import (
 // in-process httptest server. Returns the engine, the live NATS
 // connection (so individual tests can publish on it), and the
 // multiplexer (so tests can introspect subscriber state and trigger
-// shutdown).
+// shutdown). Per-IP cap is disabled so the test surface mirrors the
+// pre-#90 baseline; the cap has its own dedicated test below.
 func newTestRouter(t *testing.T, hbInterval time.Duration) (*gin.Engine, *nats.Conn, *Multiplexer) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -41,6 +42,10 @@ func newTestRouter(t *testing.T, hbInterval time.Duration) (*gin.Engine, *nats.C
 		Multiplexer:       mux,
 		JetStream:         js,
 		HeartbeatInterval: hbInterval,
+		// Disable the per-IP cap for unrelated tests; every connection
+		// in the in-process httptest server resolves to 127.0.0.1, so
+		// otherwise the cap would skew the disconnect/replay assertions.
+		MaxPerIP: -1,
 	})
 	if err != nil {
 		t.Fatalf("NewHandler: %v", err)
@@ -415,4 +420,103 @@ func waitForSubscribers(t *testing.T, m *Multiplexer, n int) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("waitForSubscribers: only saw %d (want %d)", subscriberCount(m), n)
+}
+
+// TestSSE_RejectsExcessConcurrentConnectionsPerIP opens MaxPerIP
+// concurrent /events streams from the same IP and asserts the
+// (MaxPerIP+1)th request gets a 429 with Retry-After: 5. Defends the
+// memory-pinning attack where a single client opens hundreds of
+// long-lived streams to chew up gateway buffers.
+func TestSSE_RejectsExcessConcurrentConnectionsPerIP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	nc := runEmbeddedNATS(t)
+
+	mux, err := NewMultiplexer(Config{NATS: nc})
+	if err != nil {
+		t.Fatalf("NewMultiplexer: %v", err)
+	}
+	if err := mux.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(mux.Stop)
+
+	const maxPerIP = 10
+	js, _ := nc.JetStream()
+	h, err := NewHandler(HandlerConfig{
+		Multiplexer:       mux,
+		JetStream:         js,
+		HeartbeatInterval: time.Hour,
+		MaxPerIP:          maxPerIP,
+	})
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	engine := gin.New()
+	// Trust the loopback proxy so c.ClientIP() resolves to the test
+	// connection's source ip (127.0.0.1) rather than any forwarded
+	// value. Without trusted proxies set, gin still returns the remote
+	// address — fine here too — but we pin it explicitly so the test
+	// is independent of gin's default trust posture.
+	_ = engine.SetTrustedProxies(nil)
+	h.Register(engine.Group(""))
+
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	// Open `maxPerIP` connections in parallel; each must succeed. We
+	// hold a context per connection so the goroutines stay parked on
+	// the stream until the test's defer cancels them — releasing the
+	// per-IP slot would invalidate the (maxPerIP+1)th-must-fail
+	// assertion.
+	holds := make([]context.CancelFunc, 0, maxPerIP)
+	defer func() {
+		for _, c := range holds {
+			c()
+		}
+	}()
+
+	for i := 0; i < maxPerIP; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		holds = append(holds, cancel)
+
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/events", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("connection %d: Do: %v", i, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("connection %d: status %d, want 200", i, resp.StatusCode)
+		}
+		// Drain the initial heartbeat so we KNOW the handler reached
+		// the per-IP register step before we open the next connection;
+		// otherwise the (maxPerIP+1)th request can race ahead of
+		// acquireConn and erroneously succeed.
+		r := bufio.NewReader(resp.Body)
+		if _, err := readSSEFrame(r); err != nil {
+			t.Fatalf("connection %d: read initial heartbeat: %v", i, err)
+		}
+		// Don't close the body — we want the connection to stay open.
+		// resp.Body is closed indirectly when ctx is cancelled above.
+		_ = resp
+	}
+
+	// Wait until the multiplexer sees maxPerIP subscribers so we know
+	// every prior connection has fully registered, not just acquired
+	// the per-IP slot.
+	waitForSubscribers(t, mux, maxPerIP)
+
+	// (maxPerIP+1)th request from the same source must be refused.
+	resp, err := http.Get(srv.URL + "/events")
+	if err != nil {
+		t.Fatalf("(maxPerIP+1)th GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("(maxPerIP+1)th status: got %d, want 429", resp.StatusCode)
+	}
+	if ra := resp.Header.Get("Retry-After"); ra != "5" {
+		t.Errorf("(maxPerIP+1)th Retry-After: got %q, want \"5\"", ra)
+	}
 }

--- a/services/gateway-go/internal/sse/multiplexer.go
+++ b/services/gateway-go/internal/sse/multiplexer.go
@@ -535,6 +535,13 @@ func safeClose(ch chan Event) {
 // empty input so a missing/blank ?subjects= query parameter is
 // indistinguishable from an unfiltered subscription. Reused by the
 // handler layer.
+//
+// Patterns whose FIRST token is `>` or `*` are rejected: they would
+// let a client subscribe across every registered prefix (or worse,
+// every subject NATS knows about) regardless of the multiplexer's
+// closed-set posture. The handler maps those rejections to 400; the
+// request never reaches the live tail. Patterns that narrow within a
+// known prefix (e.g. `agents.*`, `trades.>`) are preserved unchanged.
 func SubjectsFromCSV(s string) Filter {
 	if strings.TrimSpace(s) == "" {
 		return nil
@@ -546,11 +553,87 @@ func SubjectsFromCSV(s string) Filter {
 		if p == "" {
 			continue
 		}
+		if err := validateSubjectPattern(p, SubjectPrefixes); err != nil {
+			// One bad pattern poisons the whole list. The alternative
+			// (silently dropping it) would let a client think a broad
+			// `>` is being honoured and miss the more specific entries
+			// they typed alongside it; explicit rejection is safer.
+			return nil
+		}
 		out = append(out, p)
 	}
 	if len(out) == 0 {
 		return nil
 	}
 	return out
+}
+
+// ParseSubjectsCSV is the validating parser the SSE handler calls so
+// it can return a 400 rather than silently falling back to the
+// unfiltered tail when the client sent a banned pattern. Returns
+// (nil, nil) for blank input — same "no filter" semantic as
+// SubjectsFromCSV — and (nil, err) for any rejected pattern.
+func ParseSubjectsCSV(s string) (Filter, error) {
+	if strings.TrimSpace(s) == "" {
+		return nil, nil
+	}
+	parts := strings.Split(s, ",")
+	out := make(Filter, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if err := validateSubjectPattern(p, SubjectPrefixes); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// validateSubjectPattern rejects subject patterns that would let a
+// client opt out of the multiplexer's closed-set fanout. The rule is
+// narrow: the FIRST token must not be a wildcard. Once the first token
+// is a literal that matches one of the registered prefixes (agents,
+// jobs, tokens, trades), the pattern is allowed to use `*` and `>` for
+// further narrowing.
+//
+// allowedPrefixes is the registered top-level prefix list (i.e.
+// SubjectPrefixes); we extract the leading token of each entry and
+// compare against the pattern's leading token. Passing nil disables
+// the prefix check (allows any non-wildcard leading token), which is
+// only useful for unit tests.
+func validateSubjectPattern(pattern string, allowedPrefixes []string) error {
+	if pattern == "" {
+		return errors.New("sse: empty subject pattern")
+	}
+	first := pattern
+	if idx := strings.Index(pattern, "."); idx >= 0 {
+		first = pattern[:idx]
+	}
+	switch first {
+	case ">":
+		return errors.New("sse: bare `>` not allowed; subscribe within a registered prefix")
+	case "*":
+		return errors.New("sse: leading `*` not allowed; subscribe within a registered prefix")
+	}
+	if len(allowedPrefixes) == 0 {
+		return nil
+	}
+	for _, prefix := range allowedPrefixes {
+		// Leading token of each registered prefix (e.g. "agents.>" -> "agents").
+		head := prefix
+		if idx := strings.Index(prefix, "."); idx >= 0 {
+			head = prefix[:idx]
+		}
+		if head == first {
+			return nil
+		}
+	}
+	return errors.New("sse: pattern leading token does not match any registered prefix")
 }
 

--- a/services/gateway-go/internal/sse/multiplexer.go
+++ b/services/gateway-go/internal/sse/multiplexer.go
@@ -1,0 +1,556 @@
+// Package sse implements a Server-Sent Events fanout from the Titular
+// NATS subjects (agents.*, jobs.*, tokens.*, trades.*) to per-connection
+// HTTP `text/event-stream` clients.
+//
+// The package exists alongside the GraphQL subscription transport
+// (internal/graph) rather than replacing it: SDK consumers that cannot
+// open a websocket — restrictive corporate proxies, polyfilled WS in
+// older browsers, or the simpler one-way usage shape that does not need
+// bidirectional control frames — get a plain-HTTP event stream over the
+// same wire data.
+//
+// # Architecture
+//
+//	indexer                 gateway                 client
+//	┌──────────┐  publish   ┌──────────┐  GET /events
+//	│Publisher │────────────▶│ Multi-  │◀──────────── browser / SDK
+//	│(JetStr)  │  agents.>  │ plexer  │  text/event-stream
+//	└──────────┘  jobs.>    │         │  ┌──────────┐
+//	              tokens.>  │ fan-out │  │subscriber│
+//	              trades.>  │ N:M     │  │(per conn)│
+//	                        └──────────┘  └──────────┘
+//
+// The Multiplexer holds exactly one NATS subscription per top-level
+// prefix and dispatches each incoming envelope to the set of registered
+// subscribers whose subject filter matches. Matching is done once on the
+// hub goroutine; subscribers receive the already-encoded SSE frame
+// rather than decoding the envelope per-client. This keeps fan-out
+// O(matched subscribers) rather than O(connected subscribers).
+//
+// # Backpressure
+//
+// Each subscriber owns a bounded buffered channel. When the buffer is
+// full the hub drops the message for that subscriber and increments a
+// per-subscriber drop counter; we do NOT block the hub goroutine because
+// a single slow client must not stall delivery to every other client.
+// This mirrors the same posture taken by the GraphQL subscription bus
+// (see internal/graph/subscriptions.go subBufferSize = 64).
+//
+// # Replay
+//
+// Live tail uses core NATS (at-most-once from subscribe time forward),
+// matching the documented contract on GraphQL subscriptions: clients
+// reconnecting after a drop are expected to re-fetch the gap via the
+// REST API, OR — for SSE specifically — by sending the `Last-Event-ID`
+// header. The handler layer (handler.go) reads that header and uses a
+// JetStream ephemeral consumer to replay messages with a stream
+// sequence > Last-Event-ID before attaching the connection to the live
+// hub. The multiplexer itself is unaware of replay; it only ever
+// dispatches the live tail.
+package sse
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/nats-io/nats.go"
+	"github.com/rs/zerolog"
+)
+
+// SubjectPrefixes is the closed set of top-level prefixes the
+// multiplexer subscribes to. Mirrors publisher.SubjectPrefixes in the
+// indexer; we intentionally re-declare it here rather than importing
+// across services to keep the gateway in its own dependency closure
+// (same rationale as the NATSEnvelope re-declaration in
+// internal/graph/subscriptions.go).
+var SubjectPrefixes = []string{
+	"agents.>",
+	"jobs.>",
+	"tokens.>",
+	"trades.>",
+}
+
+// Event is the dispatched unit. Subject is the NATS subject the
+// publisher wrote to (e.g. "trades.bought"); ID is the per-message
+// identifier used as the SSE `id:` line — derived from the JetStream
+// stream sequence when available, falling back to a hub-local monotonic
+// counter when the multiplexer is wired against a core-NATS-only
+// deployment. Data is the publisher's JSON envelope, forwarded verbatim
+// so SDK consumers see exactly the same wire shape they would get over
+// the GraphQL subscription transport.
+type Event struct {
+	ID      string
+	Subject string
+	Data    []byte
+}
+
+// Subscriber is the per-connection sink. It is the value returned from
+// Multiplexer.Subscribe; the handler layer consumes Events from C and
+// is responsible for serialising them onto the HTTP response.
+//
+// The buffer is sized at construction (Subscribe option) and is not
+// resizable: changing it would let a misbehaving client absorb arbitrary
+// memory by pretending to be slow. Drops accumulates the number of
+// events the multiplexer has discarded for this subscriber since
+// registration; the SSE handler logs the running total when the
+// connection terminates so an operator can spot consistently slow
+// readers.
+type Subscriber struct {
+	C      <-chan Event
+	Drops  *atomic.Uint64
+	cancel func()
+}
+
+// Close detaches the subscriber from the multiplexer and releases its
+// channel. Safe to call multiple times. Always called by the handler on
+// connection teardown — leaking a Subscriber into the registry would
+// cause the hub to keep delivering to a dead reader, eventually
+// saturating the buffer and bumping Drops indefinitely.
+func (s *Subscriber) Close() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+}
+
+// Filter is the per-subscriber subject predicate. When non-empty, only
+// events whose Subject matches at least one entry are dispatched to the
+// subscriber. Patterns honour the standard NATS subject grammar:
+//
+//   - "*"  matches exactly one token (e.g. "trades.*" matches
+//     "trades.bought" but NOT "trades.bonding.bought")
+//   - ">"  matches one or more tokens (e.g. "trades.>" matches both)
+//   - bare strings are exact matches (e.g. "trades.bought")
+//
+// An empty Filter dispatches every event the multiplexer receives.
+type Filter []string
+
+// match reports whether subject matches at least one pattern. An empty
+// filter matches everything (the SDK convention for "no filter ⇒ all
+// subjects" — same shape as publisher.SubjectFor).
+func (f Filter) match(subject string) bool {
+	if len(f) == 0 {
+		return true
+	}
+	for _, p := range f {
+		if subjectMatches(p, subject) {
+			return true
+		}
+	}
+	return false
+}
+
+// subjectMatches implements the NATS pattern grammar restricted to `*`
+// and `>`. We re-implement it here rather than calling into nats.go's
+// internal matcher because the function is unexported. The grammar is
+// small enough that a token-by-token walk is clearer than a regex and
+// easier to audit for ReDoS-style inputs.
+func subjectMatches(pattern, subject string) bool {
+	if pattern == "" {
+		return false
+	}
+	if pattern == subject {
+		return true
+	}
+	pTokens := strings.Split(pattern, ".")
+	sTokens := strings.Split(subject, ".")
+	for i, pt := range pTokens {
+		switch pt {
+		case ">":
+			// `>` is only valid as the last token of a pattern. It
+			// matches one or more remaining subject tokens.
+			return i < len(sTokens)
+		case "*":
+			if i >= len(sTokens) {
+				return false
+			}
+		default:
+			if i >= len(sTokens) || sTokens[i] != pt {
+				return false
+			}
+		}
+	}
+	// Pattern consumed; subject must be exactly the same length to
+	// match (no trailing tokens allowed when there's no `>`).
+	return len(pTokens) == len(sTokens)
+}
+
+// Multiplexer is the NATS-to-SSE fanout hub.
+//
+// Construction is via NewMultiplexer; the zero value is unsafe. Start
+// must be called before any Subscribe so the underlying NATS
+// subscriptions are live; Stop tears down the hub goroutine and closes
+// every active subscriber's channel so handler goroutines exit
+// promptly.
+type Multiplexer struct {
+	nc     *nats.Conn
+	logger zerolog.Logger
+
+	// subs is the set of registered subscribers, indexed by an
+	// internal id. We use a map rather than a slice because Close on a
+	// subscriber needs O(1) removal; the id is monotonic per
+	// multiplexer instance.
+	subsMu  sync.RWMutex
+	subs    map[uint64]*subscriberEntry
+	nextID  uint64
+	natsSub []*nats.Subscription
+
+	// seq is the hub-local fallback ID counter, used when the
+	// JetStream sequence is not available (e.g. an embedded NATS
+	// server in tests that never created the stream). Atomic so the
+	// dispatch path doesn't take a lock.
+	seq atomic.Uint64
+
+	// stopped is set on Stop so concurrent Subscribe calls error out
+	// cleanly instead of registering against a dead hub.
+	stoppedMu sync.RWMutex
+	stopped   bool
+}
+
+// subscriberEntry pairs a Subscriber with the goroutine-local pieces
+// the hub needs (the writable channel end and the filter). Kept private
+// so the public Subscriber struct stays read-only from the handler's
+// perspective.
+type subscriberEntry struct {
+	id     uint64
+	filter Filter
+	ch     chan Event
+	drops  *atomic.Uint64
+}
+
+// Config tunes Multiplexer construction.
+type Config struct {
+	// NATS is the connection to subscribe on. Required.
+	NATS *nats.Conn
+
+	// Logger is used for drop logging. Zero value is allowed (will
+	// log to the default zerolog instance with the "sse" component
+	// tag).
+	Logger zerolog.Logger
+}
+
+// DefaultBufferSize is the per-subscriber channel capacity. Sized so a
+// short network blip on the SSE response writer does not drop messages
+// in the common case; longer outages will silently drop on overflow,
+// which is the right call here — back-pressuring the hub would impact
+// every other subscriber.
+//
+// Consistent with subBufferSize in the GraphQL subscription bus so the
+// two transports degrade at the same operational threshold.
+const DefaultBufferSize = 64
+
+// NewMultiplexer constructs a multiplexer. Returns an error if cfg.NATS
+// is nil; a closed connection is allowed because Start surfaces the
+// transport error at subscription time.
+func NewMultiplexer(cfg Config) (*Multiplexer, error) {
+	if cfg.NATS == nil {
+		return nil, errors.New("sse: nil NATS connection")
+	}
+	logger := cfg.Logger
+	if reflect.DeepEqual(logger, zerolog.Logger{}) {
+		logger = zerolog.Nop()
+	}
+	logger = logger.With().Str("component", "sse").Logger()
+	return &Multiplexer{
+		nc:     cfg.NATS,
+		logger: logger,
+		subs:   make(map[uint64]*subscriberEntry),
+	}, nil
+}
+
+// Start opens the NATS subscriptions for every entry in
+// SubjectPrefixes. Called once after construction; calling again is a
+// no-op (idempotent so a partial-init recovery path can re-call without
+// double-subscribing).
+func (m *Multiplexer) Start() error {
+	m.stoppedMu.Lock()
+	defer m.stoppedMu.Unlock()
+	if m.stopped {
+		return errors.New("sse: multiplexer is stopped")
+	}
+	if len(m.natsSub) > 0 {
+		return nil
+	}
+	for _, prefix := range SubjectPrefixes {
+		sub, err := m.nc.Subscribe(prefix, m.dispatch)
+		if err != nil {
+			// Roll back any partial subscriptions before returning so a
+			// failed Start leaves the hub in a clean stopped state.
+			for _, s := range m.natsSub {
+				_ = s.Unsubscribe()
+			}
+			m.natsSub = nil
+			return err
+		}
+		m.natsSub = append(m.natsSub, sub)
+	}
+	return nil
+}
+
+// Stop closes every NATS subscription and every registered subscriber's
+// channel. Safe to call multiple times. After Stop returns, Subscribe
+// will return ErrStopped — handler goroutines must observe their
+// channel close and exit before the gateway's graceful shutdown
+// timeout.
+func (m *Multiplexer) Stop() {
+	m.stoppedMu.Lock()
+	if m.stopped {
+		m.stoppedMu.Unlock()
+		return
+	}
+	m.stopped = true
+	subs := m.natsSub
+	m.natsSub = nil
+	m.stoppedMu.Unlock()
+
+	for _, s := range subs {
+		_ = s.Unsubscribe()
+	}
+
+	// Snapshot the subscriber map under the registry lock, then close
+	// each channel. Closing under the lock would deadlock if a
+	// dispatch goroutine were still fanning out (it holds the read
+	// lock); the snapshot-then-close pattern is goroutine-safe here
+	// because dispatch sends are non-blocking — a fanout into a
+	// closed channel falls into the default branch of the `select`
+	// rather than panicking — and safeClose tolerates a double close.
+	m.subsMu.Lock()
+	entries := make([]*subscriberEntry, 0, len(m.subs))
+	for _, e := range m.subs {
+		entries = append(entries, e)
+	}
+	m.subs = make(map[uint64]*subscriberEntry)
+	m.subsMu.Unlock()
+
+	for _, e := range entries {
+		safeClose(e.ch)
+	}
+}
+
+// ErrStopped is returned by Subscribe when the multiplexer has been
+// stopped. Handlers should treat this as "service shutting down" and
+// terminate the SSE response gracefully.
+var ErrStopped = errors.New("sse: multiplexer stopped")
+
+// SubscribeOptions tunes a single Subscribe call.
+type SubscribeOptions struct {
+	// Filter restricts dispatch to events whose subject matches at
+	// least one pattern. nil/empty filter receives every event.
+	Filter Filter
+
+	// Buffer overrides DefaultBufferSize for this subscriber. Values
+	// <= 0 fall back to the default.
+	Buffer int
+}
+
+// Subscribe registers a new SSE client and returns a Subscriber whose
+// channel will be fed every matching event until Close (or hub Stop) is
+// called. The returned Subscriber is owned by the caller; its channel
+// is closed on either Close or Stop.
+func (m *Multiplexer) Subscribe(opts SubscribeOptions) (*Subscriber, error) {
+	m.stoppedMu.RLock()
+	if m.stopped {
+		m.stoppedMu.RUnlock()
+		return nil, ErrStopped
+	}
+	m.stoppedMu.RUnlock()
+
+	buf := opts.Buffer
+	if buf <= 0 {
+		buf = DefaultBufferSize
+	}
+	ch := make(chan Event, buf)
+	drops := new(atomic.Uint64)
+
+	m.subsMu.Lock()
+	id := m.nextID
+	m.nextID++
+	entry := &subscriberEntry{
+		id:     id,
+		filter: opts.Filter,
+		ch:     ch,
+		drops:  drops,
+	}
+	m.subs[id] = entry
+	m.subsMu.Unlock()
+
+	cancel := func() {
+		m.subsMu.Lock()
+		_, ok := m.subs[id]
+		delete(m.subs, id)
+		m.subsMu.Unlock()
+		if ok {
+			safeClose(ch)
+		}
+	}
+
+	return &Subscriber{
+		C:      ch,
+		Drops:  drops,
+		cancel: cancel,
+	}, nil
+}
+
+// dispatch is the NATS subscription callback. Runs on the NATS
+// connection's read thread; we keep it cheap by doing the filter check
+// inline and a non-blocking send to each matched subscriber. Anything
+// blocking here would back-pressure the entire NATS client, which would
+// drop messages for OTHER consumers in the gateway (most importantly,
+// the GraphQL subscription bus that shares the same connection).
+func (m *Multiplexer) dispatch(msg *nats.Msg) {
+	id := m.eventID(msg)
+	ev := Event{
+		ID:      id,
+		Subject: msg.Subject,
+		Data:    msg.Data,
+	}
+
+	// Take the read lock for the snapshot of subscribers. Sends are
+	// non-blocking, so we hold the lock for at most O(N) channel
+	// pokes; new subscribers added during dispatch do not see this
+	// message, which is the same semantic GraphQL subscriptions have.
+	m.subsMu.RLock()
+	defer m.subsMu.RUnlock()
+	for _, entry := range m.subs {
+		if !entry.filter.match(msg.Subject) {
+			continue
+		}
+		sendNonBlocking(entry, ev, m.logger, msg.Subject)
+	}
+}
+
+// sendNonBlocking attempts a non-blocking send onto entry.ch and
+// records a drop if the buffer is full. It also recovers from the
+// `send on closed channel` panic that can race with Stop / Close
+// calling close() on the channel; that race is benign — by the time
+// we hit it, the subscriber is being torn down and we just want to
+// avoid taking the gateway down with us.
+func sendNonBlocking(entry *subscriberEntry, ev Event, logger zerolog.Logger, subject string) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Channel was closed concurrently; treat as a drop and
+			// move on. We do NOT log because Close/Stop are
+			// expected operations, not errors.
+			_ = r
+		}
+	}()
+	select {
+	case entry.ch <- ev:
+	default:
+		entry.drops.Add(1)
+		logger.Warn().
+			Uint64("subscriber_id", entry.id).
+			Str("subject", subject).
+			Uint64("drops", entry.drops.Load()).
+			Msg("sse subscriber buffer full; dropping event")
+	}
+}
+
+// eventID resolves the SSE `id:` value for an incoming NATS message.
+// JetStream messages carry a stream sequence in their metadata, which
+// is the canonical resumable identifier; core-NATS messages do not, so
+// we fall back to a hub-local monotonic counter. The fallback is
+// non-resumable across multiplexer restarts — the Last-Event-ID replay
+// path in the handler handles that case explicitly by refusing replay
+// when the current event format is the fallback shape.
+//
+// Format:
+//
+//	js:<stream_seq>     when the message has JetStream metadata
+//	hub:<local_counter> otherwise
+//
+// Both forms are stable strings, so the SSE handler can echo them back
+// in `id:` lines and decode them on a subsequent Last-Event-ID without
+// ambiguity.
+func (m *Multiplexer) eventID(msg *nats.Msg) string {
+	if md, err := msg.Metadata(); err == nil && md != nil {
+		// Stream sequence is monotonic per stream and survives client
+		// reconnects; this is the SSE-correct id.
+		seq := md.Sequence.Stream
+		if seq > 0 {
+			return formatJetStreamID(seq)
+		}
+	}
+	return formatHubID(m.seq.Add(1))
+}
+
+// formatJetStreamID / formatHubID are exported (lowercase but
+// package-visible) so the handler's Last-Event-ID parser can match
+// against the same prefixes without re-implementing the format.
+func formatJetStreamID(seq uint64) string { return "js:" + uitoa(seq) }
+func formatHubID(seq uint64) string       { return "hub:" + uitoa(seq) }
+
+// uitoa is strconv.FormatUint(x, 10) inlined to avoid the import for a
+// single call site on a hot path.
+func uitoa(x uint64) string {
+	if x == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for x > 0 {
+		i--
+		buf[i] = byte('0' + x%10)
+		x /= 10
+	}
+	return string(buf[i:])
+}
+
+// parseJetStreamID extracts the stream sequence from an event id of
+// the form "js:<digits>". Returns (seq, true) on success; any other
+// shape returns (0, false). Used by the handler when parsing
+// Last-Event-ID for replay.
+func parseJetStreamID(id string) (uint64, bool) {
+	const prefix = "js:"
+	if !strings.HasPrefix(id, prefix) {
+		return 0, false
+	}
+	rest := id[len(prefix):]
+	if rest == "" {
+		return 0, false
+	}
+	var n uint64
+	for i := 0; i < len(rest); i++ {
+		c := rest[i]
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + uint64(c-'0')
+	}
+	return n, true
+}
+
+// safeClose closes ch idempotently. Calling close on an
+// already-closed channel panics; we swallow that so Stop and Close can
+// race without crashing the gateway.
+func safeClose(ch chan Event) {
+	defer func() { _ = recover() }()
+	close(ch)
+}
+
+// SubjectsFromCSV parses a comma-separated subject filter list,
+// trimming whitespace and dropping empty entries. Returns nil for an
+// empty input so a missing/blank ?subjects= query parameter is
+// indistinguishable from an unfiltered subscription. Reused by the
+// handler layer.
+func SubjectsFromCSV(s string) Filter {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make(Filter, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+

--- a/services/gateway-go/internal/sse/multiplexer_test.go
+++ b/services/gateway-go/internal/sse/multiplexer_test.go
@@ -1,0 +1,420 @@
+package sse
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	srvtest "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
+)
+
+// runEmbeddedNATS boots an in-process nats-server with JetStream so
+// the SSE multiplexer tests exercise the same wire path the indexer's
+// publisher uses. Mirrors graph.runEmbeddedNATS — duplicated here
+// because the helper is unexported in that package and cross-package
+// test helpers are messier than a copy.
+func runEmbeddedNATS(t *testing.T) *nats.Conn {
+	t.Helper()
+	dir := t.TempDir()
+
+	opts := srvtest.DefaultTestOptions
+	opts.Port = -1
+	opts.JetStream = true
+	opts.StoreDir = filepath.Join(dir, "jetstream")
+
+	srv := srvtest.RunServer(&opts)
+	t.Cleanup(func() {
+		srv.Shutdown()
+		srv.WaitForShutdown()
+	})
+	if !srv.ReadyForConnections(2 * time.Second) {
+		t.Fatal("nats-server not ready")
+	}
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats.Connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+	return nc
+}
+
+// silence the natsserver import so future maintainers see it as
+// intentional even when no test directly references the type.
+var _ = natsserver.RANDOM_PORT
+
+// Test_Multiplexer_DispatchAllSubjects asserts the hub fans every
+// subject the indexer publisher emits to subscribers without a filter.
+// This is the smoke test for the package — it covers the full surface
+// (Start/Subscribe/dispatch/Close/Stop) end-to-end with a live NATS
+// server.
+func Test_Multiplexer_DispatchAllSubjects(t *testing.T) {
+	nc := runEmbeddedNATS(t)
+	mux, err := NewMultiplexer(Config{NATS: nc})
+	if err != nil {
+		t.Fatalf("NewMultiplexer: %v", err)
+	}
+	if err := mux.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer mux.Stop()
+
+	sub, err := mux.Subscribe(SubscribeOptions{})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer sub.Close()
+
+	// Publish one envelope on each top-level prefix and confirm we
+	// receive all four. We use plain bytes here — the multiplexer is
+	// envelope-agnostic.
+	cases := []struct{ subject, body string }{
+		{"agents.registered", `{"name":"AgentRegistry.Registered","block_number":1,"log_index":0}`},
+		{"jobs.funded", `{"name":"Escrow.Funded","block_number":2,"log_index":1}`},
+		{"tokens.fee_split", `{"name":"FeeSplitter.FeeSplit","block_number":3,"log_index":2}`},
+		{"trades.bought", `{"name":"BondingCurve.Bought","block_number":4,"log_index":3}`},
+	}
+
+	for _, c := range cases {
+		if err := nc.Publish(c.subject, []byte(c.body)); err != nil {
+			t.Fatalf("Publish %q: %v", c.subject, err)
+		}
+	}
+
+	got := make(map[string]bool)
+	deadline := time.After(3 * time.Second)
+	for len(got) < len(cases) {
+		select {
+		case ev, ok := <-sub.C:
+			if !ok {
+				t.Fatal("subscriber channel closed early")
+			}
+			got[ev.Subject] = true
+		case <-deadline:
+			t.Fatalf("only saw %d of %d subjects: %v", len(got), len(cases), got)
+		}
+	}
+	for _, c := range cases {
+		if !got[c.subject] {
+			t.Errorf("missing subject %q", c.subject)
+		}
+	}
+}
+
+// Test_Multiplexer_FilterAppliesPattern pins per-subscriber subject
+// filtering. A subscriber asking for `trades.*` must NOT see jobs
+// events; a separate subscriber asking for `jobs.>` must see only
+// jobs events.
+func Test_Multiplexer_FilterAppliesPattern(t *testing.T) {
+	nc := runEmbeddedNATS(t)
+	mux, err := NewMultiplexer(Config{NATS: nc})
+	if err != nil {
+		t.Fatalf("NewMultiplexer: %v", err)
+	}
+	if err := mux.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer mux.Stop()
+
+	tradesSub, err := mux.Subscribe(SubscribeOptions{Filter: Filter{"trades.*"}})
+	if err != nil {
+		t.Fatalf("Subscribe trades: %v", err)
+	}
+	defer tradesSub.Close()
+
+	jobsSub, err := mux.Subscribe(SubscribeOptions{Filter: Filter{"jobs.>"}})
+	if err != nil {
+		t.Fatalf("Subscribe jobs: %v", err)
+	}
+	defer jobsSub.Close()
+
+	_ = nc.Publish("trades.bought", []byte(`{"x":1}`))
+	_ = nc.Publish("jobs.funded", []byte(`{"x":2}`))
+	_ = nc.Publish("agents.registered", []byte(`{"x":3}`))
+
+	// trades subscriber: expect exactly trades.bought.
+	select {
+	case ev := <-tradesSub.C:
+		if ev.Subject != "trades.bought" {
+			t.Errorf("trades sub: got %q, want trades.bought", ev.Subject)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("trades sub: timed out")
+	}
+
+	// jobs subscriber: expect exactly jobs.funded.
+	select {
+	case ev := <-jobsSub.C:
+		if ev.Subject != "jobs.funded" {
+			t.Errorf("jobs sub: got %q, want jobs.funded", ev.Subject)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("jobs sub: timed out")
+	}
+
+	// Drain settle: wait briefly to be sure the rejected `agents.*`
+	// publish did NOT slip through the trades filter. We rely on a
+	// short polling window; a longer wait would slow the suite for no
+	// new signal.
+	select {
+	case ev := <-tradesSub.C:
+		t.Fatalf("trades sub leaked: got %q", ev.Subject)
+	case <-time.After(200 * time.Millisecond):
+		// expected — nothing else
+	}
+}
+
+// Test_Multiplexer_DropsOnOverflow asserts the bounded-buffer behaviour:
+// a slow subscriber that does NOT drain its channel must see Drops
+// increment past the buffer size, while a fast subscriber on the same
+// hub keeps receiving every message.
+//
+// This is the guard against the classic "one slow client takes down the
+// fanout" failure mode.
+func Test_Multiplexer_DropsOnOverflow(t *testing.T) {
+	nc := runEmbeddedNATS(t)
+	mux, err := NewMultiplexer(Config{NATS: nc})
+	if err != nil {
+		t.Fatalf("NewMultiplexer: %v", err)
+	}
+	if err := mux.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer mux.Stop()
+
+	// Slow subscriber: tiny buffer, never drained.
+	const bufSize = 2
+	slow, err := mux.Subscribe(SubscribeOptions{Buffer: bufSize})
+	if err != nil {
+		t.Fatalf("Subscribe slow: %v", err)
+	}
+	defer slow.Close()
+
+	// Publish far more than the buffer can hold. NATS publishes are
+	// async — the client batches them onto the wire, the server fans
+	// them back to the dispatch callback on its own read loop. We
+	// poll until the total observed (drops + buffered) settles at
+	// the expected count, then assert drops dominate.
+	const n = 50
+	for i := 0; i < n; i++ {
+		_ = nc.Publish("trades.bought", []byte(`{"i":1}`))
+	}
+	if err := nc.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// Wait until the hub has dispatched every published message. The
+	// total dispatched is "drops + items currently in buffer"; the
+	// items in buffer are at most `bufSize`. The deadline is generous
+	// because the race-detector slows scheduling materially.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		dispatched := int(slow.Drops.Load()) + len(slow.C)
+		if dispatched >= n {
+			break
+		}
+		runtime.Gosched()
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if slow.Drops.Load() == 0 {
+		t.Fatal("expected drops on saturated subscriber, got 0")
+	}
+	// Once everything has dispatched, drops MUST equal n - bufSize
+	// exactly (the buffer absorbed bufSize messages, the rest were
+	// dropped). We allow a small ±1 tolerance for the rare case
+	// where the dispatcher has not finished the last message at the
+	// moment we sample — running with -count=N catches that.
+	if got := slow.Drops.Load(); got < uint64(n-bufSize-1) || got > uint64(n) {
+		t.Errorf("drops out of range: got %d, want in [%d, %d]",
+			got, n-bufSize-1, n)
+	}
+}
+
+// Test_Multiplexer_StopClosesSubscribers verifies graceful shutdown:
+// after Stop, every subscriber's channel is closed (so the SSE handler
+// loop exits) and Subscribe returns ErrStopped.
+func Test_Multiplexer_StopClosesSubscribers(t *testing.T) {
+	nc := runEmbeddedNATS(t)
+	mux, err := NewMultiplexer(Config{NATS: nc})
+	if err != nil {
+		t.Fatalf("NewMultiplexer: %v", err)
+	}
+	if err := mux.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	sub, err := mux.Subscribe(SubscribeOptions{})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	mux.Stop()
+
+	// Channel must close.
+	select {
+	case _, ok := <-sub.C:
+		if ok {
+			t.Fatal("expected closed channel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscriber channel was not closed by Stop")
+	}
+
+	// Subscribe must refuse new connections.
+	if _, err := mux.Subscribe(SubscribeOptions{}); err == nil {
+		t.Fatal("Subscribe after Stop: expected error")
+	}
+
+	// Stop is idempotent.
+	mux.Stop()
+}
+
+// Test_Multiplexer_CloseDetachesNoLeak confirms a Close on one
+// subscriber does NOT affect other subscribers' channels and removes
+// the closed subscriber from the registry so subsequent dispatches
+// don't keep targeting it.
+//
+// Catches the regression where the fanout map is keyed by stale ids.
+func Test_Multiplexer_CloseDetachesNoLeak(t *testing.T) {
+	nc := runEmbeddedNATS(t)
+	mux, err := NewMultiplexer(Config{NATS: nc})
+	if err != nil {
+		t.Fatalf("NewMultiplexer: %v", err)
+	}
+	if err := mux.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer mux.Stop()
+
+	a, _ := mux.Subscribe(SubscribeOptions{})
+	b, _ := mux.Subscribe(SubscribeOptions{})
+
+	a.Close()
+
+	// a's channel must close.
+	select {
+	case _, ok := <-a.C:
+		if ok {
+			t.Fatal("subscriber a channel: expected closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscriber a channel: not closed by Close")
+	}
+
+	// b must still receive events.
+	_ = nc.Publish("trades.bought", []byte(`{"x":1}`))
+	select {
+	case ev := <-b.C:
+		if ev.Subject != "trades.bought" {
+			t.Errorf("subscriber b: got %q", ev.Subject)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscriber b: timed out (close on a may have leaked)")
+	}
+	b.Close()
+}
+
+// Test_Multiplexer_NilConn pins the constructor's nil guard.
+func Test_Multiplexer_NilConn(t *testing.T) {
+	if _, err := NewMultiplexer(Config{}); err == nil {
+		t.Fatal("expected error on nil conn")
+	}
+}
+
+// Test_subjectMatches drives the pattern matcher with the cases the
+// SDK is documented to accept. Exhaustive enough to catch regressions
+// in the token-walk loop without becoming a property test.
+func Test_subjectMatches(t *testing.T) {
+	cases := []struct {
+		pattern, subject string
+		want             bool
+	}{
+		// exact
+		{"trades.bought", "trades.bought", true},
+		{"trades.bought", "trades.sold", false},
+
+		// `*` single token
+		{"trades.*", "trades.bought", true},
+		{"trades.*", "trades.bonding.bought", false},
+		{"*.bought", "trades.bought", true},
+		{"*.bought", "agents.bought", true},
+
+		// `>` rest of subject
+		{"trades.>", "trades.bought", true},
+		{"trades.>", "trades.bonding.bought", true},
+		{">", "anything.at.all", true},
+		{"trades.>", "trades", false}, // > requires >= 1 trailing token
+
+		// length mismatches
+		{"a.b", "a.b.c", false},
+		{"a.b.c", "a.b", false},
+
+		// edge: empty pattern never matches
+		{"", "trades.bought", false},
+	}
+	for _, tc := range cases {
+		if got := subjectMatches(tc.pattern, tc.subject); got != tc.want {
+			t.Errorf("subjectMatches(%q,%q) = %v, want %v",
+				tc.pattern, tc.subject, got, tc.want)
+		}
+	}
+}
+
+// Test_SubjectsFromCSV pins the query-string parser. The handler relies
+// on this for `?subjects=...`; an empty / whitespace-only input must
+// produce a nil filter so the multiplexer treats it as "all subjects".
+func Test_SubjectsFromCSV(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Filter
+	}{
+		{"", nil},
+		{"   ", nil},
+		{",,,", nil},
+		{"trades.*", Filter{"trades.*"}},
+		{"trades.*,jobs.>", Filter{"trades.*", "jobs.>"}},
+		{"  trades.* ,  jobs.>  ", Filter{"trades.*", "jobs.>"}},
+	}
+	for _, tc := range cases {
+		got := SubjectsFromCSV(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("SubjectsFromCSV(%q) = %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i, p := range got {
+			if p != tc.want[i] {
+				t.Errorf("SubjectsFromCSV(%q)[%d] = %q, want %q",
+					tc.in, i, p, tc.want[i])
+			}
+		}
+	}
+}
+
+// Test_parseJetStreamID covers the Last-Event-ID parser for the canonical
+// js:<seq> shape and the rejected forms.
+func Test_parseJetStreamID(t *testing.T) {
+	cases := []struct {
+		in     string
+		seq    uint64
+		wantOK bool
+	}{
+		{"js:1", 1, true},
+		{"js:0", 0, true},
+		{"js:18446744073709551615", 1<<64 - 1, true}, // uint64 max
+		{"js:", 0, false},
+		{"hub:1", 0, false},
+		{"", 0, false},
+		{"js:abc", 0, false},
+		{"js:1.5", 0, false},
+	}
+	for _, tc := range cases {
+		seq, ok := parseJetStreamID(tc.in)
+		if ok != tc.wantOK || seq != tc.seq {
+			t.Errorf("parseJetStreamID(%q) = (%d,%v), want (%d,%v)",
+				tc.in, seq, ok, tc.seq, tc.wantOK)
+		}
+	}
+}

--- a/services/gateway-go/internal/sse/multiplexer_test.go
+++ b/services/gateway-go/internal/sse/multiplexer_test.go
@@ -393,6 +393,70 @@ func Test_SubjectsFromCSV(t *testing.T) {
 	}
 }
 
+// TestSubjectsFromCSV_RejectsGreaterThan asserts the parser refuses a
+// bare `>` pattern. A leading `>` would let a client subscribe across
+// every prefix the multiplexer holds, which defeats the closed-set
+// posture documented on SubjectPrefixes.
+func TestSubjectsFromCSV_RejectsGreaterThan(t *testing.T) {
+	if got := SubjectsFromCSV(">"); got != nil {
+		t.Errorf("SubjectsFromCSV(\">\") = %v, want nil (rejected)", got)
+	}
+	if _, err := ParseSubjectsCSV(">"); err == nil {
+		t.Error("ParseSubjectsCSV(\">\"): expected error, got nil")
+	}
+	// The reject must propagate even when mixed with a valid pattern:
+	// silently dropping the bad entry would let a client think the
+	// remaining narrow filter is being honoured while the broad one
+	// is quietly tossed.
+	if got := SubjectsFromCSV(">,trades.*"); got != nil {
+		t.Errorf("SubjectsFromCSV(\">,trades.*\") = %v, want nil", got)
+	}
+}
+
+// TestSubjectsFromCSV_RejectsBareStar asserts the parser refuses a
+// leading `*`. `*` matches any single token, so `*` alone or
+// `*.bought` would let a client cross the registered-prefix boundary
+// (e.g. fan an `attacker.>` test subject if one were ever published).
+func TestSubjectsFromCSV_RejectsBareStar(t *testing.T) {
+	if got := SubjectsFromCSV("*"); got != nil {
+		t.Errorf("SubjectsFromCSV(\"*\") = %v, want nil", got)
+	}
+	if got := SubjectsFromCSV("*.bought"); got != nil {
+		t.Errorf("SubjectsFromCSV(\"*.bought\") = %v, want nil", got)
+	}
+	if _, err := ParseSubjectsCSV("*.bought"); err == nil {
+		t.Error("ParseSubjectsCSV(\"*.bought\"): expected error, got nil")
+	}
+}
+
+// TestSubjectsFromCSV_AllowsPrefixWildcard locks in that `*` and `>`
+// remain legal within a registered prefix; the validation only
+// rejects patterns whose FIRST token is the wildcard.
+func TestSubjectsFromCSV_AllowsPrefixWildcard(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Filter
+	}{
+		{"agents.*", Filter{"agents.*"}},
+		{"trades.>", Filter{"trades.>"}},
+		{"jobs.*,tokens.>", Filter{"jobs.*", "tokens.>"}},
+		{"agents.registered", Filter{"agents.registered"}},
+	}
+	for _, tc := range cases {
+		got := SubjectsFromCSV(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("SubjectsFromCSV(%q) = %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i, p := range got {
+			if p != tc.want[i] {
+				t.Errorf("SubjectsFromCSV(%q)[%d] = %q, want %q",
+					tc.in, i, p, tc.want[i])
+			}
+		}
+	}
+}
+
 // Test_parseJetStreamID covers the Last-Event-ID parser for the canonical
 // js:<seq> shape and the rejected forms.
 func Test_parseJetStreamID(t *testing.T) {


### PR DESCRIPTION
## Summary

Phase `M4-sse-multiplexer` for milestone M4. Closes #90.

## Test plan

- [ ] `forge test` green
- [ ] `slither` clean (Critical/High/Medium = 0)
- [ ] `go test ./services/...` green where touched
- [ ] reviewer signs off

## Manual verify (review-fix-1, write deadline)

After clearing the per-response write deadline in the SSE handler, an
open SSE connection must survive past the shared `http.Server`'s
30s `WriteTimeout`. Reproduce against a local gateway:

```sh
curl -N -H "Accept: text/event-stream" \
  http://localhost:8080/events?subjects=trades.*
```

Expected: stream stays open well past 30s, periodic `: ping` heartbeat
frames continue arriving every `HeartbeatInterval` (default 30s). Pre-fix
behaviour: connection was killed by the server at the first heartbeat
write.

## Verify

log: `.claude/cron/last-verify-M4-sse-multiplexer.log`

```
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/handlers	1.608s
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/middleware	2.112s
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/router	3.641s
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/sse	4.385s
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/store	2.703s
?   	github.com/0xDevNinja/titular/services/gateway-go/internal/types	[no test files]

=== go test ./internal/sse/... -count=5 (gateway-go) ===
ok  	github.com/0xDevNinja/titular/services/gateway-go/internal/sse	6.695s

=== indexer-go regression check ===
?   	github.com/0xDevNinja/titular/services/indexer-go	[no test files]
ok  	github.com/0xDevNinja/titular/services/indexer-go/cmd/migrate	0.273s
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/abi	0.420s
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/db	0.203s
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/decoder	0.628s
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/handlers	0.837s
?   	github.com/0xDevNinja/titular/services/indexer-go/internal/integration	[no test files]
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/publisher	1.201s
ok  	github.com/0xDevNinja/titular/services/indexer-go/internal/subscriber	1.190s
```
