### PR TITLE
feat(M4): acp-sdk-ts: AcpAgent + AlchemyEvmProviderAdapter + register/browse/createJob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ out/
 # Build outputs
 dist/
 build/
+*.tsbuildinfo
 
 # Environment files
 .env

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,4 +20,5 @@ regexes = [
 paths = [
   '''apps/web/e2e/fixtures/.*''',
   '''services/indexer-go/internal/integration/anvil_test\.go''',
+  '''packages/acp-sdk-ts/src/__tests__/.*\.test\.ts''',
 ]

--- a/packages/acp-sdk-ts/package.json
+++ b/packages/acp-sdk-ts/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@titular/acp-sdk",
+  "version": "0.1.0-alpha.0",
+  "description": "TypeScript SDK for the Titular ACP (Agent Commerce Protocol) — register agents, browse the registry, and create on-chain jobs against a Titular gateway.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./providers/alchemy": {
+      "types": "./dist/providers/alchemy.d.ts",
+      "import": "./dist/providers/alchemy.js"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "biome check src",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --coverage"
+  },
+  "dependencies": {
+    "viem": "^2.21.50"
+  },
+  "devDependencies": {
+    "@types/node": "~22.0.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.5"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/acp-sdk-ts/src/__tests__/_helpers.ts
+++ b/packages/acp-sdk-ts/src/__tests__/_helpers.ts
@@ -1,0 +1,53 @@
+// Test helpers shared across agent / log-decoder unit tests. Builds an
+// EVM-format event log (topics + data) from an event ABI fragment + named
+// args, using the `encodeEventTopics` + `encodeAbiParameters` exports that
+// viem ships in its public surface (it does not export `encodeEventLog`).
+
+import { type AbiEvent, type AbiParameter, encodeAbiParameters, encodeEventTopics } from "viem";
+import type { ParsedLog } from "../providers/types.js";
+import type { EvmAddress } from "../types.js";
+
+/**
+ * Encode an event log to a {@link ParsedLog}, splitting `args` into the
+ * indexed (topic) and non-indexed (data) buckets the EVM emits.
+ *
+ * `event` is intentionally typed loosely so callers can pass narrow `as const`
+ * fragments without TypeScript widening complaints.
+ */
+export function encodeEventToLog(
+  event: AbiEvent,
+  args: Record<string, unknown>,
+  address: EvmAddress,
+  logIndex = 0
+): ParsedLog {
+  const indexedInputs = event.inputs.filter(
+    (i): i is AbiEvent["inputs"][number] & { name: string } =>
+      i.indexed === true && typeof i.name === "string"
+  );
+  const dataInputs = event.inputs.filter(
+    (i): i is AbiEvent["inputs"][number] & { name: string } =>
+      i.indexed !== true && typeof i.name === "string"
+  );
+
+  const indexedArgs: Record<string, unknown> = {};
+  for (const i of indexedInputs) indexedArgs[i.name] = args[i.name];
+
+  const rawTopics = encodeEventTopics({
+    abi: [event],
+    eventName: event.name,
+    args: indexedArgs,
+  });
+  // encodeEventTopics returns ( `0x${string}` | `0x${string}`[] | null )[];
+  // tighten to non-null `0x${string}` for our ParsedLog shape.
+  const topics = rawTopics.flatMap((t): `0x${string}`[] => {
+    if (t === null) return [];
+    return Array.isArray(t) ? t : [t];
+  });
+
+  const data = encodeAbiParameters(
+    dataInputs as readonly AbiParameter[],
+    dataInputs.map((i) => args[i.name])
+  );
+
+  return { address, topics, data, logIndex };
+}

--- a/packages/acp-sdk-ts/src/__tests__/agent.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/agent.test.ts
@@ -1,0 +1,504 @@
+import { describe, expect, it, vi } from "vitest";
+import { AcpAgent } from "../agent.js";
+import { AcpError } from "../errors.js";
+import type {
+  ContractWriteParams,
+  EvmProviderAdapter,
+  ParsedLog,
+  TxReceipt,
+} from "../providers/types.js";
+import { type EvmAddress, JobType, type TxHash } from "../types.js";
+import { encodeEventToLog } from "./_helpers.js";
+
+const AGENT_REGISTERED_EVENT = {
+  type: "event",
+  name: "AgentRegistered",
+  inputs: [
+    { name: "agentId", type: "uint256", indexed: true },
+    { name: "controller", type: "address", indexed: true },
+    { name: "metadataURI", type: "string", indexed: false },
+    { name: "capabilities", type: "uint256", indexed: false },
+  ],
+  anonymous: false,
+} as const;
+
+const JOB_CREATED_EVENT = {
+  type: "event",
+  name: "JobCreated",
+  inputs: [
+    { name: "jobId", type: "uint256", indexed: true },
+    { name: "clone", type: "address", indexed: true },
+    { name: "principal", type: "address", indexed: true },
+    { name: "jobType", type: "uint8", indexed: false },
+    { name: "token", type: "address", indexed: false },
+    { name: "budget", type: "uint256", indexed: false },
+  ],
+  anonymous: false,
+} as const;
+
+const REGISTRY: EvmAddress = "0x1111111111111111111111111111111111111111";
+const FACTORY: EvmAddress = "0x2222222222222222222222222222222222222222";
+const SIGNER: EvmAddress = "0x3333333333333333333333333333333333333333";
+const TOKEN: EvmAddress = "0x4444444444444444444444444444444444444444";
+const CLONE: EvmAddress = "0x5555555555555555555555555555555555555555";
+const EVALUATOR: EvmAddress = "0x6666666666666666666666666666666666666666";
+const ZERO: EvmAddress = "0x0000000000000000000000000000000000000000";
+
+const TX_HASH: TxHash = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+/**
+ * Build an `AgentRegistered` log shaped exactly the way the EVM emits it.
+ */
+function encodeAgentRegistered(
+  agentId: bigint,
+  controller: EvmAddress,
+  metadataURI: string,
+  capabilities: bigint
+): ParsedLog {
+  return encodeEventToLog(
+    AGENT_REGISTERED_EVENT,
+    { agentId, controller, metadataURI, capabilities },
+    REGISTRY
+  );
+}
+
+function encodeJobCreated(
+  jobId: bigint,
+  clone: EvmAddress,
+  principal: EvmAddress,
+  jobType: number,
+  token: EvmAddress,
+  budget: bigint
+): ParsedLog {
+  return encodeEventToLog(
+    JOB_CREATED_EVENT,
+    { jobId, clone, principal, jobType, token, budget },
+    FACTORY
+  );
+}
+
+function makeReceipt(status: "success" | "reverted", logs: ParsedLog[] = []): TxReceipt {
+  return {
+    status,
+    transactionHash: TX_HASH,
+    blockNumber: 123n,
+    logs,
+  };
+}
+
+interface MockProvider extends EvmProviderAdapter {
+  writeContractMock: ReturnType<typeof vi.fn>;
+  waitForReceiptMock: ReturnType<typeof vi.fn>;
+}
+
+function makeProvider(
+  opts: {
+    receipt?: TxReceipt;
+    address?: EvmAddress;
+  } = {}
+): MockProvider {
+  const writeContractMock = vi
+    .fn<(params: ContractWriteParams) => Promise<TxHash>>()
+    .mockResolvedValue(TX_HASH);
+  const waitForReceiptMock = vi
+    .fn<(txHash: TxHash) => Promise<TxReceipt>>()
+    .mockResolvedValue(opts.receipt ?? makeReceipt("success"));
+  const provider: MockProvider = {
+    getChainId: async () => 84532,
+    getAddress: async () => opts.address ?? SIGNER,
+    readContract: async () => undefined as never,
+    writeContract: writeContractMock,
+    waitForReceipt: waitForReceiptMock,
+    writeContractMock,
+    waitForReceiptMock,
+  };
+  return provider;
+}
+
+describe("AcpAgent.constructor", () => {
+  it("rejects zero AgentRegistry address", () => {
+    expect(
+      () =>
+        new AcpAgent({
+          provider: makeProvider(),
+          gatewayUrl: "http://localhost:8080",
+          contracts: { agentRegistry: ZERO, jobFactory: FACTORY },
+        })
+    ).toThrow(AcpError);
+  });
+
+  it("rejects zero JobFactory address", () => {
+    expect(
+      () =>
+        new AcpAgent({
+          provider: makeProvider(),
+          gatewayUrl: "http://localhost:8080",
+          contracts: { agentRegistry: REGISTRY, jobFactory: ZERO },
+        })
+    ).toThrow(AcpError);
+  });
+
+  it("uses an injected GatewayClient when provided", () => {
+    const fakeGateway = {
+      listAgents: vi.fn(),
+    } as never;
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+      gateway: fakeGateway,
+    });
+    expect(agent.gateway).toBe(fakeGateway);
+  });
+});
+
+describe("AcpAgent.register", () => {
+  it("submits the tx, decodes AgentRegistered, and returns the new id", async () => {
+    const log = encodeAgentRegistered(7n, SIGNER, "ipfs://meta", 5n);
+    const provider = makeProvider({ receipt: makeReceipt("success", [log]) });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+
+    const result = await agent.register({
+      metadataUri: "ipfs://meta",
+      capabilities: 5n,
+    });
+
+    expect(result.agentId).toBe(7n);
+    expect(result.txHash).toBe(TX_HASH);
+    expect(result.controller).toBe(SIGNER);
+    expect(result.metadataUri).toBe("ipfs://meta");
+    expect(result.capabilities).toBe(5n);
+
+    expect(provider.writeContractMock).toHaveBeenCalledOnce();
+    const call = provider.writeContractMock.mock.calls[0]?.[0];
+    expect(call?.address).toBe(REGISTRY);
+    expect(call?.functionName).toBe("register");
+    expect(call?.args).toEqual([SIGNER, "ipfs://meta", 5n]);
+  });
+
+  it("accepts decimal-string capabilities", async () => {
+    const log = encodeAgentRegistered(1n, SIGNER, "ipfs://m", 42n);
+    const provider = makeProvider({ receipt: makeReceipt("success", [log]) });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    const result = await agent.register({
+      metadataUri: "ipfs://m",
+      capabilities: "42",
+    });
+    expect(result.capabilities).toBe(42n);
+  });
+
+  it("accepts safe number capabilities", async () => {
+    const log = encodeAgentRegistered(1n, SIGNER, "ipfs://m", 99n);
+    const provider = makeProvider({ receipt: makeReceipt("success", [log]) });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    const result = await agent.register({
+      metadataUri: "ipfs://m",
+      capabilities: 99,
+    });
+    expect(result.capabilities).toBe(99n);
+  });
+
+  it("rejects empty metadataUri", async () => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(agent.register({ metadataUri: "", capabilities: 0n })).rejects.toMatchObject({
+      code: "invalid_param",
+    });
+  });
+
+  it("rejects negative number capabilities", async () => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.register({ metadataUri: "ipfs://m", capabilities: -1 })
+    ).rejects.toMatchObject({ code: "invalid_param" });
+  });
+
+  it("rejects number capabilities > 2^53", async () => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.register({
+        metadataUri: "ipfs://m",
+        // Number.MAX_SAFE_INTEGER + 1 — but JS coerces to a float, so we go far past.
+        capabilities: Number.MAX_SAFE_INTEGER * 2,
+      })
+    ).rejects.toMatchObject({ code: "invalid_param" });
+  });
+
+  it("rejects non-decimal-string capabilities", async () => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.register({ metadataUri: "ipfs://m", capabilities: "0xff" })
+    ).rejects.toMatchObject({ code: "invalid_param" });
+  });
+
+  it("throws tx_reverted when the receipt failed", async () => {
+    const provider = makeProvider({ receipt: makeReceipt("reverted") });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.register({ metadataUri: "ipfs://m", capabilities: 0n })
+    ).rejects.toMatchObject({ code: "tx_reverted" });
+  });
+
+  it("throws event_not_found when AgentRegistered is missing", async () => {
+    const provider = makeProvider({ receipt: makeReceipt("success", []) });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.register({ metadataUri: "ipfs://m", capabilities: 0n })
+    ).rejects.toMatchObject({ code: "event_not_found" });
+  });
+
+  it("uses an explicit controller when provided", async () => {
+    const explicit: EvmAddress = "0xabcdef0000000000000000000000000000000001";
+    const log = encodeAgentRegistered(2n, explicit, "ipfs://m", 0n);
+    const provider = makeProvider({ receipt: makeReceipt("success", [log]) });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    const result = await agent.register({
+      controller: explicit,
+      metadataUri: "ipfs://m",
+      capabilities: 0n,
+    });
+    expect(result.controller).toBe(explicit);
+    const call = provider.writeContractMock.mock.calls[0]?.[0];
+    expect(call?.args[0]).toBe(explicit);
+  });
+});
+
+describe("AcpAgent.browse", () => {
+  it("delegates to the gateway with the given filter", async () => {
+    const listAgents = vi.fn().mockResolvedValue({
+      data: [],
+      next_cursor: "cur",
+    });
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+      gateway: { listAgents } as never,
+    });
+    const page = await agent.browse({ kind: "acp", limit: 50 });
+    expect(page.next_cursor).toBe("cur");
+    expect(listAgents).toHaveBeenCalledWith({ kind: "acp", limit: 50 });
+  });
+
+  it("supports a default empty filter", async () => {
+    const listAgents = vi.fn().mockResolvedValue({ data: [], next_cursor: "" });
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+      gateway: { listAgents } as never,
+    });
+    await agent.browse();
+    expect(listAgents).toHaveBeenCalledWith({});
+  });
+
+  it.each([0, 201, 1.5])("rejects invalid limit %s", async (badLimit) => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+      gateway: { listAgents: vi.fn() } as never,
+    });
+    await expect(agent.browse({ limit: badLimit })).rejects.toMatchObject({
+      code: "invalid_param",
+    });
+  });
+});
+
+describe("AcpAgent.createJob", () => {
+  const futureDeadline = BigInt(Math.floor(Date.now() / 1000) + 3_600);
+
+  it("submits a Direct job and decodes JobCreated", async () => {
+    const log = encodeJobCreated(11n, CLONE, SIGNER, 0, TOKEN, 1_000_000n);
+    const provider = makeProvider({ receipt: makeReceipt("success", [log]) });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    const result = await agent.createJob({
+      token: TOKEN,
+      budget: 1_000_000n,
+      deadline: futureDeadline,
+    });
+    expect(result.jobId).toBe(11n);
+    expect(result.cloneAddress).toBe(CLONE);
+    expect(result.txHash).toBe(TX_HASH);
+
+    const call = provider.writeContractMock.mock.calls[0]?.[0];
+    expect(call?.address).toBe(FACTORY);
+    expect(call?.functionName).toBe("createJob");
+    expect(call?.args).toEqual([
+      0n,
+      TOKEN,
+      1_000_000n,
+      futureDeadline,
+      JobType.Direct,
+      ZERO,
+      ZERO,
+      [],
+    ]);
+  });
+
+  it("submits an Evaluated job with required evaluator", async () => {
+    const log = encodeJobCreated(12n, CLONE, SIGNER, 1, TOKEN, 100n);
+    const provider = makeProvider({ receipt: makeReceipt("success", [log]) });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    const result = await agent.createJob({
+      token: TOKEN,
+      budget: 100n,
+      deadline: futureDeadline,
+      jobType: JobType.Evaluated,
+      evaluator: EVALUATOR,
+      targetAgentId: 9n,
+      hooks: [SIGNER],
+    });
+    expect(result.jobId).toBe(12n);
+    const call = provider.writeContractMock.mock.calls[0]?.[0];
+    expect(call?.args[0]).toBe(9n);
+    expect(call?.args[4]).toBe(JobType.Evaluated);
+    expect(call?.args[5]).toBe(EVALUATOR);
+    expect(call?.args[7]).toEqual([SIGNER]);
+  });
+
+  it("rejects zero token", async () => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.createJob({ token: ZERO, budget: 1n, deadline: futureDeadline })
+    ).rejects.toMatchObject({ code: "invalid_param" });
+  });
+
+  it("rejects zero budget", async () => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.createJob({ token: TOKEN, budget: 0n, deadline: futureDeadline })
+    ).rejects.toMatchObject({ code: "invalid_param" });
+  });
+
+  it("rejects non-positive deadline", async () => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(agent.createJob({ token: TOKEN, budget: 1n, deadline: 0n })).rejects.toMatchObject(
+      { code: "invalid_param" }
+    );
+  });
+
+  it("rejects Evaluated jobType without evaluator", async () => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.createJob({
+        token: TOKEN,
+        budget: 1n,
+        deadline: futureDeadline,
+        jobType: JobType.Evaluated,
+      })
+    ).rejects.toMatchObject({ code: "invalid_param" });
+  });
+
+  it("rejects Evaluated jobType with zero evaluator", async () => {
+    const agent = new AcpAgent({
+      provider: makeProvider(),
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.createJob({
+        token: TOKEN,
+        budget: 1n,
+        deadline: futureDeadline,
+        jobType: JobType.Evaluated,
+        evaluator: ZERO,
+      })
+    ).rejects.toMatchObject({ code: "invalid_param" });
+  });
+
+  it("throws tx_reverted when the tx fails", async () => {
+    const provider = makeProvider({ receipt: makeReceipt("reverted") });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.createJob({
+        token: TOKEN,
+        budget: 1n,
+        deadline: futureDeadline,
+      })
+    ).rejects.toMatchObject({ code: "tx_reverted" });
+  });
+
+  it("throws event_not_found when JobCreated is missing", async () => {
+    const provider = makeProvider({ receipt: makeReceipt("success", []) });
+    const agent = new AcpAgent({
+      provider,
+      gatewayUrl: "http://localhost:8080",
+      contracts: { agentRegistry: REGISTRY, jobFactory: FACTORY },
+    });
+    await expect(
+      agent.createJob({
+        token: TOKEN,
+        budget: 1n,
+        deadline: futureDeadline,
+      })
+    ).rejects.toMatchObject({ code: "event_not_found" });
+  });
+});

