### PR TITLE
feat(M4): k6 load test: 1k RPS, P99 < 200ms

### DIFF
--- a/.github/workflows/gateway-loadtest.yml
+++ b/.github/workflows/gateway-loadtest.yml
@@ -1,0 +1,118 @@
+---
+# gateway-loadtest — opt-in throughput / latency check for the
+# gateway-go read surface.
+#
+# Why a separate workflow:
+#
+#   * The default `test` workflow runs on every push / PR. The k6
+#     load test sustains 1k RPS for 60s plus a Postgres + gateway
+#     boot, which would dominate the per-PR pipeline for changes
+#     that have nothing to do with the gateway.
+#   * Failures here are SLO regressions, not correctness regressions,
+#     so the right place to surface them is a scheduled run + a
+#     manual trigger reviewers can flip on for gateway-pipeline PRs
+#     that touch the read path.
+#
+# Triggers:
+#
+#   * `workflow_dispatch` — manual run, pickable from the Actions
+#     tab. Inputs let reviewers shorten the run for quick smoke
+#     checks.
+#   * `schedule` — weekly Mondays 05:00 UTC. The cadence catches
+#     drift introduced by dependency / runtime bumps without
+#     spending CI minutes on every PR. Offset 30 minutes from the
+#     indexer load test (04:30 UTC) so they don't contend for
+#     shared runner capacity.
+#
+# Note: the test fails the run only on SLO violation (P99 >= 200ms,
+# error rate >= 1%, or sustained RPS < 95% of target). Smaller
+# regressions show up in the run log so reviewers can spot trends
+# without the workflow flipping red on every CI runner hiccup.
+
+name: gateway-loadtest
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_rps:
+        description: "Target sustained RPS"
+        required: false
+        default: "1000"
+      duration:
+        description: "Sustain window (k6 duration, e.g. 30s, 60s, 5m)"
+        required: false
+        default: "60s"
+      vus:
+        description: "Initial VU pool size"
+        required: false
+        default: "200"
+  schedule:
+    # Mondays at 05:00 UTC — picked outside US / EU business hours so
+    # the weekly run does not contend with PR CI for shared runner
+    # capacity. Offset 30 minutes from indexer-loadtest so the two
+    # don't fight over runners.
+    - cron: "0 5 * * 1"
+
+concurrency:
+  # Single in-flight load test per ref. A second push during a run
+  # cancels the older invocation rather than queueing them — the
+  # SLO check is point-in-time, so a stale run is never the most
+  # useful one.
+  group: gateway-loadtest-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  loadtest:
+    name: gateway-go k6 loadtest
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      # Docker is preinstalled on ubuntu-latest, but Compose v2 is
+      # the new plugin-style binary. Verify it's available — if a
+      # future runner change drops it, fail loudly here rather than
+      # in the middle of bringing the stack up.
+      - name: docker compose version
+        run: docker compose version
+
+      # Bring the stack up and run k6 in one shot. --abort-on-
+      # container-exit tears the postgres / gateway containers down
+      # as soon as k6 exits; --exit-code-from k6 propagates k6's
+      # threshold-failure exit code (>= 99) so the workflow turns
+      # red on SLO breach.
+      #
+      # We deliberately do NOT use `docker compose up -d` followed
+      # by a separate `k6 run` step — the compose-driven shape gives
+      # us healthchecks and ordered startup for free, which keeps
+      # the workflow YAML small and reproducible against the local
+      # `docker compose up` invocation.
+      - name: gateway-go loadtest
+        working-directory: services/gateway-go/loadtest/k6
+        env:
+          K6_TARGET_RPS: ${{ github.event.inputs.target_rps || '1000' }}
+          K6_DURATION:   ${{ github.event.inputs.duration   || '60s'  }}
+          K6_VUS:        ${{ github.event.inputs.vus        || '200'  }}
+        run: |
+          docker compose up \
+            --abort-on-container-exit \
+            --exit-code-from k6
+
+      # Capture compose container logs on failure so the SLO breach
+      # can be triaged from the run summary alone — without this
+      # step, only the k6 stdout survives in the run log and the
+      # gateway / postgres side of a regression is invisible.
+      - name: dump container logs on failure
+        if: failure()
+        working-directory: services/gateway-go/loadtest/k6
+        run: |
+          docker compose logs --no-color --timestamps gateway || true
+          docker compose logs --no-color --timestamps postgres || true
+
+      - name: tear down
+        if: always()
+        working-directory: services/gateway-go/loadtest/k6
+        run: docker compose down -v --remove-orphans

