### PR TITLE
feat(M4): acp-sdk-ts: LLM helpers (availableTools, toMessages, executeTool)

### DIFF
--- a/packages/acp-sdk-ts/package.json
+++ b/packages/acp-sdk-ts/package.json
@@ -15,6 +15,10 @@
     "./providers/alchemy": {
       "types": "./dist/providers/alchemy.d.ts",
       "import": "./dist/providers/alchemy.js"
+    },
+    "./llm": {
+      "types": "./dist/llm/index.d.ts",
+      "import": "./dist/llm/index.js"
     }
   },
   "files": ["dist", "README.md"],

--- a/packages/acp-sdk-ts/src/__tests__/__snapshots__/llm-tools.test.ts.snap
+++ b/packages/acp-sdk-ts/src/__tests__/__snapshots__/llm-tools.test.ts.snap
@@ -1,0 +1,133 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`availableTools > schema is stable 1`] = `
+[
+  {
+    "function": {
+      "description": "Register a new ACP agent on chain via AgentRegistry.register. Returns the new agentId, tx hash, and the controller address that owns the agent. The connected signer pays gas.",
+      "name": "acp_register",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "capabilities": {
+            "description": "Packed capability bitmap as a decimal-encoded uint256 (e.g. \`"5"\` for caps 1+4).",
+            "pattern": "^(0|[1-9][0-9]*)$",
+            "type": "string",
+          },
+          "controller": {
+            "description": "Optional. Address that will control the agent on chain. Defaults to the connected signer's address.",
+            "pattern": "^0x[0-9a-fA-F]{40}$",
+            "type": "string",
+          },
+          "metadataUri": {
+            "description": "Non-empty URI pointing to off-chain agent metadata. Typically \`ipfs://<cid>\` or \`https://...\`.",
+            "type": "string",
+          },
+        },
+        "required": [
+          "metadataUri",
+          "capabilities",
+        ],
+        "type": "object",
+      },
+    },
+    "type": "function",
+  },
+  {
+    "function": {
+      "description": "Browse the on-chain agent registry through the gateway. Read-only; does not require a signer. Returns a paginated AgentsPage with \`data\` and \`next_cursor\`.",
+      "name": "acp_browse",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "cursor": {
+            "description": "Opaque pagination cursor returned in the previous page's \`next_cursor\`. Omit for the first page.",
+            "type": "string",
+          },
+          "kind": {
+            "description": "Filter by agent kind. Omit to return both.",
+            "enum": [
+              "launchpad",
+              "acp",
+            ],
+            "type": "string",
+          },
+          "limit": {
+            "description": "Page size in [1, 200]. Defaults to 50 server-side.",
+            "maximum": 200,
+            "minimum": 1,
+            "type": "integer",
+          },
+        },
+        "type": "object",
+      },
+    },
+    "type": "function",
+  },
+  {
+    "function": {
+      "description": "Create a new ACP job on chain via JobFactory.createJob. The connected signer must have already approved the JobFactory for \`budget\` of \`token\` (the SDK does not move ERC-20 allowance on its own). Returns the new jobId, the deployed clone address, and the tx hash.",
+      "name": "acp_create_job",
+      "parameters": {
+        "additionalProperties": false,
+        "properties": {
+          "arbiter": {
+            "description": "Optional arbiter override; falls back to the factory's default arbiter.",
+            "pattern": "^0x[0-9a-fA-F]{40}$",
+            "type": "string",
+          },
+          "budget": {
+            "description": "Amount to lock into Escrow (in token base units). Must be > 0.",
+            "pattern": "^(0|[1-9][0-9]*)$",
+            "type": "string",
+          },
+          "deadline": {
+            "description": "UNIX seconds after which the job may be expired. Must be in the future.",
+            "pattern": "^(0|[1-9][0-9]*)$",
+            "type": "string",
+          },
+          "evaluator": {
+            "description": "Required iff \`jobType\` is \`evaluated\`; ignored otherwise. Must be a non-zero address.",
+            "pattern": "^0x[0-9a-fA-F]{40}$",
+            "type": "string",
+          },
+          "hooks": {
+            "description": "Optional list of pre-approved hook addresses.",
+            "items": {
+              "description": "EVM address as a \`0x\`-prefixed 20-byte hex string.",
+              "pattern": "^0x[0-9a-fA-F]{40}$",
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "jobType": {
+            "description": "Job type. \`evaluated\` requires \`evaluator\`. Defaults to \`direct\` when omitted.",
+            "enum": [
+              "direct",
+              "evaluated",
+            ],
+            "type": "string",
+          },
+          "targetAgentId": {
+            "description": "Optional agent registry id to target. Pass \`"0"\` (or omit) to leave the job open to any active agent.",
+            "pattern": "^(0|[1-9][0-9]*)$",
+            "type": "string",
+          },
+          "token": {
+            "description": "ERC-20 payment token address. Must not be the zero address.",
+            "pattern": "^0x[0-9a-fA-F]{40}$",
+            "type": "string",
+          },
+        },
+        "required": [
+          "token",
+          "budget",
+          "deadline",
+        ],
+        "type": "object",
+      },
+    },
+    "type": "function",
+  },
+]
+`;

--- a/packages/acp-sdk-ts/src/__tests__/llm-executor.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/llm-executor.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AcpAgent } from "../agent.js";
 import { AcpError } from "../errors.js";