--- a/packages/acp-sdk-ts/src/__tests__/alchemy-provider.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/alchemy-provider.test.ts
@@ -1,0 +1,280 @@
+import type { PublicClient, WalletClient } from "viem";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AlchemyEvmProviderAdapter,
+  NoSignerError,
+  defaultAlchemyRpcUrl,
+} from "../providers/alchemy.js";
+import type { EvmAddress, TxHash } from "../types.js";
+
+const ADDR: EvmAddress = "0xabcdef0000000000000000000000000000000001";
+const TX: TxHash = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+/**
+ * Build a minimal stub of viem's PublicClient. Only the methods used by
+ * AlchemyEvmProviderAdapter are stubbed; the cast is concentrated here so the
+ * adapter constructor accepts the stub without losing access to the mock fns
+ * in the calling test.
+ */
+type StubPublicClient = {
+  getChainId: ReturnType<typeof vi.fn>;
+  readContract: ReturnType<typeof vi.fn>;
+  waitForTransactionReceipt: ReturnType<typeof vi.fn>;
+};
+
+type StubWalletClient = {
+  account: { address: EvmAddress } | undefined;
+  getAddresses: ReturnType<typeof vi.fn>;
+  writeContract: ReturnType<typeof vi.fn>;
+  signMessage: ReturnType<typeof vi.fn>;
+};
+
+function makePublicClient(overrides: Partial<StubPublicClient> = {}): StubPublicClient {
+  return {
+    getChainId: vi.fn().mockResolvedValue(84532),
+    readContract: vi.fn().mockResolvedValue("read-result"),
+    waitForTransactionReceipt: vi.fn().mockResolvedValue({
+      status: "success",
+      transactionHash: TX,
+      blockNumber: 99n,
+      logs: [
+        {
+          address: ADDR,
+          topics: ["0xdead"],
+          data: "0xbeef",
+          logIndex: 3,
+        },
+      ],
+    }),
+    ...overrides,
+  };
+}
+
+function makeWalletClient(overrides: Partial<StubWalletClient> = {}): StubWalletClient {
+  return {
+    account: { address: ADDR },
+    getAddresses: vi.fn().mockResolvedValue([ADDR]),
+    writeContract: vi.fn().mockResolvedValue(TX),
+    signMessage: vi.fn().mockResolvedValue("0xsig"),
+    ...overrides,
+  };
+}
+
+/** Cast a stub to viem's branded client types when handing it to the adapter. */
+function asPublic(s: StubPublicClient): PublicClient {
+  return s as unknown as PublicClient;
+}
+function asWallet(s: StubWalletClient): WalletClient {
+  return s as unknown as WalletClient;
+}
+
+describe("defaultAlchemyRpcUrl", () => {
+  it("builds the base mainnet URL", () => {
+    expect(defaultAlchemyRpcUrl("base", "key")).toBe("https://base-mainnet.g.alchemy.com/v2/key");
+  });
+
+  it("builds the base sepolia URL", () => {
+    expect(defaultAlchemyRpcUrl("base-sepolia", "key")).toBe(
+      "https://base-sepolia.g.alchemy.com/v2/key"
+    );
+  });
+
+  it("rejects an empty api key", () => {
+    expect(() => defaultAlchemyRpcUrl("base", "")).toThrow(/apiKey/);
+  });
+});
+
+describe("AlchemyEvmProviderAdapter (pre-built clients mode)", () => {
+  it("getChainId / getAddress / readContract delegate to the public/wallet clients", async () => {
+    const publicClient = makePublicClient();
+    const walletClient = makeWalletClient();
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+      walletClient: asWallet(walletClient),
+    });
+
+    expect(await adapter.getChainId()).toBe(84532);
+    expect(await adapter.getAddress()).toBe(ADDR);
+    const r = await adapter.readContract({
+      address: ADDR,
+      abi: [],
+      functionName: "anything",
+    });
+    expect(r).toBe("read-result");
+  });
+
+  it("getAddress falls back to walletClient.getAddresses when account is undefined", async () => {
+    const publicClient = makePublicClient();
+    const walletClient = makeWalletClient({ account: undefined });
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+      walletClient: asWallet(walletClient),
+    });
+    expect(await adapter.getAddress()).toBe(ADDR);
+  });
+
+  it("getAddress throws NoSignerError when wallet has no addresses", async () => {
+    const publicClient = makePublicClient();
+    const walletClient = makeWalletClient({
+      account: undefined,
+      getAddresses: vi.fn().mockResolvedValue([]),
+    });
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+      walletClient: asWallet(walletClient),
+    });
+    await expect(adapter.getAddress()).rejects.toBeInstanceOf(NoSignerError);
+  });
+
+  it("writeContract delegates to walletClient.writeContract and returns the hash", async () => {
+    const publicClient = makePublicClient();
+    const walletClient = makeWalletClient();
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+      walletClient: asWallet(walletClient),
+    });
+    const hash = await adapter.writeContract({
+      address: ADDR,
+      abi: [],
+      functionName: "register",
+      args: [],
+      value: 1n,
+    });
+    expect(hash).toBe(TX);
+    expect(walletClient.writeContract).toHaveBeenCalledOnce();
+  });
+
+  it("waitForReceipt normalises the receipt shape", async () => {
+    const publicClient = makePublicClient();
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+    });
+    const receipt = await adapter.waitForReceipt(TX);
+    expect(receipt.status).toBe("success");
+    expect(receipt.transactionHash).toBe(TX);
+    expect(receipt.blockNumber).toBe(99n);
+    expect(receipt.logs[0]).toMatchObject({
+      address: ADDR,
+      topics: ["0xdead"],
+      data: "0xbeef",
+      logIndex: 3,
+    });
+  });
+
+  it("waitForReceipt translates non-success receipts into status: reverted", async () => {
+    const publicClient = makePublicClient({
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "reverted",
+        transactionHash: TX,
+        blockNumber: 1n,
+        logs: [],
+      }),
+    });
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+    });
+    const r = await adapter.waitForReceipt(TX);
+    expect(r.status).toBe("reverted");
+  });
+
+  it("waitForReceipt fills logIndex=0 when missing", async () => {
+    const publicClient = makePublicClient({
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "success",
+        transactionHash: TX,
+        blockNumber: 1n,
+        logs: [{ address: ADDR, topics: [], data: "0x" }],
+      }),
+    });
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+    });
+    const r = await adapter.waitForReceipt(TX);
+    expect(r.logs[0]?.logIndex).toBe(0);
+  });
+
+  it("signMessage forwards to walletClient.signMessage", async () => {
+    const publicClient = makePublicClient();
+    const walletClient = makeWalletClient();
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+      walletClient: asWallet(walletClient),
+    });
+    const sig = await adapter.signMessage("hello");
+    expect(sig).toBe("0xsig");
+    expect(walletClient.signMessage).toHaveBeenCalledOnce();
+  });
+});
+
+describe("AlchemyEvmProviderAdapter (read-only)", () => {
+  it("write methods throw NoSignerError without a wallet", async () => {
+    const publicClient = makePublicClient();
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+    });
+    await expect(
+      adapter.writeContract({
+        address: ADDR,
+        abi: [],
+        functionName: "x",
+        args: [],
+      })
+    ).rejects.toBeInstanceOf(NoSignerError);
+    await expect(adapter.signMessage("x")).rejects.toBeInstanceOf(NoSignerError);
+    await expect(adapter.getAddress()).rejects.toBeInstanceOf(NoSignerError);
+  });
+
+  it("NoSignerError carries a stable code for branchable handling", async () => {
+    const publicClient = makePublicClient();
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+    });
+    try {
+      await adapter.getAddress();
+    } catch (e) {
+      expect(e).toBeInstanceOf(NoSignerError);
+      expect((e as NoSignerError).code).toBe("no_signer");
+      return;
+    }
+    throw new Error("expected NoSignerError");
+  });
+
+  it("signMessage rejects when walletClient has no account", async () => {
+    const publicClient = makePublicClient();
+    const walletClient = makeWalletClient({ account: undefined });
+    const adapter = new AlchemyEvmProviderAdapter({
+      publicClient: asPublic(publicClient),
+      walletClient: asWallet(walletClient),
+    });
+    await expect(adapter.signMessage("hi")).rejects.toBeInstanceOf(NoSignerError);
+  });
+});
+
+describe("AlchemyEvmProviderAdapter (apiKey constructor)", () => {
+  it("builds clients without throwing when only apiKey + chain are passed", async () => {
+    const adapter = new AlchemyEvmProviderAdapter({
+      apiKey: "test-key",
+      chain: "base-sepolia",
+    });
+    // No signer, so write methods throw — but the adapter itself must instantiate.
+    await expect(adapter.getAddress()).rejects.toBeInstanceOf(NoSignerError);
+  });
+
+  it("builds clients with a private key", () => {
+    const adapter = new AlchemyEvmProviderAdapter({
+      apiKey: "test-key",
+      chain: "base-sepolia",
+      privateKey: "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    });
+    expect(adapter).toBeInstanceOf(AlchemyEvmProviderAdapter);
+  });
+
+  it("respects rpcUrlOverride (smoke: instance constructs without error)", () => {
+    const adapter = new AlchemyEvmProviderAdapter({
+      apiKey: "test-key",
+      chain: "base",
+      rpcUrlOverride: "https://custom.example/rpc",
+    });
+    expect(adapter).toBeInstanceOf(AlchemyEvmProviderAdapter);
+  });
+});

--- a/packages/acp-sdk-ts/src/__tests__/errors.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/errors.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { AcpError } from "../errors.js";
+
+describe("AcpError", () => {
+  it("preserves code, status, gateway body, and cause", () => {
+    const cause = new Error("boom");
+    const err = new AcpError("gateway_error", "msg", {
+      status: 503,
+      gateway: { code: "upstream_down", message: "indexer is down" },
+      cause,
+    });
+    expect(err.name).toBe("AcpError");
+    expect(err.code).toBe("gateway_error");
+    expect(err.status).toBe(503);
+    expect(err.gateway?.code).toBe("upstream_down");
+    expect(err.cause).toBe(cause);
+    expect(err.message).toBe("msg");
+  });
+
+  it("omits optional fields when not supplied", () => {
+    const err = new AcpError("invalid_param", "bad");
+    expect(err.status).toBeUndefined();
+    expect(err.gateway).toBeUndefined();
+    expect(err.cause).toBeUndefined();
+  });
+
+  it("is an instance of Error", () => {
+    const err = new AcpError("auth_failed", "denied");
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/packages/acp-sdk-ts/src/__tests__/gateway-client.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/gateway-client.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi } from "vitest";
+import { AcpError } from "../errors.js";
+import { GatewayClient } from "../gateway-client.js";
+
+function makeFetch(handler: (url: string, init: RequestInit) => Response): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    return handler(String(input), init ?? {});
+  }) as unknown as typeof fetch;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("GatewayClient.constructor", () => {
+  it("rejects an empty gatewayUrl", () => {
+    expect(() => new GatewayClient({ gatewayUrl: "" })).toThrow(AcpError);
+  });
+
+  it("strips trailing slashes from the base URL", async () => {
+    let observed = "";
+    const fetchImpl = makeFetch((url) => {
+      observed = url;
+      return jsonResponse({ data: [], next_cursor: "" });
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://localhost:8080///",
+      fetch: fetchImpl,
+    });
+    await client.listAgents();
+    expect(observed).toBe("http://localhost:8080/api/v1/agents");
+  });
+});
+
+describe("GatewayClient bearer token handling", () => {
+  it("set/get cycle round-trips", () => {
+    const client = new GatewayClient({ gatewayUrl: "http://x" });
+    expect(client.getBearerToken()).toBeUndefined();
+    client.setBearerToken("abc");
+    expect(client.getBearerToken()).toBe("abc");
+    client.setBearerToken(undefined);
+    expect(client.getBearerToken()).toBeUndefined();
+  });
+
+  it("attaches Authorization header when a token is set", async () => {
+    let auth: string | null = null;
+    const fetchImpl = makeFetch((_url, init) => {
+      auth = (init.headers as Record<string, string>).Authorization ?? null;
+      return jsonResponse({
+        total_agents: 0,
+        total_jobs: 0,
+        total_trades: 0,
+        last_block_indexed: 0,
+      });
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+      bearerToken: "tok",
+    });
+    await client.getStats();
+    expect(auth).toBe("Bearer tok");
+  });
+
+  it("does not attach Authorization when no token is set", async () => {
+    let auth: string | undefined;
+    const fetchImpl = makeFetch((_url, init) => {
+      auth = (init.headers as Record<string, string>).Authorization;
+      return jsonResponse({
+        total_agents: 0,
+        total_jobs: 0,
+        total_trades: 0,
+        last_block_indexed: 0,
+      });
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await client.getStats();
+    expect(auth).toBeUndefined();
+  });
+});
+
+describe("GatewayClient.listAgents", () => {
+  it("hits /api/v1/agents with no query params by default", async () => {
+    let observed = "";
+    const fetchImpl = makeFetch((url) => {
+      observed = url;
+      return jsonResponse({ data: [], next_cursor: "" });
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    const page = await client.listAgents();
+    expect(observed).toBe("http://x/api/v1/agents");
+    expect(page).toEqual({ data: [], next_cursor: "" });
+  });
+
+  it("encodes kind, limit, and cursor", async () => {
+    let observed = "";
+    const fetchImpl = makeFetch((url) => {
+      observed = url;
+      return jsonResponse({ data: [], next_cursor: "" });
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await client.listAgents({ kind: "acp", limit: 10, cursor: "c1" });
+    expect(observed).toBe("http://x/api/v1/agents?kind=acp&limit=10&cursor=c1");
+  });
+});
+
+describe("GatewayClient.getAgent", () => {
+  it("URL-encodes the id", async () => {
+    let observed = "";
+    const fetchImpl = makeFetch((url) => {
+      observed = url;
+      return jsonResponse({});
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await client.getAgent("123");
+    expect(observed).toBe("http://x/api/v1/agents/123");
+  });
+});
+
+describe("GatewayClient.listJobs", () => {
+  it("encodes status, limit, cursor", async () => {
+    let observed = "";
+    const fetchImpl = makeFetch((url) => {
+      observed = url;
+      return jsonResponse({ data: [], next_cursor: "" });
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await client.listJobs({ status: "active", limit: 5, cursor: "c2" });
+    expect(observed).toBe("http://x/api/v1/jobs?status=active&limit=5&cursor=c2");
+  });
+});
+
+describe("GatewayClient auth methods", () => {
+  it("siweNonce hits the right endpoint with POST", async () => {
+    let observed = "";
+    let method = "";
+    const fetchImpl = makeFetch((url, init) => {
+      observed = url;
+      method = init.method ?? "GET";
+      return jsonResponse({ nonce: "n", expires_at: 1 });
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    const r = await client.siweNonce();
+    expect(observed).toBe("http://x/auth/siwe/nonce");
+    expect(method).toBe("POST");
+    expect(r.nonce).toBe("n");
+  });
+
+  it("siweVerify posts the message + signature", async () => {
+    let body = "";
+    const fetchImpl = makeFetch((_url, init) => {
+      body = String(init.body ?? "");
+      return jsonResponse({ address: "0x", expires_at: 1, token: "t" });
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await client.siweVerify({ message: "msg", signature: "sig" });
+    expect(JSON.parse(body)).toEqual({ message: "msg", signature: "sig" });
+  });
+
+  it("siwsNonce + siwsVerify hit the SIWS routes", async () => {
+    const seen: string[] = [];
+    const fetchImpl = makeFetch((url) => {
+      seen.push(url);
+      return jsonResponse({
+        nonce: "n",
+        expires_at: 1,
+        address: "0x",
+        token: "t",
+      });
+    });
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await client.siwsNonce();
+    await client.siwsVerify({ message: "m", signature: "s" });
+    expect(seen).toEqual(["http://x/auth/siws/nonce", "http://x/auth/siws/verify"]);
+  });
+
+  it("logout returns void on no-content responses", async () => {
+    const fetchImpl = makeFetch(() => new Response(null, { status: 204 }));
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await expect(client.logout()).resolves.toBeUndefined();
+  });
+});
+
+describe("GatewayClient error handling", () => {
+  it("wraps a structured 4xx body into AcpError(gateway_error)", async () => {
+    const fetchImpl = makeFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            error: { code: "not_found", message: "no such agent" },
+          }),
+          {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+    );
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await expect(client.getAgent(1)).rejects.toMatchObject({
+      code: "gateway_error",
+      status: 404,
+      gateway: { code: "not_found", message: "no such agent" },
+    });
+  });
+
+  it("falls back to a generic message when the body is not the expected shape", async () => {
+    const fetchImpl = makeFetch(
+      () =>
+        new Response("oops", {
+          status: 500,
+          headers: { "Content-Type": "text/plain" },
+        })
+    );
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await expect(client.getStats()).rejects.toMatchObject({
+      code: "gateway_error",
+      status: 500,
+    });
+  });
+
+  it("turns network failures into AcpError(gateway_unreachable)", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new TypeError("network down")) as unknown as typeof fetch;
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await expect(client.getStats()).rejects.toMatchObject({
+      code: "gateway_unreachable",
+    });
+  });
+
+  it("turns non-JSON 200 responses into AcpError(invalid_response)", async () => {
+    const fetchImpl = makeFetch(
+      () =>
+        new Response("not json", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        })
+    );
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+    });
+    await expect(client.getStats()).rejects.toMatchObject({
+      code: "invalid_response",
+    });
+  });
+
+  it("aborts the request when timeoutMs elapses", async () => {
+    // Fetch implementation that never resolves but honours AbortSignal.
+    const fetchImpl = vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    }) as unknown as typeof fetch;
+    const client = new GatewayClient({
+      gatewayUrl: "http://x",
+      fetch: fetchImpl,
+      timeoutMs: 5,
+    });
+    await expect(client.getStats()).rejects.toMatchObject({
+      code: "gateway_unreachable",
+    });
+  });
+});

--- a/packages/acp-sdk-ts/src/__tests__/log-decoder.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/log-decoder.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { decodeFirstEvent, eventTopic } from "../log-decoder.js";
+import type { ParsedLog } from "../providers/types.js";
+import type { EvmAddress } from "../types.js";
+import { encodeEventToLog } from "./_helpers.js";
+
+const ADDR: EvmAddress = "0x1111111111111111111111111111111111111111";
+
+const FOO_EVENT = {
+  type: "event",
+  name: "Foo",
+  inputs: [{ name: "x", type: "uint256", indexed: false }],
+  anonymous: false,
+} as const;
+
+const BAR_EVENT = {
+  type: "event",
+  name: "Bar",
+  inputs: [{ name: "y", type: "address", indexed: true }],
+  anonymous: false,
+} as const;
+
+const ABI = [FOO_EVENT, BAR_EVENT, { type: "function", name: "noop", inputs: [], outputs: [] }];
+
+function fooLog(x: bigint): ParsedLog {
+  return encodeEventToLog(FOO_EVENT, { x }, ADDR);
+}
+
+describe("eventTopic", () => {
+  it("computes a stable 32-byte hash", () => {
+    const t = eventTopic(FOO_EVENT);
+    expect(t).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+});
+
+describe("decodeFirstEvent", () => {
+  it("decodes the first matching log", () => {
+    const args = decodeFirstEvent<{ x: bigint }>(ABI, "Foo", [fooLog(42n)]);
+    expect(args?.x).toBe(42n);
+  });
+
+  it("returns null when no log matches", () => {
+    const args = decodeFirstEvent(ABI, "Foo", []);
+    expect(args).toBeNull();
+  });
+
+  it("returns null when the event name is not in the ABI", () => {
+    const args = decodeFirstEvent(ABI, "DoesNotExist", [fooLog(1n)]);
+    expect(args).toBeNull();
+  });
+
+  it("skips logs with mismatched topic[0]", () => {
+    const stranger: ParsedLog = {
+      address: ADDR,
+      topics: ["0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"],
+      data: "0x",
+      logIndex: 0,
+    };
+    const args = decodeFirstEvent<{ x: bigint }>(ABI, "Foo", [stranger, fooLog(7n)]);
+    expect(args?.x).toBe(7n);
+  });
+
+  it("skips logs with empty topics", () => {
+    const empty: ParsedLog = {
+      address: ADDR,
+      topics: [],
+      data: "0x",
+      logIndex: 0,
+    };
+    const args = decodeFirstEvent<{ x: bigint }>(ABI, "Foo", [empty, fooLog(9n)]);
+    expect(args?.x).toBe(9n);
+  });
+
+  it("skips logs whose data fails to decode and continues scanning", () => {
+    const corrupt: ParsedLog = {
+      address: ADDR,
+      topics: [eventTopic(FOO_EVENT)],
+      data: "0x00",
+      logIndex: 0,
+    };
+    const args = decodeFirstEvent<{ x: bigint }>(ABI, "Foo", [corrupt, fooLog(11n)]);
+    expect(args?.x).toBe(11n);
+  });
+});

--- a/packages/acp-sdk-ts/src/abi.ts
+++ b/packages/acp-sdk-ts/src/abi.ts
@@ -1,0 +1,66 @@
+// Minimal ABI fragments needed by AcpAgent. Hand-trimmed from
+// contracts/evm/src/acp/AgentRegistry.sol and JobFactory.sol so the SDK
+// doesn't drag the full forge artifact set into its npm tarball.
+//
+// If a function signature here drifts from the contract, the M4-acp-sdk-e2e
+// integration tests (#96) will fail at registration / job creation time.
+
+export const AGENT_REGISTRY_ABI = [
+  {
+    type: "function",
+    name: "register",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "controller", type: "address" },
+      { name: "metadataURI", type: "string" },
+      { name: "capabilities", type: "uint256" },
+    ],
+    outputs: [{ name: "agentId", type: "uint256" }],
+  },
+  {
+    type: "event",
+    name: "AgentRegistered",
+    inputs: [
+      { name: "agentId", type: "uint256", indexed: true },
+      { name: "controller", type: "address", indexed: true },
+      { name: "metadataURI", type: "string", indexed: false },
+      { name: "capabilities", type: "uint256", indexed: false },
+    ],
+    anonymous: false,
+  },
+] as const;
+
+export const JOB_FACTORY_ABI = [
+  {
+    type: "function",
+    name: "createJob",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "targetAgentId", type: "uint256" },
+      { name: "token", type: "address" },
+      { name: "budget", type: "uint256" },
+      { name: "deadline", type: "uint64" },
+      { name: "jobType", type: "uint8" },
+      { name: "evaluator", type: "address" },
+      { name: "arbiter", type: "address" },
+      { name: "jobHooks", type: "address[]" },
+    ],
+    outputs: [
+      { name: "jobId", type: "uint256" },
+      { name: "clone", type: "address" },
+    ],
+  },
+  {
+    type: "event",
+    name: "JobCreated",
+    inputs: [
+      { name: "jobId", type: "uint256", indexed: true },
+      { name: "clone", type: "address", indexed: true },
+      { name: "principal", type: "address", indexed: true },
+      { name: "jobType", type: "uint8", indexed: false },
+      { name: "token", type: "address", indexed: false },
+      { name: "budget", type: "uint256", indexed: false },
+    ],
+    anonymous: false,
+  },
+] as const;

--- a/packages/acp-sdk-ts/src/agent.ts
+++ b/packages/acp-sdk-ts/src/agent.ts
@@ -1,0 +1,255 @@
+// AcpAgent — the public, top-level SDK class.
+//
+// Surface:
+//   - `register(meta)`     -> AgentRegistry.register on chain, returns the new agentId
+//   - `browse(filter)`     -> GET /api/v1/agents on the gateway, returns AgentsPage
+//   - `createJob(params)`  -> JobFactory.createJob on chain, returns jobId + clone
+//
+// AcpAgent never imports viem at the type-API surface; everything talks to
+// chain through {@link EvmProviderAdapter} and to the gateway through
+// {@link GatewayClient}. That keeps the public surface stable across provider
+// implementations (Alchemy default, Coinbase Smart Wallet, EIP-1193, mocks).
+
+import { AGENT_REGISTRY_ABI, JOB_FACTORY_ABI } from "./abi.js";
+import { AcpError } from "./errors.js";
+import { GatewayClient, type GatewayClientParams } from "./gateway-client.js";
+import { decodeFirstEvent } from "./log-decoder.js";
+import type { EvmProviderAdapter } from "./providers/types.js";
+import {
+  type AgentsPage,
+  type BrowseParams,
+  type CreateJobParams,
+  type CreateJobResult,
+  type EvmAddress,
+  JobType,
+  type RegisterParams,
+  type RegisterResult,
+  type TxHash,
+} from "./types.js";
+
+/** On-chain contract addresses required by AcpAgent. */
+export interface AcpContractAddresses {
+  agentRegistry: EvmAddress;
+  jobFactory: EvmAddress;
+}
+
+/** Constructor parameters for {@link AcpAgent}. */
+export interface AcpAgentParams {
+  /** EVM provider adapter (signer + RPC). */
+  provider: EvmProviderAdapter;
+  /** Gateway base URL (e.g. `https://api.titular.dev`). */
+  gatewayUrl: string;
+  /** AgentRegistry + JobFactory addresses for the target chain. */
+  contracts: AcpContractAddresses;
+  /** Optional pre-built gateway client; mostly used in tests. */
+  gateway?: GatewayClient;
+  /** Extra options forwarded to the auto-built gateway client. */
+  gatewayClientOptions?: Omit<GatewayClientParams, "gatewayUrl">;
+}
+
+const ZERO_ADDRESS: EvmAddress = "0x0000000000000000000000000000000000000000";
+const TWO_53 = BigInt(Number.MAX_SAFE_INTEGER);
+
+/**
+ * High-level entry point used by 3rd-party developers building agents on the
+ * Titular ACP. Combines the on-chain AgentRegistry + JobFactory with the
+ * read-only gateway REST surface behind a single ergonomic API.
+ */
+export class AcpAgent {
+  readonly provider: EvmProviderAdapter;
+  readonly gateway: GatewayClient;
+  readonly contracts: AcpContractAddresses;
+
+  constructor(params: AcpAgentParams) {
+    if (params.contracts.agentRegistry === ZERO_ADDRESS) {
+      throw new AcpError("invalid_param", "AcpAgent: contracts.agentRegistry cannot be zero");
+    }
+    if (params.contracts.jobFactory === ZERO_ADDRESS) {
+      throw new AcpError("invalid_param", "AcpAgent: contracts.jobFactory cannot be zero");
+    }
+
+    this.provider = params.provider;
+    this.contracts = params.contracts;
+    this.gateway =
+      params.gateway ??
+      new GatewayClient({
+        gatewayUrl: params.gatewayUrl,
+        ...params.gatewayClientOptions,
+      });
+  }
+
+  /**
+   * Register a new ACP agent on chain.
+   *
+   * Submits `AgentRegistry.register(controller, metadataURI, capabilities)`,
+   * waits for inclusion, and decodes the resulting `AgentRegistered` event.
+   *
+   * @throws {AcpError} `invalid_param` if `metadataUri` is empty.
+   * @throws {AcpError} `tx_reverted` if the transaction reverts.
+   * @throws {AcpError} `event_not_found` if the receipt is missing the event.
+   */
+  async register(meta: RegisterParams): Promise<RegisterResult> {
+    if (meta.metadataUri.length === 0) {
+      throw new AcpError("invalid_param", "register: `metadataUri` cannot be empty");
+    }
+    const capabilities = normalizeBigInt(meta.capabilities, "capabilities");
+    const controller = (
+      meta.controller ?? (await this.provider.getAddress())
+    ).toLowerCase() as EvmAddress;
+
+    const txHash = await this.provider.writeContract({
+      address: this.contracts.agentRegistry,
+      abi: AGENT_REGISTRY_ABI,
+      functionName: "register",
+      args: [controller, meta.metadataUri, capabilities],
+    });
+
+    const receipt = await this.provider.waitForReceipt(txHash);
+    assertSuccess(receipt.status, txHash);
+
+    const decoded = decodeFirstEvent<{
+      agentId: bigint;
+      controller: `0x${string}`;
+      metadataURI: string;
+      capabilities: bigint;
+    }>(AGENT_REGISTRY_ABI, "AgentRegistered", receipt.logs);
+    if (decoded === null) {
+      throw new AcpError(
+        "event_not_found",
+        `register: AgentRegistered event missing from receipt for tx ${txHash}`
+      );
+    }
+
+    return {
+      agentId: decoded.agentId,
+      txHash,
+      controller: decoded.controller.toLowerCase() as EvmAddress,
+      metadataUri: decoded.metadataURI,
+      capabilities: decoded.capabilities,
+    };
+  }
+
+  /**
+   * Browse the agent registry through the gateway. This is a read-only call
+   * against the gateway's Postgres-backed read model and does not require
+   * authentication or a connected signer.
+   */
+  async browse(filter: BrowseParams = {}): Promise<AgentsPage> {
+    if (filter.limit !== undefined) {
+      if (!Number.isInteger(filter.limit) || filter.limit < 1 || filter.limit > 200) {
+        throw new AcpError("invalid_param", "browse: `limit` must be an integer in [1, 200]");
+      }
+    }
+    return this.gateway.listAgents(filter);
+  }
+
+  /**
+   * Create a new ACP job on chain.
+   *
+   * Submits `JobFactory.createJob(...)` with the provided params, waits for
+   * inclusion, and decodes the resulting `JobCreated` event. The caller MUST
+   * have already approved the JobFactory for `params.budget` of `params.token`
+   * (the SDK does not silently move ERC-20 allowance for the user).
+   *
+   * @throws {AcpError} `invalid_param` for zero budget, past deadline, or
+   *   `Evaluated` jobType without an `evaluator`.
+   */
+  async createJob(params: CreateJobParams): Promise<CreateJobResult> {
+    if (params.token === ZERO_ADDRESS) {
+      throw new AcpError("invalid_param", "createJob: `token` cannot be zero");
+    }
+    if (params.budget <= 0n) {
+      throw new AcpError("invalid_param", "createJob: `budget` must be > 0");
+    }
+    if (params.deadline <= 0n) {
+      throw new AcpError(
+        "invalid_param",
+        "createJob: `deadline` must be a positive UNIX timestamp"
+      );
+    }
+    const jobType = params.jobType ?? JobType.Direct;
+    if (jobType === JobType.Evaluated) {
+      if (params.evaluator === undefined || params.evaluator === ZERO_ADDRESS) {
+        throw new AcpError(
+          "invalid_param",
+          "createJob: `evaluator` must be a non-zero address when jobType === Evaluated"
+        );
+      }
+    }
+    const evaluator = params.evaluator ?? ZERO_ADDRESS;
+    const arbiter = params.arbiter ?? ZERO_ADDRESS;
+    const hooks = params.hooks ?? [];
+    const targetAgentId = params.targetAgentId ?? 0n;
+
+    const txHash = await this.provider.writeContract({
+      address: this.contracts.jobFactory,
+      abi: JOB_FACTORY_ABI,
+      functionName: "createJob",
+      args: [
+        targetAgentId,
+        params.token,
+        params.budget,
+        params.deadline,
+        jobType,
+        evaluator,
+        arbiter,
+        hooks,
+      ],
+    });
+
+    const receipt = await this.provider.waitForReceipt(txHash);
+    assertSuccess(receipt.status, txHash);
+
+    const decoded = decodeFirstEvent<{
+      jobId: bigint;
+      clone: `0x${string}`;
+      principal: `0x${string}`;
+      jobType: number;
+      token: `0x${string}`;
+      budget: bigint;
+    }>(JOB_FACTORY_ABI, "JobCreated", receipt.logs);
+    if (decoded === null) {
+      throw new AcpError(
+        "event_not_found",
+        `createJob: JobCreated event missing from receipt for tx ${txHash}`
+      );
+    }
+
+    return {
+      jobId: decoded.jobId,
+      cloneAddress: decoded.clone.toLowerCase() as EvmAddress,
+      txHash,
+    };
+  }
+}
+
+/**
+ * Normalise a capability bitmap to a `bigint`. Accepts `bigint`, decimal
+ * strings, and `number` (rejected above 2^53 to avoid silent precision loss).
+ */
+function normalizeBigInt(value: bigint | string | number, label: string): bigint {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") {
+    if (!Number.isInteger(value) || value < 0) {
+      throw new AcpError("invalid_param", `${label}: must be a non-negative integer`);
+    }
+    const big = BigInt(value);
+    if (big > TWO_53) {
+      throw new AcpError(
+        "invalid_param",
+        `${label}: value > 2^53 must be passed as a bigint or decimal string to avoid precision loss`
+      );
+    }
+    return big;
+  }
+  if (!/^\d+$/.test(value)) {
+    throw new AcpError("invalid_param", `${label}: decimal-string form must match /^\\d+$/`);
+  }
+  return BigInt(value);
+}
+
+function assertSuccess(status: "success" | "reverted", txHash: TxHash): void {
+  if (status !== "success") {
+    throw new AcpError("tx_reverted", `transaction reverted: ${txHash}`);
+  }
+}

--- a/packages/acp-sdk-ts/src/errors.ts
+++ b/packages/acp-sdk-ts/src/errors.ts
@@ -1,0 +1,40 @@
+// Error taxonomy. The SDK throws structured errors so consumers can branch on
+// `code` rather than scraping `.message`. Codes are stable; messages are not.
+
+import type { GatewayErrorBody } from "./types.js";
+
+/** Stable, machine-readable error codes surfaced by the SDK. */
+export type AcpErrorCode =
+  | "gateway_error"
+  | "gateway_unreachable"
+  | "invalid_response"
+  | "invalid_param"
+  | "no_signer"
+  | "tx_reverted"
+  | "event_not_found"
+  | "provider_cannot_sign"
+  | "auth_failed";
+
+/**
+ * Base error class for everything thrown by the SDK. Always carries a
+ * stable `code` and, where applicable, the underlying gateway error body.
+ */
+export class AcpError extends Error {
+  override readonly name = "AcpError";
+  readonly code: AcpErrorCode;
+  readonly status?: number;
+  readonly gateway?: GatewayErrorBody;
+  override readonly cause?: unknown;
+
+  constructor(
+    code: AcpErrorCode,
+    message: string,
+    options?: { status?: number; gateway?: GatewayErrorBody; cause?: unknown }
+  ) {
+    super(message);
+    this.code = code;
+    if (options?.status !== undefined) this.status = options.status;
+    if (options?.gateway !== undefined) this.gateway = options.gateway;
+    if (options?.cause !== undefined) this.cause = options.cause;
+  }
+}

--- a/packages/acp-sdk-ts/src/gateway-client.ts
+++ b/packages/acp-sdk-ts/src/gateway-client.ts
@@ -1,0 +1,205 @@
+// Typed REST client against the Titular gateway. Hand-rolled (rather than
+// generated from the OpenAPI spec) to keep the npm tarball small and to keep
+// auth handling under our direct control.
+//
+// All non-2xx responses are turned into `AcpError` with `code: "gateway_error"`
+// and the upstream error body attached when the gateway returns one. Network
+// failures become `gateway_unreachable`; payloads that don't match the
+// expected shape become `invalid_response`.
+
+import { AcpError } from "./errors.js";
+import type {
+  Agent,
+  AgentsPage,
+  AuthNonceResponse,
+  AuthVerifyRequest,
+  AuthVerifyResponse,
+  BrowseParams,
+  GatewayErrorEnvelope,
+  JobPhase,
+  JobsPage,
+  Stats,
+} from "./types.js";
+
+/** Constructor parameters for {@link GatewayClient}. */
+export interface GatewayClientParams {
+  /** Base URL of the gateway, e.g. `https://api.titular.dev` or `http://localhost:8080`. */
+  gatewayUrl: string;
+  /** Optional bearer token (set after a successful SIWE/SIWS verify). */
+  bearerToken?: string;
+  /** Optional fetch implementation; defaults to global `fetch`. */
+  fetch?: typeof fetch;
+  /** Per-request timeout in ms; default 15000. */
+  timeoutMs?: number;
+  /** Optional `User-Agent` override. */
+  userAgent?: string;
+}
+
+/** Filter accepted by {@link GatewayClient.listJobs}. */
+export interface ListJobsParams {
+  status?: JobPhase;
+  limit?: number;
+  cursor?: string;
+}
+
+/**
+ * Thin typed wrapper around the gateway's REST surface. Every method maps
+ * 1:1 onto a path in services/gateway-go/docs/openapi.json.
+ */
+export class GatewayClient {
+  readonly #base: string;
+  readonly #fetch: typeof fetch;
+  readonly #timeoutMs: number;
+  readonly #userAgent: string;
+  #bearerToken: string | undefined;
+
+  constructor(params: GatewayClientParams) {
+    if (params.gatewayUrl.length === 0) {
+      throw new AcpError("invalid_param", "GatewayClient: `gatewayUrl` cannot be empty");
+    }
+    this.#base = params.gatewayUrl.replace(/\/+$/, "");
+    this.#fetch = params.fetch ?? globalThis.fetch.bind(globalThis);
+    this.#timeoutMs = params.timeoutMs ?? 15_000;
+    this.#userAgent = params.userAgent ?? "@titular/acp-sdk/0.1.0-alpha";
+    this.#bearerToken = params.bearerToken;
+  }
+
+  /** Update the bearer token used for `Authorization` headers. */
+  setBearerToken(token: string | undefined): void {
+    this.#bearerToken = token;
+  }
+
+  /** Currently configured bearer token, or undefined if unauthenticated. */
+  getBearerToken(): string | undefined {
+    return this.#bearerToken;
+  }
+
+  /** GET /api/v1/agents — paginated registry listing. */
+  async listAgents(params: BrowseParams = {}): Promise<AgentsPage> {
+    const qs = new URLSearchParams();
+    if (params.kind !== undefined) qs.set("kind", params.kind);
+    if (params.limit !== undefined) qs.set("limit", String(params.limit));
+    if (params.cursor !== undefined) qs.set("cursor", params.cursor);
+    return this.#request<AgentsPage>("GET", `/api/v1/agents${qsSuffix(qs)}`);
+  }
+
+  /** GET /api/v1/agents/{id}. */
+  async getAgent(id: string | number): Promise<Agent> {
+    const encoded = encodeURIComponent(String(id));
+    return this.#request<Agent>("GET", `/api/v1/agents/${encoded}`);
+  }
+
+  /** GET /api/v1/jobs — paginated job listing. */
+  async listJobs(params: ListJobsParams = {}): Promise<JobsPage> {
+    const qs = new URLSearchParams();
+    if (params.status !== undefined) qs.set("status", params.status);
+    if (params.limit !== undefined) qs.set("limit", String(params.limit));
+    if (params.cursor !== undefined) qs.set("cursor", params.cursor);
+    return this.#request<JobsPage>("GET", `/api/v1/jobs${qsSuffix(qs)}`);
+  }
+
+  /** GET /api/v1/stats — aggregate counters and last indexed block. */
+  async getStats(): Promise<Stats> {
+    return this.#request<Stats>("GET", "/api/v1/stats");
+  }
+
+  /** POST /auth/siwe/nonce — fetch a fresh SIWE nonce. */
+  async siweNonce(): Promise<AuthNonceResponse> {
+    return this.#request<AuthNonceResponse>("POST", "/auth/siwe/nonce");
+  }
+
+  /** POST /auth/siwe/verify — exchange signed SIWE message for a session. */
+  async siweVerify(req: AuthVerifyRequest): Promise<AuthVerifyResponse> {
+    return this.#request<AuthVerifyResponse>("POST", "/auth/siwe/verify", req);
+  }
+
+  /** POST /auth/siws/nonce — fetch a fresh SIWS nonce. */
+  async siwsNonce(): Promise<AuthNonceResponse> {
+    return this.#request<AuthNonceResponse>("POST", "/auth/siws/nonce");
+  }
+
+  /** POST /auth/siws/verify — exchange signed SIWS message for a session. */
+  async siwsVerify(req: AuthVerifyRequest): Promise<AuthVerifyResponse> {
+    return this.#request<AuthVerifyResponse>("POST", "/auth/siws/verify", req);
+  }
+
+  /** POST /auth/logout — revoke the current bearer session. */
+  async logout(): Promise<void> {
+    await this.#request<void>("POST", "/auth/logout", undefined, {
+      expectNoContent: true,
+    });
+  }
+
+  async #request<T>(
+    method: "GET" | "POST",
+    path: string,
+    body?: unknown,
+    opts?: { expectNoContent?: boolean }
+  ): Promise<T> {
+    const url = `${this.#base}${path}`;
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      "User-Agent": this.#userAgent,
+    };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    if (this.#bearerToken !== undefined) {
+      headers.Authorization = `Bearer ${this.#bearerToken}`;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.#timeoutMs);
+
+    let res: Response;
+    try {
+      const init: RequestInit = {
+        method,
+        headers,
+        signal: controller.signal,
+      };
+      if (body !== undefined) {
+        init.body = JSON.stringify(body);
+      }
+      res = await this.#fetch(url, init);
+    } catch (cause) {
+      throw new AcpError("gateway_unreachable", `gateway request failed: ${method} ${path}`, {
+        cause,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!res.ok) {
+      let envelope: GatewayErrorEnvelope | undefined;
+      try {
+        envelope = (await res.json()) as GatewayErrorEnvelope;
+      } catch {
+        // body was empty or non-JSON; leave envelope undefined
+      }
+      throw new AcpError(
+        "gateway_error",
+        envelope?.error?.message ?? `gateway returned ${res.status}`,
+        {
+          status: res.status,
+          ...(envelope?.error !== undefined ? { gateway: envelope.error } : {}),
+        }
+      );
+    }
+
+    if (opts?.expectNoContent === true) {
+      return undefined as T;
+    }
+
+    try {
+      return (await res.json()) as T;
+    } catch (cause) {
+      throw new AcpError("invalid_response", `gateway returned non-JSON for ${method} ${path}`, {
+        cause,
+      });
+    }
+  }
+}
+
+function qsSuffix(qs: URLSearchParams): string {
+  const s = qs.toString();
+  return s.length === 0 ? "" : `?${s}`;
+}

--- a/packages/acp-sdk-ts/src/index.ts
+++ b/packages/acp-sdk-ts/src/index.ts
@@ -1,0 +1,48 @@
+// Public entry point for `@titular/acp-sdk`. Anything not exported here is
+// considered internal and may change between alpha releases.
+
+export { AcpAgent } from "./agent.js";
+export type { AcpAgentParams, AcpContractAddresses } from "./agent.js";
+export { AcpError } from "./errors.js";
+export type { AcpErrorCode } from "./errors.js";
+export { GatewayClient } from "./gateway-client.js";
+export type { GatewayClientParams, ListJobsParams } from "./gateway-client.js";
+export {
+  AlchemyEvmProviderAdapter,
+  defaultAlchemyRpcUrl,
+  NoSignerError,
+  type AlchemyEvmProviderAdapterParams,
+  type SupportedChain,
+} from "./providers/alchemy.js";
+export type {
+  ContractReadParams,
+  ContractWriteParams,
+  EvmProviderAdapter,
+  ParsedLog,
+  TxReceipt,
+} from "./providers/types.js";
+export {
+  JobType,
+  type Agent,
+  type AgentKind,
+  type AgentsPage,
+  type AuthNonceResponse,
+  type AuthVerifyRequest,
+  type AuthVerifyResponse,
+  type BigIntString,
+  type BrowseParams,
+  type CreateJobParams,
+  type CreateJobResult,
+  type EvmAddress,
+  type GatewayErrorBody,
+  type GatewayErrorEnvelope,
+  type IsoTimestamp,
+  type Job,
+  type JobPhase,
+  type JobsPage,
+  type JobTypeValue,
+  type RegisterParams,
+  type RegisterResult,
+  type Stats,
+  type TxHash,
+} from "./types.js";

--- a/packages/acp-sdk-ts/src/log-decoder.ts
+++ b/packages/acp-sdk-ts/src/log-decoder.ts
@@ -1,0 +1,61 @@
+// Internal log-decoder helper. AcpAgent uses this to pull the right event
+// out of a tx receipt without making the public EvmProviderAdapter interface
+// depend on viem.
+//
+// The adapter contract only requires that `waitForReceipt` returns logs in
+// emission order; this module handles the (relatively expensive) ABI decode
+// here so adapters built on different libraries (ethers, web3, raw EIP-1193)
+// don't have to reimplement decoding.
+
+import { type AbiEvent, decodeEventLog, keccak256, toBytes } from "viem";
+import type { ParsedLog } from "./providers/types.js";
+
+/** Compute the topic hash for an event ABI fragment. */
+export function eventTopic(event: AbiEvent): `0x${string}` {
+  const types = event.inputs.map((i) => i.type).join(",");
+  return keccak256(toBytes(`${event.name}(${types})`));
+}
+
+/**
+ * Find the first log matching `eventName` in `abi` and decode it.
+ * Returns `null` if no matching log was emitted.
+ *
+ * `abi` is intentionally typed as `readonly object[]` so the caller (AcpAgent)
+ * can pass the same hand-rolled ABI it ships in {@link ./abi.ts} without
+ * fighting viem's deeply-typed const generics.
+ */
+export function decodeFirstEvent<TArgs extends Record<string, unknown> = Record<string, unknown>>(
+  abi: readonly object[],
+  eventName: string,
+  logs: readonly ParsedLog[]
+): TArgs | null {
+  const eventFrag = abi.find(
+    (f): f is AbiEvent =>
+      typeof f === "object" &&
+      f !== null &&
+      (f as { type?: unknown }).type === "event" &&
+      (f as { name?: unknown }).name === eventName
+  );
+  if (!eventFrag) return null;
+
+  const wantTopic = eventTopic(eventFrag);
+  for (const log of logs) {
+    if (log.topics.length === 0 || log.topics[0] !== wantTopic) continue;
+    try {
+      const decoded = decodeEventLog({
+        // viem accepts the same fragment shape we use; the cast is a
+        // narrowing convenience, not a type override.
+        abi: [eventFrag] as const,
+        data: log.data,
+        topics: log.topics as [`0x${string}`, ...`0x${string}`[]],
+      });
+      // viem returns `{ args, eventName }`; we only care about args.
+      return decoded.args as unknown as TArgs;
+    } catch {
+      // Topic matched but payload didn't decode — keep scanning. This
+      // happens when the same event signature is emitted by an unrelated
+      // contract in the same tx.
+    }
+  }
+  return null;
+}

--- a/packages/acp-sdk-ts/src/providers/alchemy.ts
+++ b/packages/acp-sdk-ts/src/providers/alchemy.ts
@@ -1,0 +1,224 @@
+// Default EVM provider adapter — wraps a viem WalletClient + PublicClient
+// against an Alchemy-hosted Base RPC. Consumers MAY pass their own
+// pre-built clients (e.g. for testing, or to use account-abstraction
+// bundlers like @account-kit/aa); see the second constructor overload.
+//
+// The adapter intentionally keeps the dependency surface to viem only.
+// The "Alchemy" naming is about the default RPC URL and key handling, not
+// a hard dependency on `alchemy-sdk`.
+
+import {
+  http,
+  type Account,
+  type Address,
+  type Chain,
+  type Hex,
+  type PublicClient,
+  type Transport,
+  type WalletClient,
+  createPublicClient,
+  createWalletClient,
+  custom,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base, baseSepolia } from "viem/chains";
+import type { EvmAddress, TxHash } from "../types.js";
+import type {
+  ContractReadParams,
+  ContractWriteParams,
+  EvmProviderAdapter,
+  ParsedLog,
+  TxReceipt,
+} from "./types.js";
+
+/** Supported chain shorthand. */
+export type SupportedChain = "base" | "base-sepolia";
+
+const CHAIN_BY_NAME: Record<SupportedChain, Chain> = {
+  base,
+  "base-sepolia": baseSepolia,
+};
+
+/**
+ * Constructor params for {@link AlchemyEvmProviderAdapter}.
+ *
+ * Mutually exclusive auth modes:
+ *   - `apiKey` + `chain`: SDK builds its own viem clients hitting Alchemy.
+ *     A signer (`privateKey` or `account`) is required for write methods.
+ *   - `transport`: caller provides a viem transport (e.g. EIP-1193 from a
+ *     browser wallet). Useful for dapps where the user signs in MetaMask.
+ *   - `publicClient` + `walletClient`: caller provides pre-built viem
+ *     clients. Used in tests and advanced setups (account-abstraction
+ *     bundlers, custom transports, etc).
+ */
+export type AlchemyEvmProviderAdapterParams =
+  | {
+      apiKey: string;
+      chain: SupportedChain;
+      privateKey?: Hex;
+      account?: Account;
+      rpcUrlOverride?: string;
+    }
+  | {
+      transport: Transport;
+      chain: SupportedChain;
+      account?: Account;
+    }
+  | {
+      publicClient: PublicClient;
+      walletClient?: WalletClient;
+    };
+
+/** Thrown when a write method is called on an adapter without a signer. */
+export class NoSignerError extends Error {
+  override readonly name = "NoSignerError";
+  readonly code = "no_signer" as const;
+  constructor() {
+    super(
+      "AlchemyEvmProviderAdapter is read-only: provide a `privateKey`, `account`, " +
+        "or pre-built `walletClient` to send transactions."
+    );
+  }
+}
+
+/**
+ * Default {@link EvmProviderAdapter} backed by viem.
+ *
+ * The adapter normalises three setup modes (Alchemy-hosted RPC + private
+ * key, browser-wallet EIP-1193, fully custom viem clients) into a single
+ * surface and delegates to viem for ABI encoding, gas estimation, and
+ * receipt waiting. AcpAgent never imports viem directly; everything goes
+ * through this interface so a consumer can swap in their own adapter.
+ */
+export class AlchemyEvmProviderAdapter implements EvmProviderAdapter {
+  readonly #publicClient: PublicClient;
+  readonly #walletClient?: WalletClient;
+
+  constructor(params: AlchemyEvmProviderAdapterParams) {
+    if ("publicClient" in params) {
+      this.#publicClient = params.publicClient;
+      if (params.walletClient !== undefined) {
+        this.#walletClient = params.walletClient;
+      }
+      return;
+    }
+
+    if ("transport" in params) {
+      const chain = CHAIN_BY_NAME[params.chain];
+      this.#publicClient = createPublicClient({
+        chain,
+        transport: params.transport,
+      });
+      const walletParams: Parameters<typeof createWalletClient>[0] = {
+        chain,
+        transport: params.transport,
+      };
+      if (params.account !== undefined) {
+        walletParams.account = params.account;
+      }
+      this.#walletClient = createWalletClient(walletParams);
+      return;
+    }
+
+    // apiKey path
+    const chain = CHAIN_BY_NAME[params.chain];
+    const url = params.rpcUrlOverride ?? defaultAlchemyRpcUrl(params.chain, params.apiKey);
+    const transport = http(url);
+    this.#publicClient = createPublicClient({ chain, transport });
+
+    const account =
+      params.account ?? (params.privateKey ? privateKeyToAccount(params.privateKey) : undefined);
+    if (account !== undefined) {
+      this.#walletClient = createWalletClient({ account, chain, transport });
+    }
+  }
+
+  async getChainId(): Promise<number> {
+    return this.#publicClient.getChainId();
+  }
+
+  async getAddress(): Promise<EvmAddress> {
+    const wallet = this.#requireWallet();
+    const account = wallet.account;
+    if (account === undefined) {
+      const [addr] = await wallet.getAddresses();
+      if (addr === undefined) throw new NoSignerError();
+      return addr.toLowerCase() as EvmAddress;
+    }
+    return account.address.toLowerCase() as EvmAddress;
+  }
+
+  async readContract<T = unknown>(params: ContractReadParams): Promise<T> {
+    const result = await this.#publicClient.readContract({
+      address: params.address as Address,
+      abi: params.abi as readonly object[],
+      functionName: params.functionName,
+      args: params.args ?? [],
+      // viem's `readContract` returns `unknown` for arbitrary ABIs; the SDK
+      // is responsible for matching the call to the expected return shape.
+      // biome-ignore lint/suspicious/noExplicitAny: heterogeneous ABI surface
+    } as any);
+    return result as T;
+  }
+
+  async writeContract(params: ContractWriteParams): Promise<TxHash> {
+    const wallet = this.#requireWallet();
+    const txParams = {
+      address: params.address as Address,
+      abi: params.abi as readonly object[],
+      functionName: params.functionName,
+      args: params.args,
+      ...(params.value !== undefined ? { value: params.value } : {}),
+      // biome-ignore lint/suspicious/noExplicitAny: heterogeneous ABI surface
+    } as any;
+    // walletClient.writeContract requires `account` + `chain`; viem will pull
+    // them from the configured wallet client when omitted.
+    const hash = await wallet.writeContract(txParams);
+    return hash as TxHash;
+  }
+
+  async waitForReceipt(txHash: TxHash): Promise<TxReceipt> {
+    const r = await this.#publicClient.waitForTransactionReceipt({
+      hash: txHash,
+    });
+    const logs: ParsedLog[] = r.logs.map((log) => ({
+      address: log.address.toLowerCase() as EvmAddress,
+      topics: log.topics,
+      data: log.data,
+      logIndex: log.logIndex ?? 0,
+    }));
+    return {
+      status: r.status === "success" ? "success" : "reverted",
+      transactionHash: r.transactionHash as TxHash,
+      blockNumber: r.blockNumber,
+      logs,
+    };
+  }
+
+  async signMessage(message: string): Promise<Hex> {
+    const wallet = this.#requireWallet();
+    const account = wallet.account;
+    if (account === undefined) throw new NoSignerError();
+    return wallet.signMessage({ account, message });
+  }
+
+  #requireWallet(): WalletClient {
+    if (this.#walletClient === undefined) throw new NoSignerError();
+    return this.#walletClient;
+  }
+}
+
+/**
+ * Build the default Alchemy RPC URL for the given chain. Exported so tests
+ * can assert URL composition without pulling in the network layer.
+ */
+export function defaultAlchemyRpcUrl(chain: SupportedChain, apiKey: string): string {
+  if (apiKey.length === 0) {
+    throw new Error("AlchemyEvmProviderAdapter: `apiKey` cannot be empty");
+  }
+  const subdomain = chain === "base" ? "base-mainnet" : "base-sepolia";
+  return `https://${subdomain}.g.alchemy.com/v2/${apiKey}`;
+}
+
+/** Re-export viem's `custom` transport for adapters that need EIP-1193. */
+export { custom };