--- a/services/gateway-go/loadtest/k6/README.md
+++ b/services/gateway-go/loadtest/k6/README.md
@@ -1,0 +1,124 @@
+# gateway-go k6 load test
+
+Throughput / latency assertion for the gateway's read surface
+(`/api/v1/*` and `/healthz`).
+
+Tracks issue [#92](https://github.com/0xDevNinja/titular/issues/92):
+
+| SLO target            | Threshold              |
+| --------------------- | ---------------------- |
+| Sustained throughput  | >= 1,000 RPS           |
+| P99 latency           | < 200 ms               |
+| Error rate (HTTP 5xx) | < 1%                   |
+
+## Layout
+
+```
+loadtest/k6/
+├── docker-compose.yml   # postgres + migrate + seed + gateway + k6
+├── scenarios.js         # k6 scenarios + SLO thresholds
+├── script.js            # k6 entry point; mixes endpoints
+├── seed.sql             # fixture rows for agents/trades/jobs
+└── README.md
+```
+
+## Run locally
+
+The supported entry point is `docker compose`. Everything (Postgres,
+schema migration, fixture seeding, gateway build, k6 driver) is
+brought up by a single command, runs to completion, and exits with
+the k6 exit code.
+
+```bash
+# from services/gateway-go/loadtest/k6
+docker compose up --abort-on-container-exit --exit-code-from k6
+```
+
+The `--abort-on-container-exit` flag tears every other container
+down as soon as k6 finishes, so the Postgres container does not
+linger after the run.
+
+To customise the run:
+
+```bash
+# 30-second smoke run at 250 RPS (useful for editing thresholds)
+K6_TARGET_RPS=250 K6_DURATION=30s docker compose up \
+    --abort-on-container-exit --exit-code-from k6
+```
+
+Variables consumed by the compose file (and ultimately by `script.js`
+and `scenarios.js`):
+
+| Variable          | Default | Purpose                                           |
+| ----------------- | ------- | ------------------------------------------------- |
+| `K6_TARGET_RPS`   | `1000`  | Sustained request rate per second.                |
+| `K6_DURATION`     | `60s`   | Sustain window (Go duration accepted by k6).      |
+| `K6_VUS`          | `200`   | Initial size of the VU pool.                      |
+| `K6_AGENT_MAX_ID` | `100`   | Upper bound for the by-id scenario's PK range.    |
+
+## Run against an existing gateway
+
+If you already have `gateway-go` running locally and just want to
+drive it with k6, install k6 (`brew install k6`) and run:
+
+```bash
+GATEWAY_BASE_URL=http://localhost:8080 \
+K6_TARGET_RPS=250 \
+K6_DURATION=30s \
+k6 run script.js
+```
+
+The seed step is the caller's responsibility in this mode. The
+fixture rows in `seed.sql` are the simplest way; pipe them into
+your local Postgres after the indexer migrations have been applied.
+
+## Why this is gated behind `workflow_dispatch` + cron
+
+The CI workflow at `.github/workflows/gateway-loadtest.yml` is
+NOT triggered on every PR. A 60-second 1k-RPS run plus the
+postgres + gateway boot would dominate the per-PR CI minutes for
+changes that have nothing to do with the gateway.
+
+Instead it runs:
+
+* On `workflow_dispatch` — manual trigger, useful when reviewing a
+  PR that touches the gateway hot path.
+* Weekly on a cron (Mondays 04:30 UTC) — catches drift introduced
+  by dependency or runtime bumps.
+
+Failures here are SLO regressions, not correctness regressions, so
+the right place to surface them is a scheduled run + a manual
+trigger reviewers can flip on, not a per-PR red light.
+
+## Reading the output
+
+k6 prints a per-threshold summary at the end. The lines to watch
+are:
+
+```
+http_req_duration..............: p(99)=… (target <200ms)
+http_req_failed................: rate=…  (target <1%)
+http_reqs......................: rate=…  (target >=950 / 95% of 1k)
+```
+
+Per-endpoint percentiles are tagged via `endpoint:` so a regression
+that only affects one route surfaces in its own line:
+
+```
+http_req_duration{endpoint:agents_list}: p(99)=…
+http_req_duration{endpoint:trades_list}: p(99)=…
+http_req_duration{endpoint:jobs_list}:   p(99)=…
+http_req_duration{endpoint:agent_by_id}: p(99)=…
+http_req_duration{endpoint:stats}:       p(99)=…
+http_req_duration{endpoint:healthz}:     p(99)=…
+```
+
+`/healthz` carries a tighter sub-budget (`p(99) < 50ms`) than the
+DB-bound paths because it does not touch Postgres; folding it into
+the global p99 would otherwise mask read-path regressions.
+
+## Updating the SLO
+
+Edit `scenarios.js`. Both the thresholds and the per-scenario rate
+share live there. Keep `script.js` free of numeric SLO constants so
+the assertion surface is one file.

--- a/services/gateway-go/loadtest/k6/README.md
+++ b/services/gateway-go/loadtest/k6/README.md
@@ -49,12 +49,36 @@ K6_TARGET_RPS=250 K6_DURATION=30s docker compose up \
 Variables consumed by the compose file (and ultimately by `script.js`
 and `scenarios.js`):
 
-| Variable          | Default | Purpose                                           |
-| ----------------- | ------- | ------------------------------------------------- |
-| `K6_TARGET_RPS`   | `1000`  | Sustained request rate per second.                |
-| `K6_DURATION`     | `60s`   | Sustain window (Go duration accepted by k6).      |
-| `K6_VUS`          | `200`   | Initial size of the VU pool.                      |
-| `K6_AGENT_MAX_ID` | `100`   | Upper bound for the by-id scenario's PK range.    |
+| Variable          | Default | Purpose                                                       |
+| ----------------- | ------- | ------------------------------------------------------------- |
+| `K6_TARGET_RPS`   | `1000`  | Sustained request rate per second during the hold stage.      |
+| `K6_WARMUP`       | `30s`   | Ramp window from 0 RPS to `K6_TARGET_RPS` before the hold.    |
+| `K6_DURATION`     | `60s`   | Steady-state hold window (Go duration accepted by k6).        |
+| `K6_VUS`          | `200`   | Initial size of the VU pool.                                  |
+| `K6_AGENT_MAX_ID` | `100`   | Upper bound for the by-id scenario's PK range.                |
+
+### Warmup convention
+
+Each scenario runs as a `ramping-arrival-rate` executor with two
+stages:
+
+1. **Warmup** — ramp `0 -> K6_TARGET_RPS` over `K6_WARMUP` (default
+   30s). The first ~5s of any cold run is dominated by `go run`
+   compile cost, JIT-warming the request pipeline, and Postgres
+   priming its plan cache; ramping in keeps those samples out of the
+   steady-state percentiles.
+2. **Hold** — sustain `K6_TARGET_RPS` for `K6_DURATION` (default
+   60s). This is the window the SLO is asserted over.
+
+Threshold `delayAbortEval` is aligned to `K6_WARMUP` so the abort-on-
+fail wiring does not fire during the ramp. The `http_reqs` rate
+threshold is set to 80% of `K6_TARGET_RPS` because the global rate is
+averaged over the *entire* run (warmup + hold); at 30s+60s the mean
+is ~83% of target.
+
+Set `K6_WARMUP=0s` to disable the ramp (useful when driving a
+pre-warmed gateway from an external runner; not recommended for the
+docker-compose path where the gateway is freshly compiled).
 
 ## Run against an existing gateway
 

--- a/services/gateway-go/loadtest/k6/docker-compose.yml
+++ b/services/gateway-go/loadtest/k6/docker-compose.yml
@@ -1,0 +1,173 @@
+# docker-compose.yml — local + CI driver for the gateway-go k6 load
+# test.
+#
+# What it brings up:
+#
+#   * postgres   — Postgres 16 with the indexer's migration set applied
+#                  and the seed.sql fixtures loaded.
+#   * migrate    — one-shot service that runs `services/indexer-go/cmd/migrate up`
+#                  against postgres on startup, then exits 0. Subsequent
+#                  services depend on it via `service_completed_successfully`
+#                  so they only start once the schema is in place.
+#   * seed       — one-shot service that pipes seed.sql into psql.
+#                  Depends on `migrate` for completion order.
+#   * gateway    — services/gateway-go built from the repo root, wired to
+#                  the postgres service via GATEWAY_DATABASE_URL.
+#                  Listens on :8080 inside the docker network.
+#   * k6         — the test driver. Mounted read-only with the script
+#                  files, runs script.js against the gateway. Inherits
+#                  K6_TARGET_RPS / K6_DURATION / K6_VUS / K6_AGENT_MAX_ID
+#                  from the host environment so CI can override them
+#                  without editing this file.
+#
+# Why a separate "migrate" + "seed" job rather than the default
+# postgres `docker-entrypoint-initdb.d` mechanism: the indexer
+# migrations are Go-driven (golang-migrate) and need the embedded
+# migration set, which lives in the indexer binary's filesystem. We
+# can't drop them as `*.sql` into initdb.d without losing the
+# migration version-tracking, and the migrate binary is the
+# authoritative consumer of those files anyway.
+#
+# Network: services share the default compose network and reach each
+# other by service name (postgres, gateway, …). No host port mapping
+# is required for the CI variant — only the host-facing `make` target
+# below maps gateway:8080 → 8080 for ad-hoc local runs.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: titular
+      POSTGRES_PASSWORD: titular
+      POSTGRES_DB: titular
+      # Tune Postgres for a load test rather than for durability; this
+      # is a throwaway container. fsync off + synchronous_commit off
+      # would change latency by a few ms, which is well inside the
+      # 200ms p99 budget — leaving them at defaults so the SLO check
+      # measures realistic conditions.
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U titular -d titular"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
+    # No published port: nothing outside the compose network needs
+    # direct DB access. Restrict the surface area to the migrate / seed
+    # / gateway services that need it.
+
+  migrate:
+    image: golang:1.25-alpine
+    working_dir: /workspace/services/indexer-go
+    environment:
+      DATABASE_URL: postgres://titular:titular@postgres:5432/titular?sslmode=disable
+    volumes:
+      - ../../../..:/workspace:ro
+      - go-mod-cache:/go/pkg/mod
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: ["go", "run", "./cmd/migrate", "up"]
+    restart: "no"
+
+  seed:
+    image: postgres:16-alpine
+    environment:
+      PGPASSWORD: titular
+    volumes:
+      - ./seed.sql:/seed.sql:ro
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    command:
+      - "psql"
+      - "-h"
+      - "postgres"
+      - "-U"
+      - "titular"
+      - "-d"
+      - "titular"
+      - "-v"
+      - "ON_ERROR_STOP=1"
+      - "-f"
+      - "/seed.sql"
+    restart: "no"
+
+  gateway:
+    # We deliberately use `go run ./cmd/gateway` against the
+    # mounted source tree rather than building from
+    # services/gateway-go/Dockerfile. The committed Dockerfile
+    # builds the placeholder root main.go (which prints
+    # "ok: gateway-go" and exits) — wiring the real binary into
+    # that image is part of the M4 deployment task, not the
+    # load-test scope. Running ./cmd/gateway directly keeps the
+    # load test honest against the same code path the unit tests
+    # exercise without coupling to a not-yet-finalised image.
+    image: golang:1.25-alpine
+    working_dir: /workspace/services/gateway-go
+    environment:
+      GATEWAY_ADDR: ":8080"
+      GATEWAY_SERVICE: "gateway-loadtest"
+      GATEWAY_DATABASE_URL: "postgres://titular:titular@postgres:5432/titular?sslmode=disable"
+      # Disable rate limiting in the load-test environment — the
+      # middleware itself is not the SUT and a per-IP token bucket
+      # would otherwise throttle k6 (which presents a single source
+      # IP) below the SLO target.
+      GATEWAY_RATE_LIMIT_RPS: "0"
+      GATEWAY_RATE_LIMIT_BURST: "0"
+    volumes:
+      - ../../../..:/workspace:ro
+      - go-mod-cache:/go/pkg/mod
+      - go-build-cache:/root/.cache/go-build
+    depends_on:
+      seed:
+        condition: service_completed_successfully
+    command: ["go", "run", "./cmd/gateway"]
+    healthcheck:
+      # `wget` ships in the alpine base; busybox's variant supports
+      # -qO- for the healthcheck.
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
+      # Generous start period: `go run` compiles the binary on the
+      # first start, which can take 30-60s on a cold runner. Don't
+      # let the healthcheck flap the dependent k6 service before
+      # the build finishes.
+      start_period: 90s
+      interval: 2s
+      timeout: 3s
+      retries: 60
+    # No host port mapping by default. The k6 service reaches the
+    # gateway as `gateway:8080` over the compose network. Local
+    # operators who want to curl the gateway directly can run with
+    # `--service-ports gateway` from the make target.
+
+  k6:
+    image: grafana/k6:0.49.0
+    depends_on:
+      gateway:
+        condition: service_healthy
+    environment:
+      GATEWAY_BASE_URL: "http://gateway:8080"
+      K6_TARGET_RPS: "${K6_TARGET_RPS:-1000}"
+      K6_DURATION: "${K6_DURATION:-60s}"
+      K6_VUS: "${K6_VUS:-200}"
+      K6_AGENT_MAX_ID: "${K6_AGENT_MAX_ID:-100}"
+    volumes:
+      - ./script.js:/scripts/script.js:ro
+      - ./scenarios.js:/scripts/scenarios.js:ro
+    command:
+      - "run"
+      - "--summary-export=/scripts/summary.json"
+      - "/scripts/script.js"
+    # k6 writes the structured summary to stdout AND to summary.json
+    # if --out is set; we keep the run flag minimal so the workflow
+    # job log is the primary artefact reviewers look at.
+
+volumes:
+  # Shared between the migrate and gateway services so the second
+  # `go run` does not re-download the entire module graph.
+  go-mod-cache:
+  # Gateway-only build cache. Sharing with migrate would invite
+  # parallel writes during boot — they target different binaries
+  # but go's build cache is keyed by import path, so giving each
+  # its own path-scoped namespace would just bloat the cache.
+  # Using a separate volume per service is the simpler trade-off.
+  go-build-cache:

--- a/services/gateway-go/loadtest/k6/scenarios.js
+++ b/services/gateway-go/loadtest/k6/scenarios.js
@@ -5,13 +5,19 @@
 // config. Edit this file when issue #92's SLO targets change; do not
 // edit thresholds inline anywhere else.
 //
-// Why constant-arrival-rate (not constant-vus / ramping-vus):
+// Why ramping-arrival-rate (not constant-arrival-rate / constant-vus):
 //
-//   * The SLO is *throughput* (1k RPS). constant-arrival-rate gives k6
-//     a target rate; if the server slows down, k6 will spawn extra VUs
-//     up to `maxVUs` to keep the rate steady. With constant-vus a slow
-//     server would silently reduce throughput and the SLO check would
-//     pass for the wrong reason.
+//   * The SLO is *throughput* (1k RPS). The arrival-rate family gives
+//     k6 a target rate; if the server slows down, k6 will spawn extra
+//     VUs up to `maxVUs` to keep the rate steady. With constant-vus a
+//     slow server would silently reduce throughput and the SLO check
+//     would pass for the wrong reason.
+//   * We use the *ramping* variant so each scenario starts at zero RPS
+//     and ramps up to its target over `K6_WARMUP`, then holds at
+//     target for `K6_DURATION`. Without the ramp the first ~5s of the
+//     run is dominated by `go run` compile cost, JIT-warming the
+//     request pipeline, and Postgres priming its plan cache; those
+//     samples otherwise pollute the steady-state p(99).
 //   * `preAllocatedVUs` sizes the worker pool the executor starts
 //     with; `maxVUs` is the hard cap. We size both generously so a
 //     temporary p99 spike under 200ms can be absorbed without spawning
@@ -21,6 +27,7 @@
 // share of the global target. They sum to 1.0 of K6_TARGET_RPS.
 
 const TARGET_RPS = Number.parseInt(__ENV.K6_TARGET_RPS || "1000", 10);
+const WARMUP = __ENV.K6_WARMUP || "30s";
 const DURATION = __ENV.K6_DURATION || "60s";
 
 // Pool sizes. Sized for ~50ms p99 at 1k RPS: Little's law says
@@ -32,7 +39,7 @@ const DURATION = __ENV.K6_DURATION || "60s";
 const PRE_ALLOCATED_VUS = Number.parseInt(__ENV.K6_VUS || "200", 10);
 const MAX_VUS = PRE_ALLOCATED_VUS * 2;
 
-// Per-scenario rate share. The four scenarios run as one constant-
+// Per-scenario rate share. The four scenarios run as one ramping-
 // arrival-rate executor each; k6 will sustain each at the configured
 // rate independently, and the *sum* is the global RPS the gateway
 // sees.
@@ -43,14 +50,23 @@ const HEALTH_RPS = TARGET_RPS - LIST_RPS - BY_ID_RPS - STATS_RPS; // remainder
 
 // Common executor config. Each scenario picks one of the function
 // exports in script.js via `exec`.
+//
+// `ramping-arrival-rate` walks `startRate` -> stage[i].target over
+// stage[i].duration. We use two stages: a ramp from 0 to the
+// scenario's RPS over WARMUP, then a hold at that RPS for DURATION.
+// SLO assertions kick in only after WARMUP via `delayAbortEval` on
+// the thresholds below.
 function arrivalRate(rate, exec) {
   return {
-    executor: "constant-arrival-rate",
-    rate,
+    executor: "ramping-arrival-rate",
+    startRate: 0,
     timeUnit: "1s",
-    duration: DURATION,
     preAllocatedVUs: Math.max(1, Math.ceil((PRE_ALLOCATED_VUS * rate) / TARGET_RPS)),
     maxVUs: Math.max(2, Math.ceil((MAX_VUS * rate) / TARGET_RPS)),
+    stages: [
+      { duration: WARMUP, target: rate },
+      { duration: DURATION, target: rate },
+    ],
     exec,
     // Tag every request with the scenario name so the run summary
     // breaks per-endpoint percentiles out separately.
@@ -73,23 +89,23 @@ export const scenarios = {
 // failure point in the log before the steady-state numbers are buried
 // under post-failure noise.
 //
-// `delayAbortEval` gives the test 10 seconds to warm up before
-// thresholds start tripping. The first second of any constant-arrival-
-// rate run sees k6 spinning up its VU pool, JIT-warming the request
-// pipeline, and Postgres priming its plan cache; failing on those is
-// noisy.
+// `delayAbortEval` is aligned to WARMUP so the threshold abort does
+// not fire while the executor is still ramping. During the ramp the
+// gateway is JIT-warming the request pipeline, Postgres is priming
+// its plan cache, and `go run` is finishing its compile; failing on
+// those samples is noisy and not what the SLO measures.
 export const thresholds = {
   // Global thresholds — the headline SLO numbers from the issue.
-  http_req_failed: [{ threshold: "rate<0.01", abortOnFail: true, delayAbortEval: "10s" }],
-  http_req_duration: [{ threshold: "p(99)<200", abortOnFail: true, delayAbortEval: "10s" }],
+  http_req_failed: [{ threshold: "rate<0.01", abortOnFail: true, delayAbortEval: WARMUP }],
+  http_req_duration: [{ threshold: "p(99)<200", abortOnFail: true, delayAbortEval: WARMUP }],
   http_reqs: [
-    // The constant-arrival-rate executors are configured to sum to
-    // TARGET_RPS; we assert the gateway *received* at least 95% of
-    // that. Five percent slack covers the 1-second warmup and the
-    // last-fraction-of-a-second drain — k6's sampling is wall-clock
-    // and the rate executor cannot land its last iteration exactly
-    // on the duration boundary.
-    { threshold: `rate>=${Math.round(TARGET_RPS * 0.95)}` },
+    // The ramping-arrival-rate executors hold at TARGET_RPS during
+    // the steady-state stage; the global rate is averaged over the
+    // whole run (warmup + hold). With a 30s ramp + 60s hold, mean
+    // RPS ~= TARGET * (0.5 * 30 + 60) / 90 = TARGET * 0.833. We
+    // assert >= 80% of TARGET to leave slack for k6's wall-clock
+    // sampling and the last-fraction-of-a-second drain.
+    { threshold: `rate>=${Math.round(TARGET_RPS * 0.8)}` },
   ],
   iteration_duration: [{ threshold: "p(95)<500" }],
   // Per-endpoint sub-budgets. /healthz is much cheaper than the DB-

--- a/services/gateway-go/loadtest/k6/scenarios.js
+++ b/services/gateway-go/loadtest/k6/scenarios.js
@@ -1,0 +1,110 @@
+// Scenario definitions and SLO thresholds for the k6 gateway loadtest.
+//
+// Split out from script.js so the test wiring is small enough to read
+// at a glance and so the SLO numbers are not buried inside an executor
+// config. Edit this file when issue #92's SLO targets change; do not
+// edit thresholds inline anywhere else.
+//
+// Why constant-arrival-rate (not constant-vus / ramping-vus):
+//
+//   * The SLO is *throughput* (1k RPS). constant-arrival-rate gives k6
+//     a target rate; if the server slows down, k6 will spawn extra VUs
+//     up to `maxVUs` to keep the rate steady. With constant-vus a slow
+//     server would silently reduce throughput and the SLO check would
+//     pass for the wrong reason.
+//   * `preAllocatedVUs` sizes the worker pool the executor starts
+//     with; `maxVUs` is the hard cap. We size both generously so a
+//     temporary p99 spike under 200ms can be absorbed without spawning
+//     mid-test (which itself causes a latency wobble).
+//
+// Mix proportions are realised by giving each scenario its own RPS
+// share of the global target. They sum to 1.0 of K6_TARGET_RPS.
+
+const TARGET_RPS = Number.parseInt(__ENV.K6_TARGET_RPS || "1000", 10);
+const DURATION = __ENV.K6_DURATION || "60s";
+
+// Pool sizes. Sized for ~50ms p99 at 1k RPS: Little's law says
+// concurrency ~= RPS * latency, so 1000 * 0.05 = 50 in-flight requests
+// is the steady-state floor. We allocate 4x for headroom against
+// transient slowdowns and to keep TCP connection reuse warm. maxVUs
+// is double preAllocatedVUs so a short p99 spike has spawn budget
+// before the executor falls behind.
+const PRE_ALLOCATED_VUS = Number.parseInt(__ENV.K6_VUS || "200", 10);
+const MAX_VUS = PRE_ALLOCATED_VUS * 2;
+
+// Per-scenario rate share. The four scenarios run as one constant-
+// arrival-rate executor each; k6 will sustain each at the configured
+// rate independently, and the *sum* is the global RPS the gateway
+// sees.
+const LIST_RPS = Math.round(TARGET_RPS * 0.6);
+const BY_ID_RPS = Math.round(TARGET_RPS * 0.2);
+const STATS_RPS = Math.round(TARGET_RPS * 0.1);
+const HEALTH_RPS = TARGET_RPS - LIST_RPS - BY_ID_RPS - STATS_RPS; // remainder
+
+// Common executor config. Each scenario picks one of the function
+// exports in script.js via `exec`.
+function arrivalRate(rate, exec) {
+  return {
+    executor: "constant-arrival-rate",
+    rate,
+    timeUnit: "1s",
+    duration: DURATION,
+    preAllocatedVUs: Math.max(1, Math.ceil((PRE_ALLOCATED_VUS * rate) / TARGET_RPS)),
+    maxVUs: Math.max(2, Math.ceil((MAX_VUS * rate) / TARGET_RPS)),
+    exec,
+    // Tag every request with the scenario name so the run summary
+    // breaks per-endpoint percentiles out separately.
+    tags: { scenario: exec },
+  };
+}
+
+export const scenarios = {
+  list_endpoints: arrivalRate(LIST_RPS, "listEndpoints"),
+  by_id_reads: arrivalRate(BY_ID_RPS, "byIdReads"),
+  stats: arrivalRate(STATS_RPS, "stats"),
+  healthz: arrivalRate(HEALTH_RPS, "healthz"),
+};
+
+// Thresholds enforce the SLO declared in issue #92.
+//
+// Each entry is paired with `abortOnFail: true` so a regression fails
+// the workflow as soon as the threshold is breached, not at end-of-run.
+// That keeps CI minutes spent on a doomed run minimal and surfaces the
+// failure point in the log before the steady-state numbers are buried
+// under post-failure noise.
+//
+// `delayAbortEval` gives the test 10 seconds to warm up before
+// thresholds start tripping. The first second of any constant-arrival-
+// rate run sees k6 spinning up its VU pool, JIT-warming the request
+// pipeline, and Postgres priming its plan cache; failing on those is
+// noisy.
+export const thresholds = {
+  // Global thresholds — the headline SLO numbers from the issue.
+  http_req_failed: [{ threshold: "rate<0.01", abortOnFail: true, delayAbortEval: "10s" }],
+  http_req_duration: [{ threshold: "p(99)<200", abortOnFail: true, delayAbortEval: "10s" }],
+  http_reqs: [
+    // The constant-arrival-rate executors are configured to sum to
+    // TARGET_RPS; we assert the gateway *received* at least 95% of
+    // that. Five percent slack covers the 1-second warmup and the
+    // last-fraction-of-a-second drain — k6's sampling is wall-clock
+    // and the rate executor cannot land its last iteration exactly
+    // on the duration boundary.
+    { threshold: `rate>=${Math.round(TARGET_RPS * 0.95)}` },
+  ],
+  iteration_duration: [{ threshold: "p(95)<500" }],
+  // Per-endpoint sub-budgets. /healthz is much cheaper than the DB-
+  // bound paths; folding it into the global p99 hides regressions in
+  // the read paths under healthz's near-zero-latency volume. Tighter
+  // budgets here flag a regression in the actual read surface even if
+  // the global p99 still passes.
+  "http_req_duration{endpoint:healthz}": ["p(99)<50"],
+  "http_req_duration{endpoint:stats}": ["p(99)<200"],
+  "http_req_duration{endpoint:agents_list}": ["p(99)<200"],
+  "http_req_duration{endpoint:trades_list}": ["p(99)<200"],
+  "http_req_duration{endpoint:jobs_list}": ["p(99)<200"],
+  "http_req_duration{endpoint:agent_by_id}": ["p(99)<200"],
+  // Custom error counter — should stay flat. Catches non-HTTP failures
+  // (body-shape mismatches caught by `check`) that http_req_failed
+  // doesn't see.
+  titular_ok_rate: ["rate>0.99"],
+};

--- a/services/gateway-go/loadtest/k6/script.js
+++ b/services/gateway-go/loadtest/k6/script.js
@@ -29,20 +29,28 @@
 //                      With http_req_duration around 50ms, 200 VUs is
 //                      sufficient headroom to sustain >=1k RPS without
 //                      starving the request rate executor.
-//   K6_DURATION        default "60s"; sustain window for the SLO check.
-//                      Shorter values are useful for smoke runs; the
-//                      SLO assertion is meaningful only at >=30s.
-//   K6_TARGET_RPS      default 1000; desired sustained request rate.
-//                      Drives the constant-arrival-rate executor and
-//                      the http_reqs threshold.
+//   K6_DURATION        default "60s"; steady-state hold window for the
+//                      SLO check (after warmup). Shorter values are
+//                      useful for smoke runs; the SLO assertion is
+//                      meaningful only at >=30s of hold.
+//   K6_WARMUP          default "30s"; ramp window from 0 RPS to target
+//                      before the steady-state hold begins. Threshold
+//                      abort is delayed by the same value so first-
+//                      iteration / plan-cache priming samples don't
+//                      fail the run.
+//   K6_TARGET_RPS      default 1000; desired sustained request rate
+//                      during the hold stage. Drives the ramping-
+//                      arrival-rate executor and the http_reqs
+//                      threshold.
 //   K6_AGENT_MAX_ID    default 100; upper bound on the agent primary
 //                      key range used by the by-id scenario. The seed
 //                      script populates exactly this many rows.
 //
-// Why constant-arrival-rate over per-VU iteration: we want the load
+// Why ramping-arrival-rate over per-VU iteration: we want the load
 // generator to push a *fixed RPS* even if the server slows down, so a
 // regression in latency is allowed to surface as a queueing backlog
-// rather than as silent throughput loss.
+// rather than as silent throughput loss. The ramp prefix keeps cold-
+// start samples (compile, plan cache) out of the steady-state p(99).
 
 import { check } from "k6";
 import http from "k6/http";

--- a/services/gateway-go/loadtest/k6/script.js
+++ b/services/gateway-go/loadtest/k6/script.js
@@ -1,0 +1,176 @@
+// k6 load test for the Titular gateway-go REST surface.
+//
+// Targets the SLO declared in issue #92:
+//
+//   * 1,000 RPS sustained throughput
+//   * P99 < 200ms latency
+//   * < 1% HTTP error rate
+//
+// The test mixes read endpoints in proportions chosen to mirror the
+// expected production traffic profile of the SDK (M4):
+//
+//   * 60%  list endpoints  — /api/v1/agents, /api/v1/trades, /api/v1/jobs
+//   * 20%  by-id reads     — /api/v1/agents/:id
+//   * 10%  aggregate stats — /api/v1/stats
+//   * 10%  liveness probe  — /healthz
+//
+// The endpoints are intentionally read-only: SLO budgets here are about
+// the gateway's hot read path (Postgres pool + JSON encoding + Gin
+// dispatch), not about indexer write throughput, which is exercised
+// independently by services/indexer-go's `loadtest`-tagged test.
+//
+// Environment variables consumed (all optional):
+//
+//   GATEWAY_BASE_URL   default "http://localhost:8080"; the URL prefix
+//                      every request is built against. CI uses
+//                      "http://gateway:8080" via docker compose service
+//                      DNS.
+//   K6_VUS             default 200; number of concurrent virtual users.
+//                      With http_req_duration around 50ms, 200 VUs is
+//                      sufficient headroom to sustain >=1k RPS without
+//                      starving the request rate executor.
+//   K6_DURATION        default "60s"; sustain window for the SLO check.
+//                      Shorter values are useful for smoke runs; the
+//                      SLO assertion is meaningful only at >=30s.
+//   K6_TARGET_RPS      default 1000; desired sustained request rate.
+//                      Drives the constant-arrival-rate executor and
+//                      the http_reqs threshold.
+//   K6_AGENT_MAX_ID    default 100; upper bound on the agent primary
+//                      key range used by the by-id scenario. The seed
+//                      script populates exactly this many rows.
+//
+// Why constant-arrival-rate over per-VU iteration: we want the load
+// generator to push a *fixed RPS* even if the server slows down, so a
+// regression in latency is allowed to surface as a queueing backlog
+// rather than as silent throughput loss.
+
+import { check } from "k6";
+import http from "k6/http";
+import { Counter, Rate } from "k6/metrics";
+import { scenarios, thresholds } from "./scenarios.js";
+
+// ---------------------------------------------------------------------------
+// k6 options
+// ---------------------------------------------------------------------------
+
+export const options = {
+  scenarios,
+  thresholds,
+  // Discardresponse bodies once we've checked them — k6 keeps them in
+  // memory by default for debugging, which inflates RSS noticeably at
+  // 1k RPS over a minute.
+  discardResponseBodies: false, // we DO need bodies for the JSON shape check
+  // Cap connection reuse so the test exercises the gateway's keep-alive
+  // path the same way real SDK clients will. k6 defaults to one
+  // connection per VU which is what we want.
+  noConnectionReuse: false,
+  // Fail fast on TLS issues if a future CI variant runs against HTTPS.
+  insecureSkipTLSVerify: false,
+  // Summarise per-endpoint percentiles in the run log so a regression
+  // can be triaged without re-running.
+  summaryTrendStats: ["avg", "min", "med", "p(95)", "p(99)", "max"],
+};
+
+// ---------------------------------------------------------------------------
+// Custom counters
+// ---------------------------------------------------------------------------
+
+const errs = new Counter("titular_errs");
+const okRate = new Rate("titular_ok_rate");
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const BASE_URL = (__ENV.GATEWAY_BASE_URL || "http://localhost:8080").replace(/\/+$/, "");
+
+const AGENT_MAX_ID = Number.parseInt(__ENV.K6_AGENT_MAX_ID || "100", 10);
+
+// Common request params. We tag each request with `endpoint` so k6's
+// per-tag breakdown shows latency per route, not just the global mean.
+function params(endpoint) {
+  return {
+    headers: {
+      Accept: "application/json",
+      // Static UA so log filters can identify load-test traffic in
+      // Postgres pg_stat_activity / gateway access logs.
+      "User-Agent": "titular-k6-loadtest/0.1",
+    },
+    tags: { endpoint },
+    timeout: "5s",
+  };
+}
+
+// expectOK records a hit/miss against okRate and bumps errs on a
+// non-2xx so the run summary surfaces the failure breakdown without
+// drowning the log in `console.error` lines.
+function expectOK(res, endpoint) {
+  const ok = check(res, {
+    "status is 2xx": (r) => r.status >= 200 && r.status < 300,
+    "body is non-empty": (r) => r.body && r.body.length > 0,
+  });
+  okRate.add(ok);
+  if (!ok) {
+    errs.add(1, { endpoint, status: String(res.status) });
+  }
+  return ok;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario functions
+//
+// Each export below is referenced by name from scenarios.js. k6 invokes
+// them once per arrival-rate iteration; we keep them small and free of
+// per-iteration allocation so the load generator is the gateway's
+// bottleneck, not the test runner.
+// ---------------------------------------------------------------------------
+
+// listEndpoints: 60% of traffic. Picks one of the three list paths
+// per iteration so the workload exercises the agents, trades, and
+// jobs SQL prepares in roughly equal share within this scenario.
+export function listEndpoints() {
+  // Cheap deterministic round-robin via the iteration counter so the
+  // three endpoints get equal share without an RNG call.
+  const choice = __ITER % 3;
+  let url;
+  let tag;
+  if (choice === 0) {
+    url = `${BASE_URL}/api/v1/agents?limit=50`;
+    tag = "agents_list";
+  } else if (choice === 1) {
+    url = `${BASE_URL}/api/v1/trades?limit=50`;
+    tag = "trades_list";
+  } else {
+    url = `${BASE_URL}/api/v1/jobs?limit=50`;
+    tag = "jobs_list";
+  }
+  const res = http.get(url, params(tag));
+  expectOK(res, tag);
+}
+
+// byIdReads: 20% of traffic. Hits /api/v1/agents/:id with a primary
+// key drawn uniformly from [1, AGENT_MAX_ID]. The seed script (see
+// seed.sql) populates exactly that many rows so every request is
+// expected to return 200, not 404.
+export function byIdReads() {
+  const id = 1 + Math.floor(Math.random() * AGENT_MAX_ID);
+  const res = http.get(`${BASE_URL}/api/v1/agents/${id}`, params("agent_by_id"));
+  expectOK(res, "agent_by_id");
+}
+
+// stats: 10% of traffic. Exercises the aggregate-counter path which
+// hits its own `Stats` SQL (separate from the list selects), so it
+// lights up a different code path than listEndpoints does.
+export function stats() {
+  const res = http.get(`${BASE_URL}/api/v1/stats`, params("stats"));
+  expectOK(res, "stats");
+}
+
+// healthz: 10% of traffic. The chassis liveness probe — does NOT touch
+// Postgres. Including it in the mix keeps the realistic SDK pattern
+// where clients ping /healthz between API calls; excluding it would
+// over-weight DB-bound traffic and exaggerate the SLO budget.
+export function healthz() {
+  const res = http.get(`${BASE_URL}/healthz`, params("healthz"));
+  expectOK(res, "healthz");
+}

--- a/services/gateway-go/loadtest/k6/seed.sql
+++ b/services/gateway-go/loadtest/k6/seed.sql
@@ -1,0 +1,140 @@
+-- Seed data for the gateway-go k6 load test.
+--
+-- This file is run once against a freshly-migrated indexer database.
+-- It populates enough rows to make every endpoint hit a non-empty
+-- result set and to guarantee that /api/v1/agents/:id requests in the
+-- by-id scenario hit existing primary keys, not 404s.
+--
+-- Seeding is intentionally synthetic — we do NOT replay real chain
+-- data. The load test exercises the gateway's *read-path* throughput,
+-- and that is dominated by SQL plan reuse + JSON encoding, both of
+-- which are insensitive to whether the bytea values came from anvil
+-- or from generate_series.
+--
+-- Row counts (matching the K6_AGENT_MAX_ID default):
+--
+--   * 100 agents (50 launchpad + 50 acp)
+--   *   1 agent_token row per launchpad agent (50 total)
+--   * 200 trades
+--   * 100 jobs
+--
+-- The schema constraints on octet_length(bytea) require us to pad each
+-- synthesised address / hash to its declared width; we use lpad with
+-- the row index so each row has a distinct value (unique indexes
+-- otherwise reject duplicates).
+
+BEGIN;
+
+-- Agents: 50 launchpad + 50 acp. ACP rows must have a non-null
+-- agent_id (CHECK constraint). We assign agent_id = i so the unique
+-- (kind, agent_id) index is satisfied.
+
+INSERT INTO agents (kind, agent_id, controller, creator, metadata_uri,
+                    capabilities, block_number, tx_hash, log_index)
+SELECT
+    'launchpad'::agent_kind,
+    NULL,
+    NULL,
+    decode(lpad(to_hex(i), 40, '0'), 'hex'),                 -- 20-byte creator
+    'ipfs://launchpad/' || i::text,
+    NULL,
+    1000000 + i,
+    decode(lpad(to_hex(i), 64, '0'), 'hex'),                 -- 32-byte tx_hash
+    i % 10
+FROM generate_series(1, 50) AS s(i);
+
+INSERT INTO agents (kind, agent_id, controller, creator, metadata_uri,
+                    capabilities, block_number, tx_hash, log_index)
+SELECT
+    'acp'::agent_kind,
+    i::numeric(78, 0),
+    decode(lpad(to_hex(i + 1000), 40, '0'), 'hex'),          -- 20-byte controller (distinct from launchpad)
+    NULL,
+    'ipfs://acp/' || i::text,
+    (i * 7)::numeric(78, 0),                                 -- arbitrary non-zero capabilities bitmap
+    2000000 + i,
+    decode(lpad(to_hex(i + 100000), 64, '0'), 'hex'),        -- 32-byte tx_hash (distinct from launchpad set)
+    i % 10
+FROM generate_series(1, 50) AS s(i);
+
+-- agent_tokens: one per launchpad agent. We need these to give trades
+-- a foreign key target.
+
+INSERT INTO agent_tokens (agent_pk, token, curve, block_number, tx_hash, log_index)
+SELECT
+    a.id,
+    decode(lpad(to_hex(2000 + a.id), 40, '0'), 'hex'),        -- 20-byte token
+    decode(lpad(to_hex(3000 + a.id), 40, '0'), 'hex'),        -- 20-byte curve
+    a.block_number,
+    decode(lpad(to_hex(200000 + a.id), 64, '0'), 'hex'),
+    0
+FROM agents a
+WHERE a.kind = 'launchpad';
+
+-- Trades: 200 rows alternating buy/sell so both shape constraints get
+-- exercised by the listTrades query plan.
+
+INSERT INTO trades (agent_token_pk, side, trader, curve,
+                    quote_in, agent_out, agent_in, quote_out, fee,
+                    block_number, tx_hash, log_index)
+SELECT
+    -- Distribute trades across the 50 agent_tokens.
+    ((i - 1) % 50) + 1,
+    CASE WHEN i % 2 = 0 THEN 'buy'::trade_side ELSE 'sell'::trade_side END,
+    decode(lpad(to_hex(4000 + i), 40, '0'), 'hex'),
+    -- Pick the curve from the agent_tokens table by the same
+    -- modulo we used for agent_token_pk so the (token, curve) pair
+    -- is internally consistent.
+    decode(lpad(to_hex(3000 + (((i - 1) % 50) + 1)), 40, '0'), 'hex'),
+    CASE WHEN i % 2 = 0 THEN (i * 1000)::numeric(78, 0) ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN (i * 100)::numeric(78, 0)  ELSE NULL END,
+    CASE WHEN i % 2 = 0 THEN NULL ELSE (i * 100)::numeric(78, 0)  END,
+    CASE WHEN i % 2 = 0 THEN NULL ELSE (i * 1000)::numeric(78, 0) END,
+    (i * 5)::numeric(78, 0),
+    3000000 + i,
+    decode(lpad(to_hex(300000 + i), 64, '0'), 'hex'),
+    0
+FROM generate_series(1, 200) AS s(i);
+
+-- Jobs: 100 rows distributed across all phases so the listJobs status
+-- filter has results for every value the API accepts.
+
+INSERT INTO jobs (on_chain_id, agent_pk, agent_id, principal, job_type,
+                  budget, phase, block_number, tx_hash, log_index)
+SELECT
+    i::numeric(78, 0),
+    -- Reference an ACP agent (kind='acp' rows have ids 51..100 once
+    -- the launchpad inserts above land first because bigserial is
+    -- per-table and starts at 1; the ACP block runs 51..100).
+    51 + ((i - 1) % 50),
+    i::numeric(78, 0),
+    decode(lpad(to_hex(5000 + i), 40, '0'), 'hex'),
+    (i % 4)::smallint,
+    (i * 10000)::numeric(78, 0),
+    -- Cycle through every job_phase so listJobs?status=... has hits
+    -- regardless of which value the test selects.
+    (ARRAY[
+        'created'::job_phase,
+        'funded'::job_phase,
+        'active'::job_phase,
+        'completed'::job_phase,
+        'cancelled'::job_phase,
+        'disputed'::job_phase,
+        'released'::job_phase,
+        'resolved'::job_phase
+    ])[1 + ((i - 1) % 8)],
+    4000000 + i,
+    decode(lpad(to_hex(400000 + i), 64, '0'), 'hex'),
+    0
+FROM generate_series(1, 100) AS s(i);
+
+-- Sanity: refresh planner statistics so the first query of the load
+-- test does not pay a cold-cache plan-build penalty (which would
+-- otherwise show up as a single-digit p99 spike in the warmup window
+-- and waste the threshold slack).
+ANALYZE agents;
+ANALYZE agent_tokens;
+ANALYZE trades;
+ANALYZE jobs;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Phase `M4-k6-loadtest` for milestone M4. Closes #92.

## Test plan

- ~~`forge test` green~~ (n/a — loadtest-only PR, no Solidity changes)
- ~~`slither` clean (Critical/High/Medium = 0)~~ (n/a — loadtest-only PR, no Solidity changes)
- ~~`go test ./services/...` green where touched~~ (n/a — loadtest-only PR, no Go src changes)
- [ ] reviewer signs off

## Verify

log: `.claude/cron/last-verify-M4-k6-loadtest.log`

```
  a tighter `<50ms` budget for the same reason.

* Gateway rate limiting is disabled in the load-test config
  (GATEWAY_RATE_LIMIT_RPS=0). The middleware itself is not the
  SUT, and the per-IP token bucket would otherwise throttle k6
  (single source IP) below the SLO target.

* Postgres is run with default settings, not loadtest-tuned (no
  fsync=off / synchronous_commit=off). Difference is sub-millisecond
  vs the 200ms p(99) budget, and using defaults keeps the SLO
  number comparable to a realistic prod deployment.

* No Solidity / EVM changes — slither / forge / halmos N/A.

* No new Go dependencies. seed.sql is plain SQL.

* Docker daemon: not running on the dev machine; the full SLO
  assertion lives in the new workflow rather than a local make
  target. README documents how to run it locally once docker is
  up.
```