-import { TOOL_NAMES, executeTool } from "../llm/executor.js";
+import { executeTool } from "../llm/executor.js";
+import { TOOL_NAMES } from "../llm/tools.js";
 import type { ToolCall } from "../llm/types.js";
 import {
   type CreateJobResult,

--- a/packages/acp-sdk-ts/src/__tests__/llm-executor.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/llm-executor.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AcpAgent } from "../agent.js";
+import { AcpError } from "../errors.js";
+import { TOOL_NAMES, executeTool } from "../llm/executor.js";
+import type { ToolCall } from "../llm/types.js";
+import {
+  type CreateJobResult,
+  type EvmAddress,
+  JobType,
+  type RegisterResult,
+  type TxHash,
+} from "../types.js";
+
+const SIGNER: EvmAddress = "0x1111111111111111111111111111111111111111";
+const TOKEN: EvmAddress = "0x2222222222222222222222222222222222222222";
+const CLONE: EvmAddress = "0x3333333333333333333333333333333333333333";
+const EVALUATOR: EvmAddress = "0x4444444444444444444444444444444444444444";
+const TX: TxHash = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+interface MockAgent {
+  register: ReturnType<typeof vi.fn>;
+  browse: ReturnType<typeof vi.fn>;
+  createJob: ReturnType<typeof vi.fn>;
+}
+
+function makeAgent(): MockAgent {
+  return {
+    register: vi.fn(),
+    browse: vi.fn(),
+    createJob: vi.fn(),
+  };
+}
+
+function call(name: string, args: unknown): ToolCall {
+  return {
+    id: "call_1",
+    type: "function",
+    function: {
+      name,
+      arguments: typeof args === "string" ? args : JSON.stringify(args),
+    },
+  };
+}
+
+function asAcpAgent(m: MockAgent): AcpAgent {
+  return m as unknown as AcpAgent;
+}
+
+describe("executeTool — register", () => {
+  const okResult: RegisterResult = {
+    agentId: 7n,
+    txHash: TX,
+    controller: SIGNER,
+    metadataUri: "ipfs://meta",
+    capabilities: 5n,
+  };
+
+  it("dispatches register and serialises BigInts as decimal strings", async () => {
+    const agent = makeAgent();
+    agent.register.mockResolvedValue(okResult);
+
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.register, {
+        metadataUri: "ipfs://meta",
+        capabilities: "5",
+      })
+    );
+
+    expect(res.isError).toBe(false);
+    expect(res.role).toBe("tool");
+    expect(res.tool_call_id).toBe("call_1");
+    expect(res.name).toBe(TOOL_NAMES.register);
+    const payload = JSON.parse(res.content);
+    expect(payload.agentId).toBe("7");
+    expect(payload.capabilities).toBe("5");
+    expect(payload.txHash).toBe(TX);
+    expect(payload.controller).toBe(SIGNER);
+    expect(agent.register).toHaveBeenCalledWith({
+      metadataUri: "ipfs://meta",
+      capabilities: "5",
+    });
+  });
+
+  it("forwards an explicit controller and lowercases it", async () => {
+    const agent = makeAgent();
+    agent.register.mockResolvedValue(okResult);
+
+    await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.register, {
+        metadataUri: "ipfs://meta",
+        capabilities: "5",
+        controller: "0xABCDEF0000000000000000000000000000000001",
+      })
+    );
+
+    expect(agent.register).toHaveBeenCalledWith({
+      metadataUri: "ipfs://meta",
+      capabilities: "5",
+      controller: "0xabcdef0000000000000000000000000000000001",
+    });
+  });
+
+  it("returns an error envelope for non-decimal capabilities", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.register, {
+        metadataUri: "ipfs://meta",
+        capabilities: "0xff",
+      })
+    );
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content).error.message).toMatch(/decimal/);
+    expect(agent.register).not.toHaveBeenCalled();
+  });
+
+  it("returns an error envelope when metadataUri is missing", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.register, { capabilities: "5" })
+    );
+    expect(res.isError).toBe(true);
+  });
+
+  it("returns an error envelope when controller is malformed", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.register, {
+        metadataUri: "ipfs://meta",
+        capabilities: "5",
+        controller: "not-an-address",
+      })
+    );
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content).error.message).toMatch(/address/);
+  });
+
+  it("propagates AcpError code from the agent", async () => {
+    const agent = makeAgent();
+    agent.register.mockRejectedValue(new AcpError("tx_reverted", "tx reverted: 0xabc"));
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.register, { metadataUri: "ipfs://m", capabilities: "0" })
+    );
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content).error.code).toBe("tx_reverted");
+  });
+
+  it("propagates non-AcpError as invalid_param fallback", async () => {
+    const agent = makeAgent();
+    agent.register.mockRejectedValue(new Error("network down"));
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.register, { metadataUri: "ipfs://m", capabilities: "0" })
+    );
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content).error.code).toBe("invalid_param");
+    expect(JSON.parse(res.content).error.message).toBe("network down");
+  });
+});
+
+describe("executeTool — browse", () => {
+  it("dispatches browse with full filter", async () => {
+    const agent = makeAgent();
+    agent.browse.mockResolvedValue({ data: [], next_cursor: "next" });
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.browse, { kind: "acp", limit: 10, cursor: "abc" })
+    );
+    expect(res.isError).toBe(false);
+    expect(JSON.parse(res.content)).toEqual({ data: [], next_cursor: "next" });
+    expect(agent.browse).toHaveBeenCalledWith({
+      kind: "acp",
+      limit: 10,
+      cursor: "abc",
+    });
+  });
+
+  it("dispatches browse with no filter", async () => {
+    const agent = makeAgent();
+    agent.browse.mockResolvedValue({ data: [], next_cursor: "" });
+    await executeTool(asAcpAgent(agent), call(TOOL_NAMES.browse, {}));
+    expect(agent.browse).toHaveBeenCalledWith({});
+  });
+
+  it("rejects non-enum kind", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(asAcpAgent(agent), call(TOOL_NAMES.browse, { kind: "other" }));
+    expect(res.isError).toBe(true);
+    expect(agent.browse).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-integer limit", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(asAcpAgent(agent), call(TOOL_NAMES.browse, { limit: 1.5 }));
+    expect(res.isError).toBe(true);
+  });
+});
+
+describe("executeTool — createJob", () => {
+  const okResult: CreateJobResult = {
+    jobId: 11n,
+    cloneAddress: CLONE,
+    txHash: TX,
+  };
+
+  it("dispatches a Direct job and coerces strings to bigints", async () => {
+    const agent = makeAgent();
+    agent.createJob.mockResolvedValue(okResult);
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.createJob, {
+        token: TOKEN,
+        budget: "1000000",
+        deadline: "2000000000",
+      })
+    );
+    expect(res.isError).toBe(false);
+    const payload = JSON.parse(res.content);
+    expect(payload.jobId).toBe("11");
+    expect(payload.cloneAddress).toBe(CLONE);
+    expect(agent.createJob).toHaveBeenCalledWith({
+      token: TOKEN,
+      budget: 1000000n,
+      deadline: 2000000000n,
+    });
+  });
+
+  it("dispatches an Evaluated job with evaluator + targetAgentId + hooks", async () => {
+    const agent = makeAgent();
+    agent.createJob.mockResolvedValue(okResult);
+    await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.createJob, {
+        token: TOKEN,
+        budget: "100",
+        deadline: "2000000000",
+        jobType: "evaluated",
+        evaluator: EVALUATOR,
+        targetAgentId: "9",
+        hooks: [SIGNER],
+      })
+    );
+    expect(agent.createJob).toHaveBeenCalledWith({
+      token: TOKEN,
+      budget: 100n,
+      deadline: 2000000000n,
+      jobType: JobType.Evaluated,
+      evaluator: EVALUATOR,
+      targetAgentId: 9n,
+      hooks: [SIGNER],
+    });
+  });
+
+  it("translates jobType=direct to JobType.Direct", async () => {
+    const agent = makeAgent();
+    agent.createJob.mockResolvedValue(okResult);
+    await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.createJob, {
+        token: TOKEN,
+        budget: "1",
+        deadline: "2000000000",
+        jobType: "direct",
+      })
+    );
+    expect(agent.createJob.mock.calls[0]?.[0].jobType).toBe(JobType.Direct);
+  });
+
+  it("rejects unknown jobType", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.createJob, {
+        token: TOKEN,
+        budget: "1",
+        deadline: "2000000000",
+        jobType: "garbage",
+      })
+    );
+    expect(res.isError).toBe(true);
+  });
+
+  it("rejects malformed token", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.createJob, {
+        token: "0xnope",
+        budget: "1",
+        deadline: "2000000000",
+      })
+    );
+    expect(res.isError).toBe(true);
+  });
+
+  it("rejects malformed hook entry", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.createJob, {
+        token: TOKEN,
+        budget: "1",
+        deadline: "2000000000",
+        hooks: ["not-an-address"],
+      })
+    );
+    expect(res.isError).toBe(true);
+  });
+
+  it("rejects non-array hooks", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.createJob, {
+        token: TOKEN,
+        budget: "1",
+        deadline: "2000000000",
+        hooks: SIGNER,
+      })
+    );
+    expect(res.isError).toBe(true);
+  });
+
+  it("propagates AcpError from createJob", async () => {
+    const agent = makeAgent();
+    agent.createJob.mockRejectedValue(new AcpError("invalid_param", "budget must be > 0"));
+    const res = await executeTool(
+      asAcpAgent(agent),
+      call(TOOL_NAMES.createJob, {
+        token: TOKEN,
+        budget: "1",
+        deadline: "2000000000",
+      })
+    );
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content).error.code).toBe("invalid_param");
+  });
+});
+
+describe("executeTool — argument parsing", () => {
+  it("returns an error envelope for invalid JSON arguments", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(asAcpAgent(agent), call(TOOL_NAMES.register, "{not json"));
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content).error.message).toMatch(/JSON/);
+  });
+
+  it("returns an error envelope when arguments are an array", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(asAcpAgent(agent), call(TOOL_NAMES.register, [1, 2, 3]));
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content).error.message).toMatch(/object/);
+  });
+
+  it("treats empty argument string as empty object", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(asAcpAgent(agent), {
+      id: "x",
+      type: "function",
+      function: { name: TOOL_NAMES.register, arguments: "" },
+    });
+    // metadataUri is required, so this surfaces as an arg-parsing error,
+    // but importantly NOT as a "not valid JSON" error.
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content).error.message).not.toMatch(/JSON/);
+  });
+
+  it("returns an error envelope for unknown tool name", async () => {
+    const agent = makeAgent();
+    const res = await executeTool(asAcpAgent(agent), call("acp_does_not_exist", {}));
+    expect(res.isError).toBe(true);
+    expect(JSON.parse(res.content).error.message).toMatch(/unknown tool/);
+  });
+});