--- a/packages/acp-sdk-ts/src/providers/types.ts
+++ b/packages/acp-sdk-ts/src/providers/types.ts
@@ -1,0 +1,90 @@
+// Provider adapter interface used by AcpAgent. The SDK ships an
+// AlchemyEvmProviderAdapter (see ./alchemy.ts) but consumers can swap in their
+// own adapter — Coinbase Smart Wallet, MetaMask, viem WalletClient, etc — by
+// implementing this interface.
+
+import type { EvmAddress, TxHash } from "../types.js";
+
+/**
+ * Minimal contract-call shape. Mirrors viem's `WriteContractParameters` but
+ * keeps the surface small so the adapter doesn't have to depend on viem
+ * directly. `args` is unknown[] rather than `readonly unknown[]` so consumers
+ * can pass mutable arrays without a cast.
+ */
+export interface ContractWriteParams {
+  /** Target contract address. */
+  address: EvmAddress;
+  /** Human-readable ABI fragment describing only the function being called. */
+  abi: readonly object[];
+  /** Function name to invoke. */
+  functionName: string;
+  /** Positional arguments matching `abi[functionName]`. */
+  args: readonly unknown[];
+  /** Optional ETH value to attach (wei). */
+  value?: bigint;
+}
+
+/**
+ * Minimal read-only contract-call shape. Same conventions as
+ * {@link ContractWriteParams} but for `eth_call`.
+ */
+export interface ContractReadParams {
+  address: EvmAddress;
+  abi: readonly object[];
+  functionName: string;
+  args?: readonly unknown[];
+}
+
+/** Decoded log returned by waitForReceipt. */
+export interface ParsedLog {
+  address: EvmAddress;
+  topics: readonly `0x${string}`[];
+  data: `0x${string}`;
+  logIndex: number;
+}
+
+/** Minimal receipt returned by waitForReceipt. */
+export interface TxReceipt {
+  status: "success" | "reverted";
+  transactionHash: TxHash;
+  blockNumber: bigint;
+  logs: ParsedLog[];
+}
+
+/**
+ * EVM provider adapter consumed by AcpAgent.
+ *
+ * Implementations MUST:
+ *   - return the connected account address from {@link getAddress}
+ *   - submit transactions via {@link writeContract} and return the tx hash
+ *   - block until inclusion via {@link waitForReceipt}, returning logs in
+ *     emission order so AcpAgent can decode `AgentRegistered` / `JobCreated`
+ *
+ * Implementations MUST NOT:
+ *   - cache nonces across calls (the underlying client should handle that)
+ *   - swallow or rewrap revert reasons — surface them so the SDK can map them
+ *     to its `AcpError` taxonomy
+ */
+export interface EvmProviderAdapter {
+  /** Numeric chain id the adapter is connected to. */
+  getChainId(): Promise<number>;
+
+  /** Address of the connected signer / smart account. */
+  getAddress(): Promise<EvmAddress>;
+
+  /** Read-only `eth_call`. */
+  readContract<T = unknown>(params: ContractReadParams): Promise<T>;
+
+  /** Submit a state-changing transaction; return the tx hash. */
+  writeContract(params: ContractWriteParams): Promise<TxHash>;
+
+  /** Block until `txHash` is included; return the parsed receipt. */
+  waitForReceipt(txHash: TxHash): Promise<TxReceipt>;
+
+  /**
+   * Sign an arbitrary message string for SIWE/SIWS auth against the gateway.
+   * Optional — adapters that cannot sign (e.g. read-only RPCs) may omit this,
+   * but `AcpAgent.authenticate` will throw `provider_cannot_sign` if called.
+   */
+  signMessage?(message: string): Promise<`0x${string}`>;
+}