--- a/packages/acp-sdk-ts/src/__tests__/llm-messages.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/llm-messages.test.ts
@@ -54,7 +54,7 @@ describe("toMessages", () => {
   });
 
   it("emits a JSON state turn when agents are present", () => {
-    const messages = toMessages({ agents: [AGENT_A] });
+    const messages = toMessages({ agents: [AGENT_A] }, { redactAddresses: false });
     expect(messages).toHaveLength(2);
     expect(messages[1]?.role).toBe("user");
     const content = (messages[1] as { content: string }).content;
@@ -74,7 +74,7 @@ describe("toMessages", () => {
   });
 
   it("emits jobs in the JSON payload", () => {
-    const messages = toMessages({ jobs: [JOB_A] });
+    const messages = toMessages({ jobs: [JOB_A] }, { redactAddresses: false });
     expect(messages).toHaveLength(2);
     const json = extractJson((messages[1] as { content: string }).content);
     expect(json.jobs).toHaveLength(1);
@@ -166,6 +166,58 @@ describe("toMessages", () => {
     const json = extractJson((messages[1] as { content: string }).content);
     expect(json.jobs[0]?.clone_address).toBeUndefined();
     expect(json.jobs[0]?.result_uri).toBeUndefined();
+  });
+
+  it("redacts controller + principal addresses by default", () => {
+    const messages = toMessages({ agents: [AGENT_A], jobs: [JOB_A] });
+    const json = extractJson((messages[1] as { content: string }).content);
+
+    const controller = json.agents[0]?.controller as string | undefined;
+    const principal = json.jobs[0]?.principal as string | undefined;
+
+    // Raw hex addresses MUST NOT appear under the default privacy contract.
+    expect(controller).not.toBe(AGENT_A.controller);
+    expect(principal).not.toBe(JOB_A.principal);
+
+    // Both should be tokenized to the deterministic short form.
+    expect(controller).toMatch(/^addr_[0-9a-f]{8}$/);
+    expect(principal).toMatch(/^addr_[0-9a-f]{8}$/);
+
+    // Public protocol fields MUST still flow through unchanged.
+    expect(json.jobs[0]?.token).toBe(JOB_A.token);
+    expect(json.jobs[0]?.clone_address).toBe(JOB_A.clone_address);
+  });
+
+  it("preserves identity equality across messages when redacted", () => {
+    // Same wallet appears as both controller (agent) and principal (job).
+    const sharedAddr = "0xabababababababababababababababababababab";
+    const agent: Agent = { ...AGENT_A, controller: sharedAddr };
+    const job: Job = { ...JOB_A, principal: sharedAddr };
+
+    const messages = toMessages({ agents: [agent], jobs: [job] });
+    const json = extractJson((messages[1] as { content: string }).content);
+
+    const controller = json.agents[0]?.controller as string;
+    const principal = json.jobs[0]?.principal as string;
+
+    expect(controller).toBeDefined();
+    expect(controller).toBe(principal);
+
+    // Checksum-cased input collides to the same token (case-insensitive).
+    const checksumAgent: Agent = {
+      ...AGENT_A,
+      controller: `0x${sharedAddr.slice(2).toUpperCase()}` as `0x${string}`,
+    };
+    const messages2 = toMessages({ agents: [checksumAgent] });
+    const json2 = extractJson((messages2[1] as { content: string }).content);
+    expect(json2.agents[0]?.controller).toBe(controller);
+  });
+
+  it("leaves addresses intact when redactAddresses is false", () => {
+    const messages = toMessages({ agents: [AGENT_A], jobs: [JOB_A] }, { redactAddresses: false });
+    const json = extractJson((messages[1] as { content: string }).content);
+    expect(json.agents[0]?.controller).toBe(AGENT_A.controller);
+    expect(json.jobs[0]?.principal).toBe(JOB_A.principal);
   });
 });
 

--- a/packages/acp-sdk-ts/src/__tests__/llm-messages.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/llm-messages.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { toMessages } from "../llm/messages.js";
+import type { Agent, Job } from "../types.js";
+
+const AGENT_A: Agent = {
+  id: 1,
+  agent_id: "1",
+  kind: "acp",
+  controller: "0x1111111111111111111111111111111111111111",
+  capabilities: "5",
+  metadata_uri: "ipfs://meta-a",
+  block_number: 100,
+  log_index: 0,
+  tx_hash: "0xaa",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const JOB_A: Job = {
+  id: 11,
+  agent_pk: 1,
+  agent_id: "1",
+  phase: "active",
+  job_type: 0,
+  principal: "0x2222222222222222222222222222222222222222",
+  clone_address: "0x3333333333333333333333333333333333333333",
+  token: "0x4444444444444444444444444444444444444444",
+  budget: "1000000",
+  deadline: "2026-01-31T00:00:00Z",
+  block_number: 200,
+  log_index: 1,
+  tx_hash: "0xbb",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("toMessages", () => {
+  it("emits a system message with the default prompt when none is provided", () => {
+    const messages = toMessages({});
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.role).toBe("system");
+    expect((messages[0] as { content: string }).content).toMatch(/Titular ACP/);
+  });
+
+  it("uses a custom systemPrompt when provided", () => {
+    const messages = toMessages({ systemPrompt: "act as a launchpad bot" });
+    expect(messages[0]?.role).toBe("system");
+    expect((messages[0] as { content: string }).content).toBe("act as a launchpad bot");
+  });
+
+  it("falls back to default prompt when systemPrompt is empty", () => {
+    const messages = toMessages({ systemPrompt: "" });
+    expect((messages[0] as { content: string }).content).toMatch(/Titular ACP/);
+  });
+
+  it("emits a JSON state turn when agents are present", () => {
+    const messages = toMessages({ agents: [AGENT_A] });
+    expect(messages).toHaveLength(2);
+    expect(messages[1]?.role).toBe("user");
+    const content = (messages[1] as { content: string }).content;
+    expect(content).toContain("```json");
+    const json = extractJson(content);
+    expect(json.agents).toHaveLength(1);
+    expect(json.agents[0]).toMatchObject({
+      agent_id: "1",
+      kind: "acp",
+      controller: AGENT_A.controller,
+      capabilities: "5",
+      metadata_uri: "ipfs://meta-a",
+    });
+    // Indexer-only fields should NOT leak into the model context.
+    expect(json.agents[0]?.block_number).toBeUndefined();
+    expect(json.agents[0]?.tx_hash).toBeUndefined();
+  });
+
+  it("emits jobs in the JSON payload", () => {
+    const messages = toMessages({ jobs: [JOB_A] });
+    expect(messages).toHaveLength(2);
+    const json = extractJson((messages[1] as { content: string }).content);
+    expect(json.jobs).toHaveLength(1);
+    expect(json.jobs[0]).toMatchObject({
+      agent_id: "1",
+      phase: "active",
+      job_type: 0,
+      principal: JOB_A.principal,
+      clone_address: JOB_A.clone_address,
+      token: JOB_A.token,
+      budget: "1000000",
+    });
+    expect(json.jobs[0]?.tx_hash).toBeUndefined();
+  });
+
+  it("merges agents + jobs into a single payload turn", () => {
+    const messages = toMessages({ agents: [AGENT_A], jobs: [JOB_A] });
+    expect(messages).toHaveLength(2);
+    const json = extractJson((messages[1] as { content: string }).content);
+    expect(json.agents).toHaveLength(1);
+    expect(json.jobs).toHaveLength(1);
+  });
+
+  it("omits the JSON turn when both agents + jobs are absent or empty", () => {
+    const messages = toMessages({ agents: [], jobs: [] });
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.role).toBe("system");
+  });
+
+  it("appends an optional userPrompt as a final user turn", () => {
+    const messages = toMessages({ userPrompt: "what should I do next?" });
+    expect(messages).toHaveLength(2);
+    expect(messages[1]).toEqual({
+      role: "user",
+      content: "what should I do next?",
+    });
+  });
+
+  it("places userPrompt after the JSON state turn", () => {
+    const messages = toMessages({
+      agents: [AGENT_A],
+      userPrompt: "pick the best agent",
+    });
+    expect(messages.map((m) => m.role)).toEqual(["system", "user", "user"]);
+    expect((messages[2] as { content: string }).content).toBe("pick the best agent");
+  });
+
+  it("ignores empty userPrompt", () => {
+    const messages = toMessages({ userPrompt: "" });
+    expect(messages).toHaveLength(1);
+  });
+
+  it("drops optional fields cleanly when an agent has no controller / metadata_uri", () => {
+    const sparse: Agent = {
+      id: AGENT_A.id,
+      agent_id: AGENT_A.agent_id,
+      kind: AGENT_A.kind,
+      capabilities: AGENT_A.capabilities,
+      block_number: AGENT_A.block_number,
+      log_index: AGENT_A.log_index,
+      tx_hash: AGENT_A.tx_hash,
+      created_at: AGENT_A.created_at,
+      updated_at: AGENT_A.updated_at,
+    };
+    const messages = toMessages({ agents: [sparse] });
+    const json = extractJson((messages[1] as { content: string }).content);
+    expect(json.agents[0]?.controller).toBeUndefined();
+    expect(json.agents[0]?.metadata_uri).toBeUndefined();
+  });
+
+  it("drops optional fields cleanly when a job has no clone_address / result_uri", () => {
+    const sparse: Job = {
+      id: JOB_A.id,
+      agent_pk: JOB_A.agent_pk,
+      agent_id: JOB_A.agent_id,
+      phase: JOB_A.phase,
+      job_type: JOB_A.job_type,
+      principal: JOB_A.principal,
+      token: JOB_A.token,
+      budget: JOB_A.budget,
+      deadline: JOB_A.deadline,
+      block_number: JOB_A.block_number,
+      log_index: JOB_A.log_index,
+      tx_hash: JOB_A.tx_hash,
+      created_at: JOB_A.created_at,
+      updated_at: JOB_A.updated_at,
+    };
+    const messages = toMessages({ jobs: [sparse] });
+    const json = extractJson((messages[1] as { content: string }).content);
+    expect(json.jobs[0]?.clone_address).toBeUndefined();
+    expect(json.jobs[0]?.result_uri).toBeUndefined();
+  });
+});
+
+interface ExtractedPayload {
+  agents: Array<Record<string, unknown>>;
+  jobs: Array<Record<string, unknown>>;
+}
+
+function extractJson(content: string): ExtractedPayload {
+  const match = content.match(/```json\n([\s\S]*?)\n```/);
+  if (match === null) throw new Error(`no fenced json block in: ${content}`);
+  const parsed = JSON.parse(match[1] ?? "") as Partial<ExtractedPayload>;
+  return {
+    agents: parsed.agents ?? [],
+    jobs: parsed.jobs ?? [],
+  };
+}

--- a/packages/acp-sdk-ts/src/__tests__/llm-tools.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/llm-tools.test.ts
@@ -8,6 +8,12 @@ describe("availableTools", () => {
     expect(names).toEqual([TOOL_NAMES.browse, TOOL_NAMES.createJob, TOOL_NAMES.register].sort());
   });
 
+  it("schema is stable", () => {
+    // Snapshot guards the model-facing tool surface against accidental drift.
+    // Reviewer ack required to update (`pnpm test --update`).
+    expect(availableTools()).toMatchSnapshot();
+  });
+
   it("emits OpenAI-shaped envelopes", () => {
     for (const tool of availableTools()) {
       expect(tool.type).toBe("function");

--- a/packages/acp-sdk-ts/src/__tests__/llm-tools.test.ts
+++ b/packages/acp-sdk-ts/src/__tests__/llm-tools.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { TOOL_NAMES, availableTools } from "../llm/tools.js";
+
+describe("availableTools", () => {
+  it("returns one tool per AcpAgent action", () => {
+    const tools = availableTools();
+    const names = tools.map((t) => t.function.name).sort();
+    expect(names).toEqual([TOOL_NAMES.browse, TOOL_NAMES.createJob, TOOL_NAMES.register].sort());
+  });
+
+  it("emits OpenAI-shaped envelopes", () => {
+    for (const tool of availableTools()) {
+      expect(tool.type).toBe("function");
+      expect(typeof tool.function.name).toBe("string");
+      expect(typeof tool.function.description).toBe("string");
+      expect(tool.function.description.length).toBeGreaterThan(20);
+      expect(tool.function.parameters.type).toBe("object");
+    }
+  });
+
+  it("returns a fresh array each call (mutation safety)", () => {
+    const a = availableTools();
+    const b = availableTools();
+    expect(a).not.toBe(b);
+    a.pop();
+    expect(b.length).toBe(3);
+  });
+
+  it("filters with `include`", () => {
+    const tools = availableTools({ include: [TOOL_NAMES.browse] });
+    expect(tools.map((t) => t.function.name)).toEqual([TOOL_NAMES.browse]);
+  });
+
+  it("filters with `include` set to multiple", () => {
+    const tools = availableTools({
+      include: [TOOL_NAMES.browse, TOOL_NAMES.register],
+    });
+    const names = tools.map((t) => t.function.name).sort();
+    expect(names).toEqual([TOOL_NAMES.browse, TOOL_NAMES.register].sort());
+  });
+
+  it("returns an empty array when `include` matches nothing", () => {
+    // @ts-expect-error: deliberately passing an unknown name to verify behavior
+    const tools = availableTools({ include: ["does_not_exist"] });
+    expect(tools).toEqual([]);
+  });
+
+  describe("acp_register schema", () => {
+    const tool = availableTools().find((t) => t.function.name === TOOL_NAMES.register);
+
+    it("requires metadataUri + capabilities", () => {
+      expect(tool?.function.parameters.required).toEqual(["metadataUri", "capabilities"]);
+    });
+
+    it("describes the controller field", () => {
+      const props = tool?.function.parameters.properties;
+      expect(props?.controller?.pattern).toBe("^0x[0-9a-fA-F]{40}$");
+    });
+
+    it("constrains capabilities to decimal uint", () => {
+      const props = tool?.function.parameters.properties;
+      expect(props?.capabilities?.pattern).toBe("^(0|[1-9][0-9]*)$");
+    });
+
+    it("disallows additional properties", () => {
+      expect(tool?.function.parameters.additionalProperties).toBe(false);
+    });
+  });
+
+  describe("acp_browse schema", () => {
+    const tool = availableTools().find((t) => t.function.name === TOOL_NAMES.browse);
+
+    it("has no required fields", () => {
+      expect(tool?.function.parameters.required).toBeUndefined();
+    });
+
+    it("constrains kind to enum", () => {
+      const props = tool?.function.parameters.properties;
+      expect(props?.kind?.enum).toEqual(["launchpad", "acp"]);
+    });
+
+    it("constrains limit to [1, 200]", () => {
+      const props = tool?.function.parameters.properties;
+      expect(props?.limit?.type).toBe("integer");
+      expect(props?.limit?.minimum).toBe(1);
+      expect(props?.limit?.maximum).toBe(200);
+    });
+  });
+
+  describe("acp_create_job schema", () => {
+    const tool = availableTools().find((t) => t.function.name === TOOL_NAMES.createJob);
+
+    it("requires token, budget, deadline", () => {
+      expect(tool?.function.parameters.required).toEqual(["token", "budget", "deadline"]);
+    });
+
+    it("constrains jobType enum", () => {
+      const props = tool?.function.parameters.properties;
+      expect(props?.jobType?.enum).toEqual(["direct", "evaluated"]);
+    });
+
+    it("typed hooks as array of addresses", () => {
+      const props = tool?.function.parameters.properties;
+      expect(props?.hooks?.type).toBe("array");
+      expect(props?.hooks?.items?.pattern).toBe("^0x[0-9a-fA-F]{40}$");
+    });
+  });
+});

--- a/packages/acp-sdk-ts/src/llm/executor.ts
+++ b/packages/acp-sdk-ts/src/llm/executor.ts
@@ -23,7 +23,7 @@ import {
   JobType,
   type RegisterParams,
 } from "../types.js";
-import { TOOL_NAMES, type ToolName } from "./tools.js";
+import { TOOL_NAMES } from "./tools.js";
 import type { ToolCall, ToolResult } from "./types.js";
 
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
@@ -213,7 +213,3 @@ function errorResult(call: ToolCall, name: string, code: string, message: string
     isError: true,
   };
 }
-
-/** Re-export so callers don't have to know the dispatch table layout. */
-export { TOOL_NAMES };
-export type { ToolName };

--- a/packages/acp-sdk-ts/src/llm/executor.ts
+++ b/packages/acp-sdk-ts/src/llm/executor.ts
@@ -1,0 +1,219 @@
+// executeTool — dispatch a model-emitted {@link ToolCall} to the matching
+// {@link AcpAgent} method, marshal the return value back into a tool-result
+// envelope the model can consume.
+//
+// Errors are caught and returned in the result envelope (`isError: true`)
+// rather than thrown, because the LLM tool-calling protocols expect every
+// `tool_call_id` to be answered exactly once. Throwing here would force the
+// caller to invent a synthetic error response for the model, which is both
+// boilerplate and easy to get wrong.
+//
+// All BigInts in the SDK return values are coerced to decimal-encoded strings
+// before serialisation — JSON cannot represent BigInt natively, and JS engines
+// throw `TypeError: Do not know how to serialize a BigInt` if you try
+// `JSON.stringify({n: 1n})`. Decimal strings round-trip cleanly through both
+// the OpenAI tool-result protocol and our own `availableTools` schemas.
+
+import type { AcpAgent } from "../agent.js";
+import { AcpError } from "../errors.js";
+import {
+  type BrowseParams,
+  type CreateJobParams,
+  type EvmAddress,
+  JobType,
+  type RegisterParams,
+} from "../types.js";
+import { TOOL_NAMES, type ToolName } from "./tools.js";
+import type { ToolCall, ToolResult } from "./types.js";
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+const DECIMAL_UINT_RE = /^(0|[1-9][0-9]*)$/;
+
+/**
+ * Dispatch a single tool call. The return value is always a {@link ToolResult}
+ * — failures are encoded as `{isError: true, content: JSON({error: ...})}`
+ * rather than thrown.
+ */
+export async function executeTool(agent: AcpAgent, call: ToolCall): Promise<ToolResult> {
+  const name = call.function.name;
+  let args: Record<string, unknown>;
+  try {
+    args = parseArgs(call.function.arguments);
+  } catch (err) {
+    return errorResult(call, name, "invalid_param", (err as Error).message);
+  }
+
+  try {
+    switch (name) {
+      case TOOL_NAMES.register: {
+        const params = parseRegisterArgs(args);
+        const result = await agent.register(params);
+        return successResult(call, name, {
+          agentId: result.agentId.toString(),
+          txHash: result.txHash,
+          controller: result.controller,
+          metadataUri: result.metadataUri,
+          capabilities: result.capabilities.toString(),
+        });
+      }
+      case TOOL_NAMES.browse: {
+        const params = parseBrowseArgs(args);
+        const page = await agent.browse(params);
+        return successResult(call, name, page);
+      }
+      case TOOL_NAMES.createJob: {
+        const params = parseCreateJobArgs(args);
+        const result = await agent.createJob(params);
+        return successResult(call, name, {
+          jobId: result.jobId.toString(),
+          cloneAddress: result.cloneAddress,
+          txHash: result.txHash,
+        });
+      }
+      default:
+        return errorResult(call, name, "invalid_param", `unknown tool: ${name}`);
+    }
+  } catch (err) {
+    if (err instanceof AcpError) {
+      return errorResult(call, name, err.code, err.message);
+    }
+    return errorResult(call, name, "invalid_param", (err as Error).message ?? "unknown error");
+  }
+}
+
+// -- argument parsing -------------------------------------------------------
+
+function parseArgs(raw: string): Record<string, unknown> {
+  if (raw === "" || raw === undefined) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    throw new Error(`tool arguments are not valid JSON: ${(cause as Error).message}`);
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("tool arguments must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseRegisterArgs(args: Record<string, unknown>): RegisterParams {
+  const metadataUri = requireString(args, "metadataUri");
+  const capabilities = requireDecimalUint(args, "capabilities");
+  const params: RegisterParams = { metadataUri, capabilities };
+  if (args.controller !== undefined) {
+    params.controller = requireAddress(args, "controller");
+  }
+  return params;
+}
+
+function parseBrowseArgs(args: Record<string, unknown>): BrowseParams {
+  const params: BrowseParams = {};
+  if (args.kind !== undefined) {
+    if (args.kind !== "launchpad" && args.kind !== "acp") {
+      throw new Error("`kind` must be 'launchpad' or 'acp'");
+    }
+    params.kind = args.kind;
+  }
+  if (args.limit !== undefined) {
+    if (typeof args.limit !== "number" || !Number.isInteger(args.limit)) {
+      throw new Error("`limit` must be an integer");
+    }
+    params.limit = args.limit;
+  }
+  if (args.cursor !== undefined) {
+    params.cursor = requireString(args, "cursor");
+  }
+  return params;
+}
+
+function parseCreateJobArgs(args: Record<string, unknown>): CreateJobParams {
+  const token = requireAddress(args, "token");
+  const budget = requireBigUint(args, "budget");
+  const deadline = requireBigUint(args, "deadline");
+  const params: CreateJobParams = { token, budget, deadline };
+  if (args.targetAgentId !== undefined) {
+    params.targetAgentId = requireBigUint(args, "targetAgentId");
+  }
+  if (args.jobType !== undefined) {
+    if (args.jobType === "direct") {
+      params.jobType = JobType.Direct;
+    } else if (args.jobType === "evaluated") {
+      params.jobType = JobType.Evaluated;
+    } else {
+      throw new Error("`jobType` must be 'direct' or 'evaluated'");
+    }
+  }
+  if (args.evaluator !== undefined) {
+    params.evaluator = requireAddress(args, "evaluator");
+  }
+  if (args.arbiter !== undefined) {
+    params.arbiter = requireAddress(args, "arbiter");
+  }
+  if (args.hooks !== undefined) {
+    if (!Array.isArray(args.hooks)) {
+      throw new Error("`hooks` must be an array of addresses");
+    }
+    params.hooks = args.hooks.map((h, i) => coerceAddress(h, `hooks[${i}]`));
+  }
+  return params;
+}
+
+// -- coercion primitives ----------------------------------------------------
+
+function requireString(args: Record<string, unknown>, key: string): string {
+  const v = args[key];
+  if (typeof v !== "string" || v.length === 0) {
+    throw new Error(`\`${key}\` must be a non-empty string`);
+  }
+  return v;
+}
+
+function requireAddress(args: Record<string, unknown>, key: string): EvmAddress {
+  return coerceAddress(args[key], key);
+}
+
+function coerceAddress(v: unknown, key: string): EvmAddress {
+  if (typeof v !== "string" || !ADDRESS_RE.test(v)) {
+    throw new Error(`\`${key}\` must be a 0x-prefixed 20-byte hex address`);
+  }
+  return v.toLowerCase() as EvmAddress;
+}
+
+function requireDecimalUint(args: Record<string, unknown>, key: string): string {
+  const v = args[key];
+  if (typeof v !== "string" || !DECIMAL_UINT_RE.test(v)) {
+    throw new Error(`\`${key}\` must be a decimal-encoded uint256 string`);
+  }
+  return v;
+}
+
+function requireBigUint(args: Record<string, unknown>, key: string): bigint {
+  return BigInt(requireDecimalUint(args, key));
+}
+
+// -- result envelope helpers ------------------------------------------------
+
+function successResult(call: ToolCall, name: string, payload: unknown): ToolResult {
+  return {
+    role: "tool",
+    tool_call_id: call.id,
+    name,
+    content: JSON.stringify(payload),
+    isError: false,
+  };
+}
+
+function errorResult(call: ToolCall, name: string, code: string, message: string): ToolResult {
+  return {
+    role: "tool",
+    tool_call_id: call.id,
+    name,
+    content: JSON.stringify({ error: { code, message } }),
+    isError: true,
+  };
+}
+
+/** Re-export so callers don't have to know the dispatch table layout. */
+export { TOOL_NAMES };
+export type { ToolName };

--- a/packages/acp-sdk-ts/src/llm/index.ts
+++ b/packages/acp-sdk-ts/src/llm/index.ts
@@ -1,0 +1,17 @@
+// Public entry point for `@titular/acp-sdk/llm`. The LLM helpers are exposed
+// behind a subpath so consumers building non-LLM applications don't pay any
+// cost (bundle size or startup) for them — bundlers tree-shake the subpath
+// when nothing in it is imported.
+
+export { availableTools, TOOL_NAMES } from "./tools.js";
+export type { AvailableToolsParams, ToolName } from "./tools.js";
+export { toMessages } from "./messages.js";
+export { executeTool } from "./executor.js";
+export type {
+  AgentState,
+  JsonSchema,
+  Message,
+  ToolCall,
+  ToolDefinition,
+  ToolResult,
+} from "./types.js";

--- a/packages/acp-sdk-ts/src/llm/messages.ts
+++ b/packages/acp-sdk-ts/src/llm/messages.ts
@@ -12,6 +12,7 @@
 // API. Models reliably parse fenced JSON blocks; we wrap the payload in
 // `\`\`\`json ... \`\`\`` so the model treats it as data, not prose.
 
+import { keccak256, toBytes } from "viem";
 import type { Agent, Job } from "../types.js";
 import type { AgentState, Message } from "./types.js";
 
@@ -21,6 +22,23 @@ const DEFAULT_SYSTEM_PROMPT =
   "the provided tools to act on this state; do not invent agentIds, jobIds, or " +
   "addresses that do not appear in the snapshot. All numeric ids are decimal-" +
   "encoded uint256 strings — pass them through verbatim.";
+
+/** Options accepted by {@link toMessages}. */
+export interface ToMessagesOptions {
+  /**
+   * Redact wallet addresses (`controller`, `principal`) before sending to the
+   * LLM. Default: `true`.
+   *
+   * Each address is replaced with a deterministic short token of the form
+   * `addr_${first8charsOfKeccak256(addr)}` so the model can still reason about
+   * identity equality across messages without seeing the raw wallet.
+   *
+   * Set to `false` only when the caller has independently established that
+   * leaking these addresses to the model provider is acceptable (e.g. a
+   * self-hosted model, or an explicit user opt-in).
+   */
+  redactAddresses?: boolean;
+}
 
 /**
  * Render `state` into a role-tagged message stream.
@@ -37,8 +55,21 @@ const DEFAULT_SYSTEM_PROMPT =
  * If `state` carries no agents and no jobs, the JSON payload turn is omitted
  * entirely (so a stand-alone systemPrompt + userPrompt round-trips to a clean
  * 2-message stream).
+ *
+ * Privacy contract:
+ *   - When `opts.redactAddresses` is `true` (default), the `controller` field
+ *     on agents and the `principal` field on jobs are replaced with a
+ *     deterministic `addr_<8hex>` token. Identity equality is preserved (same
+ *     address → same token) across the same call.
+ *   - All other on-chain fields (`agent_id`, `chain_id`, `token`,
+ *     `clone_address`, `tx_hash`, `metadata_uri`, `result_uri`, etc.) are
+ *     fundamentally public and are NOT redacted. Callers who need stricter
+ *     redaction must pre-filter `state` themselves.
+ *   - The `userPrompt` and `systemPrompt` are passed through verbatim; the
+ *     SDK does not attempt to scrub free-form text.
  */
-export function toMessages(state: AgentState): Message[] {
+export function toMessages(state: AgentState, opts: ToMessagesOptions = {}): Message[] {
+  const redact = opts.redactAddresses ?? true;
   const messages: Message[] = [];
 
   const systemPrompt =
@@ -52,8 +83,8 @@ export function toMessages(state: AgentState): Message[] {
 
   if (hasAgents || hasJobs) {
     const payload: { agents?: SerializedAgent[]; jobs?: SerializedJob[] } = {};
-    if (hasAgents) payload.agents = (state.agents ?? []).map(serializeAgent);
-    if (hasJobs) payload.jobs = (state.jobs ?? []).map(serializeJob);
+    if (hasAgents) payload.agents = (state.agents ?? []).map((a) => serializeAgent(a, redact));
+    if (hasJobs) payload.jobs = (state.jobs ?? []).map((j) => serializeJob(j, redact));
     const json = JSON.stringify(payload, null, 2);
     messages.push({
       role: "user",
@@ -93,24 +124,33 @@ interface SerializedJob {
  * tool-call decisions. We drop the indexer book-keeping columns (`block_number`,
  * `log_index`, `tx_hash`, `created_at`, `updated_at`) so the JSON payload stays
  * compact — every byte counts against the model's context window.
+ *
+ * When `redact` is `true`, `controller` is replaced with `addr_<8hex>`.
  */
-function serializeAgent(a: Agent): SerializedAgent {
+function serializeAgent(a: Agent, redact: boolean): SerializedAgent {
   const out: SerializedAgent = {
     agent_id: a.agent_id,
     kind: a.kind,
     capabilities: a.capabilities,
   };
-  if (a.controller !== undefined) out.controller = a.controller;
+  if (a.controller !== undefined) {
+    out.controller = redact ? redactAddress(a.controller) : a.controller;
+  }
   if (a.metadata_uri !== undefined) out.metadata_uri = a.metadata_uri;
   return out;
 }
 
-function serializeJob(j: Job): SerializedJob {
+/**
+ * Project a {@link Job} down to model-relevant fields. When `redact` is `true`,
+ * `principal` is replaced with `addr_<8hex>`. `token` and `clone_address` are
+ * left intact — they are protocol-level public data, not user wallets.
+ */
+function serializeJob(j: Job, redact: boolean): SerializedJob {
   const out: SerializedJob = {
     agent_id: j.agent_id,
     phase: j.phase,
     job_type: j.job_type,
-    principal: j.principal,
+    principal: redact ? redactAddress(j.principal) : j.principal,
     token: j.token,
     budget: j.budget,
     deadline: j.deadline,
@@ -118,4 +158,18 @@ function serializeJob(j: Job): SerializedJob {
   if (j.clone_address !== undefined) out.clone_address = j.clone_address;
   if (j.result_uri !== undefined) out.result_uri = j.result_uri;
   return out;
+}
+
+/**
+ * Replace a raw EVM address with a short, deterministic token. Same input →
+ * same output, so the model can still recognize when two messages reference
+ * the same wallet without seeing the wallet itself.
+ *
+ * Lower-cases the input first so checksum-cased and non-checksum forms collide
+ * to the same token.
+ */
+function redactAddress(addr: string): string {
+  const hash = keccak256(toBytes(addr.toLowerCase()));
+  // hash is `0x` + 64 hex chars; take the first 8 hex chars after the prefix.
+  return `addr_${hash.slice(2, 10)}`;
 }

--- a/packages/acp-sdk-ts/src/llm/messages.ts
+++ b/packages/acp-sdk-ts/src/llm/messages.ts
@@ -1,0 +1,121 @@
+// toMessages — render an {@link AgentState} snapshot into a role-tagged
+// message stream suitable for an OpenAI / Anthropic / Gemini chat completion.
+//
+// The output starts with a single `system` message describing how to read the
+// state, followed by one `user` message containing the JSON payload itself,
+// followed (optionally) by a final `user` turn carrying the human-side prompt.
+//
+// Why JSON inside a user turn rather than a structured `content` array?
+// Because all three providers accept plain string content while only OpenAI
+// (currently) accepts the multi-part `content: [...]` shape. JSON-in-string
+// keeps the surface portable and round-trippable through any chat completion
+// API. Models reliably parse fenced JSON blocks; we wrap the payload in
+// `\`\`\`json ... \`\`\`` so the model treats it as data, not prose.
+
+import type { Agent, Job } from "../types.js";
+import type { AgentState, Message } from "./types.js";
+
+const DEFAULT_SYSTEM_PROMPT =
+  "You are an autonomous agent operating on the Titular ACP. The next message " +
+  "contains a JSON snapshot of the on-chain registry and your active jobs. Use " +
+  "the provided tools to act on this state; do not invent agentIds, jobIds, or " +
+  "addresses that do not appear in the snapshot. All numeric ids are decimal-" +
+  "encoded uint256 strings — pass them through verbatim.";
+
+/**
+ * Render `state` into a role-tagged message stream.
+ *
+ * The function is synchronous and pure — it does not call the gateway or the
+ * chain. Callers are expected to assemble `state` themselves (typically via
+ * `agent.browse(...)` for `agents` and `gateway.listJobs(...)` for `jobs`).
+ *
+ * Output structure:
+ *   1. `system` — either {@link AgentState.systemPrompt} or a sensible default.
+ *   2. `user`   — JSON-encoded payload of agents + jobs, fenced as ```json ... ```.
+ *   3. `user`   — optional, only emitted when {@link AgentState.userPrompt} is set.
+ *
+ * If `state` carries no agents and no jobs, the JSON payload turn is omitted
+ * entirely (so a stand-alone systemPrompt + userPrompt round-trips to a clean
+ * 2-message stream).
+ */
+export function toMessages(state: AgentState): Message[] {
+  const messages: Message[] = [];
+
+  const systemPrompt =
+    state.systemPrompt !== undefined && state.systemPrompt.length > 0
+      ? state.systemPrompt
+      : DEFAULT_SYSTEM_PROMPT;
+  messages.push({ role: "system", content: systemPrompt });
+
+  const hasAgents = state.agents !== undefined && state.agents.length > 0;
+  const hasJobs = state.jobs !== undefined && state.jobs.length > 0;
+
+  if (hasAgents || hasJobs) {
+    const payload: { agents?: SerializedAgent[]; jobs?: SerializedJob[] } = {};
+    if (hasAgents) payload.agents = (state.agents ?? []).map(serializeAgent);
+    if (hasJobs) payload.jobs = (state.jobs ?? []).map(serializeJob);
+    const json = JSON.stringify(payload, null, 2);
+    messages.push({
+      role: "user",
+      content: `Current ACP state snapshot:\n\n\`\`\`json\n${json}\n\`\`\``,
+    });
+  }
+
+  if (state.userPrompt !== undefined && state.userPrompt.length > 0) {
+    messages.push({ role: "user", content: state.userPrompt });
+  }
+
+  return messages;
+}
+
+interface SerializedAgent {
+  agent_id: string;
+  kind: string;
+  controller?: string;
+  capabilities: string;
+  metadata_uri?: string;
+}
+
+interface SerializedJob {
+  agent_id: string;
+  phase: string;
+  job_type: number;
+  principal: string;
+  clone_address?: string;
+  token: string;
+  budget: string;
+  deadline: string;
+  result_uri?: string;
+}
+
+/**
+ * Project an {@link Agent} down to the fields a model actually needs to make
+ * tool-call decisions. We drop the indexer book-keeping columns (`block_number`,
+ * `log_index`, `tx_hash`, `created_at`, `updated_at`) so the JSON payload stays
+ * compact — every byte counts against the model's context window.
+ */
+function serializeAgent(a: Agent): SerializedAgent {
+  const out: SerializedAgent = {
+    agent_id: a.agent_id,
+    kind: a.kind,
+    capabilities: a.capabilities,
+  };
+  if (a.controller !== undefined) out.controller = a.controller;
+  if (a.metadata_uri !== undefined) out.metadata_uri = a.metadata_uri;
+  return out;
+}
+
+function serializeJob(j: Job): SerializedJob {
+  const out: SerializedJob = {
+    agent_id: j.agent_id,
+    phase: j.phase,
+    job_type: j.job_type,
+    principal: j.principal,
+    token: j.token,
+    budget: j.budget,
+    deadline: j.deadline,
+  };
+  if (j.clone_address !== undefined) out.clone_address = j.clone_address;
+  if (j.result_uri !== undefined) out.result_uri = j.result_uri;
+  return out;
+}

--- a/packages/acp-sdk-ts/src/llm/tools.ts
+++ b/packages/acp-sdk-ts/src/llm/tools.ts
@@ -1,0 +1,204 @@
+// availableTools — emit OpenAI-compatible tool definitions for every action
+// AcpAgent currently exposes (register, browse, createJob).
+//
+// Tool names use the `acp_` prefix so models can disambiguate ACP actions from
+// any other tools the host application registers.
+//
+// Schemas are hand-written (rather than generated from Zod or the ABI) because
+// the LLM-facing surface is intentionally narrower than the on-chain ABI:
+//   - `capabilities` accepts decimal strings only (BigInts can't cross the
+//     JSON boundary; numbers > 2^53 lose precision)
+//   - `targetAgentId`, `budget`, `deadline` likewise
+//   - addresses are constrained to the `0x[0-9a-fA-F]{40}` pattern
+//   - jobType is exposed as the literal strings the user thinks in
+//     ("direct" | "evaluated") rather than the uint8 the contract expects
+//
+// The dispatcher in `executor.ts` does the inverse mapping (string -> uint8,
+// decimal -> bigint) before calling AcpAgent.
+
+import type { JsonSchema, ToolDefinition } from "./types.js";
+
+const ADDRESS_PATTERN = "^0x[0-9a-fA-F]{40}$";
+const DECIMAL_UINT_PATTERN = "^(0|[1-9][0-9]*)$";
+
+const ADDRESS_SCHEMA: JsonSchema = {
+  type: "string",
+  description: "EVM address as a `0x`-prefixed 20-byte hex string.",
+  pattern: ADDRESS_PATTERN,
+};
+
+const DECIMAL_UINT_SCHEMA: JsonSchema = {
+  type: "string",
+  description:
+    "Decimal-encoded uint256 (no `0x` prefix, no scientific notation). Required for any " +
+    "numeric value that may exceed 2^53.",
+  pattern: DECIMAL_UINT_PATTERN,
+};
+
+/** Names of every tool emitted by {@link availableTools}. Stable; treat as enum. */
+export const TOOL_NAMES = {
+  register: "acp_register",
+  browse: "acp_browse",
+  createJob: "acp_create_job",
+} as const;
+export type ToolName = (typeof TOOL_NAMES)[keyof typeof TOOL_NAMES];
+
+const REGISTER_TOOL: ToolDefinition = {
+  type: "function",
+  function: {
+    name: TOOL_NAMES.register,
+    description:
+      "Register a new ACP agent on chain via AgentRegistry.register. Returns the new agentId, " +
+      "tx hash, and the controller address that owns the agent. The connected signer pays gas.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["metadataUri", "capabilities"],
+      properties: {
+        controller: {
+          ...ADDRESS_SCHEMA,
+          description:
+            "Optional. Address that will control the agent on chain. Defaults to the connected " +
+            "signer's address.",
+        },
+        metadataUri: {
+          type: "string",
+          description:
+            "Non-empty URI pointing to off-chain agent metadata. Typically `ipfs://<cid>` or " +
+            "`https://...`.",
+        },
+        capabilities: {
+          ...DECIMAL_UINT_SCHEMA,
+          description:
+            'Packed capability bitmap as a decimal-encoded uint256 (e.g. `"5"` for caps 1+4).',
+        },
+      },
+    },
+  },
+};
+
+const BROWSE_TOOL: ToolDefinition = {
+  type: "function",
+  function: {
+    name: TOOL_NAMES.browse,
+    description:
+      "Browse the on-chain agent registry through the gateway. Read-only; does not require a " +
+      "signer. Returns a paginated AgentsPage with `data` and `next_cursor`.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        kind: {
+          type: "string",
+          enum: ["launchpad", "acp"],
+          description: "Filter by agent kind. Omit to return both.",
+        },
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: 200,
+          description: "Page size in [1, 200]. Defaults to 50 server-side.",
+        },
+        cursor: {
+          type: "string",
+          description:
+            "Opaque pagination cursor returned in the previous page's `next_cursor`. Omit for " +
+            "the first page.",
+        },
+      },
+    },
+  },
+};
+
+const CREATE_JOB_TOOL: ToolDefinition = {
+  type: "function",
+  function: {
+    name: TOOL_NAMES.createJob,
+    description:
+      "Create a new ACP job on chain via JobFactory.createJob. The connected signer must have " +
+      "already approved the JobFactory for `budget` of `token` (the SDK does not move ERC-20 " +
+      "allowance on its own). Returns the new jobId, the deployed clone address, and the tx " +
+      "hash.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["token", "budget", "deadline"],
+      properties: {
+        targetAgentId: {
+          ...DECIMAL_UINT_SCHEMA,
+          description:
+            'Optional agent registry id to target. Pass `"0"` (or omit) to leave the job ' +
+            "open to any active agent.",
+        },
+        token: {
+          ...ADDRESS_SCHEMA,
+          description: "ERC-20 payment token address. Must not be the zero address.",
+        },
+        budget: {
+          ...DECIMAL_UINT_SCHEMA,
+          description: "Amount to lock into Escrow (in token base units). Must be > 0.",
+        },
+        deadline: {
+          ...DECIMAL_UINT_SCHEMA,
+          description: "UNIX seconds after which the job may be expired. Must be in the future.",
+        },
+        jobType: {
+          type: "string",
+          enum: ["direct", "evaluated"],
+          description:
+            "Job type. `evaluated` requires `evaluator`. Defaults to `direct` when omitted.",
+        },
+        evaluator: {
+          ...ADDRESS_SCHEMA,
+          description:
+            "Required iff `jobType` is `evaluated`; ignored otherwise. Must be a non-zero " +
+            "address.",
+        },
+        arbiter: {
+          ...ADDRESS_SCHEMA,
+          description: "Optional arbiter override; falls back to the factory's default arbiter.",
+        },
+        hooks: {
+          type: "array",
+          description: "Optional list of pre-approved hook addresses.",
+          items: ADDRESS_SCHEMA,
+        },
+      },
+    },
+  },
+};
+
+const ALL_TOOLS: readonly ToolDefinition[] = Object.freeze([
+  REGISTER_TOOL,
+  BROWSE_TOOL,
+  CREATE_JOB_TOOL,
+]);
+
+/** Filter accepted by {@link availableTools}. */
+export interface AvailableToolsParams {
+  /**
+   * If provided, only the listed tools are returned. Useful when the host
+   * application wants to expose, say, only read-only tools to a model that
+   * shouldn't be allowed to register agents or spend tokens.
+   */
+  include?: readonly ToolName[];
+}
+
+/**
+ * Return OpenAI / Anthropic / Gemini-compatible tool definitions for every
+ * action {@link import("../agent.js").AcpAgent} currently exposes.
+ *
+ * The result is a fresh array on every call so callers can mutate it without
+ * affecting subsequent calls. Returned tool objects are deeply frozen.
+ *
+ * @example
+ * ```ts
+ * const tools = availableTools();
+ * const completion = await openai.chat.completions.create({ model, tools, messages });
+ * ```
+ */
+export function availableTools(params: AvailableToolsParams = {}): ToolDefinition[] {
+  if (params.include === undefined) return ALL_TOOLS.slice();
+  const allow = new Set<string>(params.include);
+  return ALL_TOOLS.filter((t) => allow.has(t.function.name));
+}

--- a/packages/acp-sdk-ts/src/llm/tools.ts
+++ b/packages/acp-sdk-ts/src/llm/tools.ts
@@ -168,6 +168,8 @@ const CREATE_JOB_TOOL: ToolDefinition = {
   },
 };
 
+// TODO(M5): add tools for AcpAgent.acceptJob, submitResult, release once those
+// methods land on the agent surface (issue #96 deferred per acpAgent scope).
 const ALL_TOOLS: readonly ToolDefinition[] = Object.freeze([
   REGISTER_TOOL,
   BROWSE_TOOL,

--- a/packages/acp-sdk-ts/src/llm/types.ts
+++ b/packages/acp-sdk-ts/src/llm/types.ts
@@ -1,0 +1,124 @@
+// Types for the LLM helpers exposed at `@titular/acp-sdk/llm`.
+//
+// The shapes here intentionally mirror OpenAI's Chat Completions tool / message
+// surface (`{type: "function", function: {name, description, parameters}}` for
+// tools; role-tagged objects for messages) because Anthropic's `messages` API
+// and Gemini's function-calling surface both accept the same shape via official
+// adapters today (Anthropic auto-translates OpenAI-format tools; Gemini exposes
+// `function_declarations` that map 1:1).
+//
+// Keeping the public surface vendor-neutral means consumers can pass our output
+// straight to `openai.chat.completions.create({tools, messages})` or to
+// `anthropic.messages.create({tools, messages})` without an adapter layer.
+//
+// JSON Schema is hand-written rather than generated from Zod because the SDK
+// avoids adding optional runtime deps; the surface is small (a handful of
+// tools) and the schemas are checked against the `AcpAgent` method signatures
+// in unit tests (`tools.test.ts`, `executor.test.ts`).
+
+import type { Agent, Job } from "../types.js";
+
+/**
+ * JSON Schema (draft-07 subset) used in tool `parameters`. Restricted to the
+ * subset the OpenAI / Anthropic / Gemini tool-calling adapters all accept.
+ */
+export interface JsonSchema {
+  type?: "object" | "string" | "number" | "integer" | "boolean" | "array" | "null";
+  description?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean | JsonSchema;
+  items?: JsonSchema;
+  enum?: readonly (string | number | boolean | null)[];
+  /** Inclusive lower bound for numeric types. */
+  minimum?: number;
+  /** Inclusive upper bound for numeric types. */
+  maximum?: number;
+  /** Regex pattern (ECMA-262) for string types. */
+  pattern?: string;
+  /** Minimum item count for array types. */
+  minItems?: number;
+  /** Maximum item count for array types. */
+  maxItems?: number;
+}
+
+/**
+ * OpenAI-compatible tool definition. Anthropic and Gemini both accept this
+ * exact shape (Anthropic since 2024-04, Gemini via the `tools` param on the
+ * v1beta `generateContent` endpoint).
+ */
+export interface ToolDefinition {
+  type: "function";
+  function: {
+    /** Stable, snake_case tool name. Used as the dispatch key in `executeTool`. */
+    name: string;
+    /** Single-paragraph description shown to the model. */
+    description: string;
+    /** JSON Schema for the function's argument object. */
+    parameters: JsonSchema;
+  };
+}
+
+/** Role-tagged message. Mirrors `OpenAI.Chat.Completions.ChatCompletionMessageParam`. */
+export type Message =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string };
+
+/**
+ * Snapshot of agent-side state to render into LLM context. All fields are
+ * optional so callers can render partial views (e.g. only owned jobs without
+ * the full registry).
+ */
+export interface AgentState {
+  /** Optional system-prompt prefix prepended to the message stream. */
+  systemPrompt?: string;
+  /** Agents the model should know about. Typically the result of `agent.browse(...)`. */
+  agents?: readonly Agent[];
+  /** Jobs the model should know about. Typically the result of `gateway.listJobs(...)`. */
+  jobs?: readonly Job[];
+  /**
+   * Optional human-side turn appended after the state snapshot. Useful when
+   * the SDK is feeding state plus an instruction in a single render.
+   */
+  userPrompt?: string;
+}
+
+/**
+ * Tool call as emitted by the model. Matches the OpenAI Chat Completions
+ * `tool_calls[]` element shape; consumers typically pass these through
+ * verbatim.
+ */
+export interface ToolCall {
+  /** Provider-supplied call id. Echoed back in {@link ToolResult.tool_call_id}. */
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    /**
+     * JSON-encoded argument string. Most providers stringify even when the
+     * model emits a JSON object, so the SDK parses it lazily.
+     */
+    arguments: string;
+  };
+}
+
+/**
+ * Result of dispatching a {@link ToolCall} via {@link executeTool}. Shape is
+ * compatible with the `role: "tool"` message both OpenAI and Anthropic accept.
+ */
+export interface ToolResult {
+  role: "tool";
+  /** Echo of {@link ToolCall.id} so the model can correlate the result. */
+  tool_call_id: string;
+  /** Tool name (echoed for Anthropic compatibility — OpenAI ignores it). */
+  name: string;
+  /**
+   * JSON-encoded payload. On success this is the SDK return value with
+   * BigInts coerced to decimal strings. On failure this is `{error: {code, message}}`
+   * — the error is returned, not thrown, so the model can recover.
+   */
+  content: string;
+  /** True iff the dispatch raised. */
+  isError: boolean;
+}


### PR DESCRIPTION
## Summary

Phase `M4-acp-sdk-llm` for milestone M4. Closes #96.

## Test plan

- [ ] `forge test` green
- [ ] `slither` clean (Critical/High/Medium = 0)
- [ ] `go test ./services/...` green where touched
- [ ] reviewer signs off

## Verify

log: `.claude/cron/last-verify-M4-acp-sdk-llm.log`

```
 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   97.24 |    95.08 |     100 |   97.31 |                   
 src               |     100 |    97.32 |     100 |     100 |                   
  ...way-client.ts |     100 |     92.1 |     100 |     100 | 95-97             
 src/llm           |   98.42 |    94.79 |     100 |   99.14 |                   
  executor.ts      |    98.8 |    96.72 |     100 |   98.78 | 151               
  messages.ts      |   96.55 |    90.62 |     100 |     100 | 55-56,119         
 src/providers     |   87.27 |    88.88 |     100 |   86.27 |                   
  alchemy.ts       |   87.27 |    88.88 |     100 |   86.27 | 107-120           
-------------------|---------|----------|---------|---------|-------------------

=============================== Coverage summary ===============================
Statements   : 97.24% ( 318/327 )
Branches     : 95.08% ( 232/244 )
Functions    : 100% ( 55/55 )
Lines        : 97.31% ( 290/298 )
================================================================================
```