--- a/packages/acp-sdk-ts/src/types.ts
+++ b/packages/acp-sdk-ts/src/types.ts
@@ -1,0 +1,195 @@
+// Wire types mirroring services/gateway-go/docs/openapi.json (v0.1.0-alpha).
+//
+// Values that originate as uint256 on chain are encoded as decimal strings on
+// the wire — never coerce them to `number`. Addresses are lowercase 0x-hex.
+//
+// This file is hand-rolled rather than codegen'd to keep the SDK dependency
+// graph minimal; the openapi-check CI gate (`gateway-openapi-check` workflow)
+// catches drift in the upstream spec, and the `roundtrip` integration tests
+// in M4-acp-sdk-e2e (#96) catch drift on the consumer side.
+
+/** Hex-encoded EVM address, lowercase, `0x`-prefixed (20 bytes). */
+export type EvmAddress = `0x${string}`;
+
+/** Hex-encoded 32-byte transaction hash, `0x`-prefixed. */
+export type TxHash = `0x${string}`;
+
+/** Decimal-string encoding of a uint256 (no `0x` prefix). */
+export type BigIntString = string;
+
+/** RFC 3339 timestamp string. */
+export type IsoTimestamp = string;
+
+/** Discriminant matching the gateway's `store.AgentKind` enum. */
+export type AgentKind = "launchpad" | "acp";
+
+/** Discriminant matching the gateway's `store.JobPhase` enum. */
+export type JobPhase =
+  | "created"
+  | "funded"
+  | "active"
+  | "completed"
+  | "cancelled"
+  | "disputed"
+  | "released"
+  | "resolved";
+
+/** Mirror of `store.Agent` — fields tagged `optional` in the spec are optional here. */
+export interface Agent {
+  id: number;
+  agent_id: BigIntString;
+  kind: AgentKind;
+  controller?: EvmAddress;
+  creator?: EvmAddress;
+  capabilities: BigIntString;
+  metadata_uri?: string;
+  block_number: number;
+  log_index: number;
+  tx_hash: TxHash;
+  created_at: IsoTimestamp;
+  updated_at: IsoTimestamp;
+}
+
+/** Mirror of `store.Job`. */
+export interface Job {
+  id: number;
+  on_chain_id?: string;
+  agent_pk: number;
+  agent_id: BigIntString;
+  phase: JobPhase;
+  job_type: number;
+  principal: EvmAddress;
+  clone_address?: EvmAddress;
+  token: EvmAddress;
+  budget: BigIntString;
+  deadline: IsoTimestamp;
+  result_uri?: string;
+  block_number: number;
+  log_index: number;
+  tx_hash: TxHash;
+  created_at: IsoTimestamp;
+  updated_at: IsoTimestamp;
+}
+
+/** Mirror of `openapi.AgentsPage`. */
+export interface AgentsPage {
+  data: Agent[];
+  next_cursor: string;
+}
+
+/** Mirror of `openapi.JobsPage`. */
+export interface JobsPage {
+  data: Job[];
+  next_cursor: string;
+}
+
+/** Mirror of `store.Stats`. */
+export interface Stats {
+  total_agents: number;
+  total_jobs: number;
+  total_trades: number;
+  last_block_indexed: number;
+}
+
+/** Auth: shape returned by `/auth/siwe/nonce` and `/auth/siws/nonce`. */
+export interface AuthNonceResponse {
+  nonce: string;
+  expires_at: number;
+}
+
+/** Auth: payload for `/auth/siwe/verify` and `/auth/siws/verify`. */
+export interface AuthVerifyRequest {
+  message: string;
+  signature: string;
+}
+
+/** Auth: response from `/auth/(siwe|siws)/verify`. */
+export interface AuthVerifyResponse {
+  address: string;
+  expires_at: number;
+  /** Bearer token to use as `Authorization: Bearer <token>` on subsequent requests. */
+  token?: string;
+}
+
+/** Shape of the gateway error envelope. */
+export interface GatewayErrorBody {
+  code: string;
+  message: string;
+}
+
+export interface GatewayErrorEnvelope {
+  error: GatewayErrorBody;
+}
+
+/**
+ * Direct vs evaluated job, mirroring `IJob.JobType` on the contracts side.
+ * Uses an explicit numeric encoding so the SDK serialises the same uint8 the
+ * `JobFactory.createJob` ABI expects.
+ */
+export const JobType = {
+  Direct: 0,
+  Evaluated: 1,
+} as const;
+export type JobTypeValue = (typeof JobType)[keyof typeof JobType];
+
+/** Parameters accepted by `AcpAgent.register`. */
+export interface RegisterParams {
+  /**
+   * Address that will control the agent on chain. If omitted, the SDK uses the
+   * connected provider's account address.
+   */
+  controller?: EvmAddress;
+  /** Non-empty URI pointing to off-chain agent metadata (typically `ipfs://...`). */
+  metadataUri: string;
+  /**
+   * Packed capability bitmap (consumer-defined). Accepts both `bigint` (preferred,
+   * lossless) and decimal strings; passing `number` is allowed for small bitmaps
+   * but disallowed above 2^53 to prevent silent precision loss.
+   */
+  capabilities: bigint | BigIntString | number;
+}
+
+/** Result returned by `AcpAgent.register`. */
+export interface RegisterResult {
+  agentId: bigint;
+  txHash: TxHash;
+  controller: EvmAddress;
+  metadataUri: string;
+  capabilities: bigint;
+}
+
+/** Filter accepted by `AcpAgent.browse`. */
+export interface BrowseParams {
+  kind?: AgentKind;
+  /** Page size; the gateway clamps to `[1, 200]` and defaults to 50. */
+  limit?: number;
+  /** Opaque pagination cursor returned in the previous page's `next_cursor`. */
+  cursor?: string;
+}
+
+/** Parameters accepted by `AcpAgent.createJob`. */
+export interface CreateJobParams {
+  /** Agent registry id to target; pass `0n` to leave it open to any active agent. */
+  targetAgentId?: bigint;
+  /** ERC-20 payment token. */
+  token: EvmAddress;
+  /** Amount to lock into Escrow (in token base units). */
+  budget: bigint;
+  /** UNIX seconds after which the job may be expired. Must be in the future. */
+  deadline: bigint;
+  /** Direct or Evaluated. */
+  jobType?: JobTypeValue;
+  /** Required iff `jobType === JobType.Evaluated`; ignored otherwise. */
+  evaluator?: EvmAddress;
+  /** Optional arbiter override; falls back to the factory's default arbiter. */
+  arbiter?: EvmAddress;
+  /** Optional list of pre-approved hook addresses. */
+  hooks?: EvmAddress[];
+}
+
+/** Result returned by `AcpAgent.createJob`. */
+export interface CreateJobResult {
+  jobId: bigint;
+  cloneAddress: EvmAddress;
+  txHash: TxHash;
+}

--- a/packages/acp-sdk-ts/tsconfig.build.json
+++ b/packages/acp-sdk-ts/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "incremental": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/__tests__/**/*"]
+}

--- a/packages/acp-sdk-ts/tsconfig.json
+++ b/packages/acp-sdk-ts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/acp-sdk-ts/vitest.config.ts
+++ b/packages/acp-sdk-ts/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: false,
+    include: ["src/__tests__/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/__tests__/**", "src/index.ts", "src/types.ts"],
+      thresholds: {
+        lines: 80,
+        statements: 80,
+        functions: 80,
+        branches: 75,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,18 +99,40 @@ importers:
         version: 6.0.1(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
       jsdom:
         specifier: ^29.0.2
-        version: 29.0.2
+        version: 29.0.2(@noble/hashes@1.8.0)
       typescript:
         specifier: ~5.6.0
         version: 5.6.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.0.3)(jsdom@29.0.2)(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
+        version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
+
+  packages/acp-sdk-ts:
+    dependencies:
+      viem:
+        specifier: ^2.21.50
+        version: 2.48.4(typescript@5.6.3)(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ~22.0.0
+        version: 22.0.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      typescript:
+        specifier: ~5.6.0
+        version: 5.6.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
 
 packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -131,13 +153,30 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@1.9.4':
     resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
@@ -461,8 +500,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -520,6 +566,18 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
@@ -624,6 +682,15 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -707,6 +774,15 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -739,6 +815,17 @@ packages:
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -783,6 +870,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -958,6 +1048,9 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -1024,9 +1117,16 @@ packages:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -1089,9 +1189,29 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1255,6 +1375,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -1327,6 +1454,14 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  ox@0.14.20:
+    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
@@ -1548,6 +1683,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -1647,6 +1786,14 @@ packages:
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
+
+  viem@2.48.4:
+    resolution: {integrity: sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -1766,6 +1913,18 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -1801,6 +1960,8 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@adraffy/ens-normalize@1.11.1': {}
+
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
@@ -1827,9 +1988,22 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@1.9.4':
     optionalDependencies:
@@ -2020,7 +2194,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@18.3.1))':
     dependencies:
@@ -2124,7 +2300,14 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2158,6 +2341,14 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
+
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
 
   '@oxc-project/types@0.127.0': {}
 
@@ -2217,6 +2408,19 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -2300,6 +2504,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1)
 
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2346,6 +2564,11 @@ snapshots:
       jsonparse: 1.3.1
       through: 2.3.8
 
+  abitype@1.2.3(typescript@5.6.3)(zod@4.3.6):
+    optionalDependencies:
+      typescript: 5.6.3
+      zod: 4.3.6
+
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2380,6 +2603,12 @@ snapshots:
   array-ify@1.0.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   bidi-js@1.0.3:
     dependencies:
@@ -2481,10 +2710,10 @@ snapshots:
 
   dargs@8.1.0: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -2527,6 +2756,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  eventemitter3@5.0.1: {}
 
   eventemitter3@5.0.4: {}
 
@@ -2584,11 +2815,15 @@ snapshots:
     dependencies:
       ini: 4.1.1
 
-  html-encoding-sniffer@6.0.0:
+  has-flag@4.0.0: {}
+
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   human-signals@5.0.0: {}
 
@@ -2629,7 +2864,26 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isows@1.0.7(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.6.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2637,17 +2891,17 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.0.2:
+  jsdom@29.0.2(@noble/hashes@1.8.0):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.5
       parse5: 8.0.1
@@ -2658,7 +2912,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -2788,6 +3042,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   mdn-data@2.27.1: {}
 
   meow@12.1.1: {}
@@ -2848,6 +3112,21 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  ox@0.14.20(typescript@5.6.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.6.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - zod
 
   p-limit@4.0.0:
     dependencies:
@@ -3076,6 +3355,10 @@ snapshots:
       client-only: 0.0.1
       react: 18.3.1
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   symbol-tree@3.2.4: {}
 
   text-extensions@2.4.0: {}
@@ -3150,6 +3433,23 @@ snapshots:
 
   unicorn-magic@0.1.0: {}
 
+  viem@2.48.4(typescript@5.6.3)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.6.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.14.20(typescript@5.6.3)(zod@4.3.6)
+      ws: 8.18.3
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1):
     dependencies:
       lightningcss: 1.32.0
@@ -3163,7 +3463,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.6.1
 
-  vitest@4.1.5(@types/node@22.0.3)(jsdom@29.0.2)(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1)):
+  vitest@4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
@@ -3187,7 +3487,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.0.3
-      jsdom: 29.0.2
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+      jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
 
@@ -3199,9 +3500,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -3227,6 +3528,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.18.3: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Phase `M4-acp-sdk-core` for milestone M4. Closes #95.

## Test plan

- [ ] `forge test` green
- [ ] `slither` clean (Critical/High/Medium = 0)
- [ ] `go test ./services/...` green where touched
- [ ] reviewer signs off

## Verify

log: `.claude/cron/last-verify-M4-acp-sdk-core.log`

```

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |    96.5 |    95.27 |     100 |   96.13 |                   
 src               |     100 |    97.32 |     100 |     100 |                   
  ...way-client.ts |     100 |     92.1 |     100 |     100 | 95-97             
 src/providers     |   87.27 |    88.88 |     100 |   86.27 |                   
  alchemy.ts       |   87.27 |    88.88 |     100 |   86.27 | 107-120           
-------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 96.5% ( 193/200 )
Branches     : 95.27% ( 141/148 )
Functions    : 100% ( 37/37 )
Lines        : 96.13% ( 174/181 )
================================================================================

result: PASS
```