### PR TITLE
feat(m4): examples/hello-agent + arb-bot

### DIFF
--- a/examples/arb-bot/.env.example
+++ b/examples/arb-bot/.env.example
@@ -1,0 +1,36 @@
+# Required: Alchemy API key for Base Sepolia RPC.
+ALCHEMY_API_KEY=
+
+# Required: Titular gateway base URL. SSE endpoint is `${GATEWAY_URL}/events`.
+GATEWAY_URL=https://api.titular.dev
+
+# Required: 0x-prefixed 32-byte private key for the bot's controller wallet.
+PRIVATE_KEY=
+
+# Required: Base Sepolia AgentRegistry address.
+AGENT_REGISTRY_ADDRESS=
+
+# Required: Base Sepolia JobFactory address.
+JOB_FACTORY_ADDRESS=
+
+# Required: ERC-20 quote token used to fund arb jobs (e.g. test USDC on Base
+# Sepolia). Bot must have already approved JobFactory for this token.
+QUOTE_TOKEN_ADDRESS=
+
+# Required: comma-separated 0x-hex addresses of agent tokens to monitor. The
+# bot looks for spreads between any two of these.
+AGENT_TOKENS=0x...,0x...
+
+# Optional: minimum price spread (in basis points) before an arb is opened.
+# Default: 50 (= 0.5%).
+MIN_SPREAD_BPS=50
+
+# Optional: budget per arb job, in QUOTE_TOKEN base units. Default: 1000000
+# (= 1 USDC at 6 decimals).
+ARB_BUDGET=1000000
+
+# Optional: cooldown between executions, in milliseconds. Default: 30000.
+COOLDOWN_MS=30000
+
+# Optional: deadline window for created jobs, in seconds. Default: 3600.
+JOB_DEADLINE_SECS=3600

--- a/examples/arb-bot/package.json
+++ b/examples/arb-bot/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@titular/example-arb-bot",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Realistic ACP agent: subscribes to gateway SSE trades, detects price spreads between two agent tokens, and creates an arbitrage job via the SDK.",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node --enable-source-maps dist/index.js",
+    "dev": "tsx src/index.ts",
+    "lint": "biome check src",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@titular/acp-sdk": "workspace:*",
+    "viem": "^2.21.50"
+  },
+  "devDependencies": {
+    "@types/node": "~22.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.5"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/examples/arb-bot/src/__tests__/strategy.test.ts
+++ b/examples/arb-bot/src/__tests__/strategy.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "vitest";
+import {
+  PriceBook,
+  type PriceQuote,
+  type StrategyConfig,
+  type TradeEvent,
+  compareQuotes,
+  detectArb,
+  quoteFromTrade,
+  spreadBps,
+} from "../strategy.js";
+
+const TOKEN_A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const TOKEN_B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const TOKEN_C = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+function buy(agentToken: string, quoteIn: string, agentOut: string, blockNumber = 1): TradeEvent {
+  return { agentToken, side: "buy", quoteIn, agentOut, blockNumber };
+}
+
+function sell(agentToken: string, quoteOut: string, agentIn: string, blockNumber = 1): TradeEvent {
+  return { agentToken, side: "sell", quoteOut, agentIn, blockNumber };
+}
+
+describe("quoteFromTrade", () => {
+  it("derives a price quote from a buy", () => {
+    const q = quoteFromTrade(buy(TOKEN_A, "1000000", "500", 42));
+    expect(q).not.toBeNull();
+    expect(q?.agentToken).toBe(TOKEN_A);
+    expect(q?.numerator).toBe(1_000_000n);
+    expect(q?.denominator).toBe(500n);
+    expect(q?.blockNumber).toBe(42);
+  });
+
+  it("derives a price quote from a sell", () => {
+    const q = quoteFromTrade(sell(TOKEN_A, "750000", "300", 99));
+    expect(q?.numerator).toBe(750_000n);
+    expect(q?.denominator).toBe(300n);
+  });
+
+  it("lowercases mixed-case agent token addresses", () => {
+    const mixed = "0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa";
+    const q = quoteFromTrade(buy(mixed, "1", "1"));
+    expect(q?.agentToken).toBe(TOKEN_A);
+  });
+
+  it("returns null when buy fields are missing", () => {
+    const t: TradeEvent = { agentToken: TOKEN_A, side: "buy", blockNumber: 1 };
+    expect(quoteFromTrade(t)).toBeNull();
+  });
+
+  it("returns null when sell fields are missing", () => {
+    const t: TradeEvent = { agentToken: TOKEN_A, side: "sell", blockNumber: 1 };
+    expect(quoteFromTrade(t)).toBeNull();
+  });
+
+  it("returns null when amounts are zero (would divide by zero)", () => {
+    expect(quoteFromTrade(buy(TOKEN_A, "0", "100"))).toBeNull();
+    expect(quoteFromTrade(buy(TOKEN_A, "100", "0"))).toBeNull();
+  });
+
+  it("returns null on non-decimal junk values", () => {
+    const bad: TradeEvent = {
+      agentToken: TOKEN_A,
+      side: "buy",
+      quoteIn: "0xabc",
+      agentOut: "10",
+      blockNumber: 1,
+    };
+    expect(quoteFromTrade(bad)).toBeNull();
+  });
+
+  it("preserves uint256-scale amounts without precision loss", () => {
+    // 2^200 is well above 2^53; coerced as bigint must round-trip exactly.
+    const huge = (1n << 200n).toString();
+    const q = quoteFromTrade(buy(TOKEN_A, huge, "1"));
+    expect(q?.numerator).toBe(1n << 200n);
+  });
+});
+
+describe("PriceBook", () => {
+  it("retains the most recent quote per token", () => {
+    const book = new PriceBook();
+    const q1: PriceQuote = {
+      agentToken: TOKEN_A,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    };
+    const q2: PriceQuote = {
+      agentToken: TOKEN_A,
+      numerator: 200n,
+      denominator: 1n,
+      blockNumber: 5,
+    };
+    book.observe(q1);
+    book.observe(q2);
+    expect(book.get(TOKEN_A)?.numerator).toBe(200n);
+  });
+
+  it("ignores stale observations (lower block number)", () => {
+    const book = new PriceBook();
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 200n,
+      denominator: 1n,
+      blockNumber: 5,
+    });
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    expect(book.get(TOKEN_A)?.numerator).toBe(200n);
+  });
+
+  it("looks up case-insensitively", () => {
+    const book = new PriceBook();
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 1n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    expect(book.get(TOKEN_A.toUpperCase())).toBeDefined();
+  });
+
+  it("snapshot returns one entry per token", () => {
+    const book = new PriceBook();
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 1n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    book.observe({
+      agentToken: TOKEN_B,
+      numerator: 2n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 3n,
+      denominator: 1n,
+      blockNumber: 2,
+    });
+    expect(book.snapshot()).toHaveLength(2);
+  });
+});
+
+describe("spreadBps + compareQuotes", () => {
+  it("computes a 0-bps spread for equal prices", () => {
+    const a: PriceQuote = {
+      agentToken: TOKEN_A,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    };
+    const b: PriceQuote = {
+      agentToken: TOKEN_B,
+      numerator: 200n,
+      denominator: 2n,
+      blockNumber: 1,
+    };
+    expect(spreadBps(a, b)).toBe(0);
+    expect(compareQuotes(a, b)).toBe(0);
+  });
+
+  it("computes 100 bps for a 1% spread", () => {
+    // 100 vs 101 → ~1% spread
+    const cheap: PriceQuote = {
+      agentToken: TOKEN_A,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    };
+    const rich: PriceQuote = {
+      agentToken: TOKEN_B,
+      numerator: 101n,
+      denominator: 1n,
+      blockNumber: 1,
+    };
+    expect(spreadBps(cheap, rich)).toBe(100);
+    expect(compareQuotes(cheap, rich)).toBe(-1);
+    expect(compareQuotes(rich, cheap)).toBe(1);
+  });
+
+  it("is symmetric", () => {
+    const a: PriceQuote = {
+      agentToken: TOKEN_A,
+      numerator: 90n,
+      denominator: 1n,
+      blockNumber: 1,
+    };
+    const b: PriceQuote = {
+      agentToken: TOKEN_B,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    };
+    expect(spreadBps(a, b)).toBe(spreadBps(b, a));
+  });
+});
+
+describe("detectArb", () => {
+  const config: StrategyConfig = {
+    minSpreadBps: 50,
+    watchedTokens: [TOKEN_A, TOKEN_B, TOKEN_C],
+  };
+
+  it("returns null when fewer than two tokens are quoted", () => {
+    const book = new PriceBook();
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    expect(detectArb(book, config)).toBeNull();
+  });
+
+  it("returns null when the spread is below threshold", () => {
+    const book = new PriceBook();
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 1000n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    book.observe({
+      agentToken: TOKEN_B,
+      numerator: 1001n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    // spread is 10 bps, threshold is 50 bps → ignored
+    expect(detectArb(book, config)).toBeNull();
+  });
+
+  it("emits an opportunity when threshold is crossed", () => {
+    const book = new PriceBook();
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    book.observe({
+      agentToken: TOKEN_B,
+      numerator: 101n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    const opp = detectArb(book, { ...config, minSpreadBps: 50 });
+    expect(opp).not.toBeNull();
+    expect(opp?.cheapToken).toBe(TOKEN_A);
+    expect(opp?.richToken).toBe(TOKEN_B);
+    expect(opp?.spreadBps).toBe(100);
+  });
+
+  it("picks the widest spread when multiple pairs qualify", () => {
+    const book = new PriceBook();
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    book.observe({
+      agentToken: TOKEN_B,
+      numerator: 101n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    book.observe({
+      agentToken: TOKEN_C,
+      numerator: 110n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    const opp = detectArb(book, config);
+    expect(opp?.cheapToken).toBe(TOKEN_A);
+    expect(opp?.richToken).toBe(TOKEN_C);
+  });
+
+  it("ignores tokens not in the watch list", () => {
+    const ROGUE = "0xdddddddddddddddddddddddddddddddddddddddd";
+    const book = new PriceBook();
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    book.observe({
+      agentToken: ROGUE,
+      numerator: 1000n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    expect(detectArb(book, config)).toBeNull();
+  });
+
+  it("is deterministic — same inputs return identical opportunities", () => {
+    const book = new PriceBook();
+    book.observe({
+      agentToken: TOKEN_A,
+      numerator: 100n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    book.observe({
+      agentToken: TOKEN_B,
+      numerator: 105n,
+      denominator: 1n,
+      blockNumber: 1,
+    });
+    const a = detectArb(book, config);
+    const b = detectArb(book, config);
+    expect(a).toEqual(b);
+  });
+});

--- a/examples/arb-bot/src/index.ts
+++ b/examples/arb-bot/src/index.ts
@@ -1,0 +1,330 @@
+// arb-bot — connects to the Titular gateway SSE stream, watches `trades.*`
+// events, and opens an ACP job whenever the spread between two configured
+// agent tokens exceeds the configured threshold.
+//
+// State machine:
+//
+//                ┌──────────┐
+//                │   idle   │  ◄── boot
+//                └──────────┘
+//                     │ first SSE event
+//                     ▼
+//                ┌──────────┐
+//                │ scanning │  ◄────────────────┐
+//                └──────────┘                   │
+//                     │ detectArb >= threshold  │
+//                     ▼                         │
+//                ┌──────────┐                   │
+//                │executing │  createJob (1 tx) │
+//                └──────────┘                   │
+//                     │ tx confirmed            │
+//                     ▼                         │
+//                ┌──────────┐ cooldown elapsed  │
+//                │ cooldown │ ──────────────────┘
+//                └──────────┘
+//
+// We deliberately consume the gateway SSE stream rather than connecting
+// directly to NATS so the example mirrors what an external developer can
+// reach without infra access. The stream format is documented in
+// services/gateway-go/internal/sse/handler.go (subjects=trades.*).
+//
+// What this example demonstrates:
+//   - SSE consumption against the gateway, with reconnect-on-error.
+//   - Pure-function strategy module that's testable in isolation.
+//   - SDK usage: `AcpAgent.createJob(...)` against Base Sepolia, with
+//     evaluator/arbiter left to factory defaults.
+//   - State-machine discipline (no concurrent createJob calls).
+//
+// What it does NOT do:
+//   - Move ERC-20 allowance — the bot's wallet must have already approved
+//     the JobFactory for QUOTE_TOKEN.
+//   - Actually execute the arb on chain. The created job carries the
+//     intent; a downstream agent (or the bot's own future M5 surface)
+//     would `acceptJob` + `submitResult` to settle.
+
+import {
+  AcpAgent,
+  AlchemyEvmProviderAdapter,
+  type CreateJobResult,
+  type EvmAddress,
+} from "@titular/acp-sdk";
+import type { Hex } from "viem";
+import {
+  type ArbOpportunity,
+  PriceBook,
+  type StrategyConfig,
+  type TradeEvent,
+  detectArb,
+  quoteFromTrade,
+} from "./strategy.js";
+
+interface Config {
+  alchemyApiKey: string;
+  gatewayUrl: string;
+  privateKey: Hex;
+  agentRegistry: EvmAddress;
+  jobFactory: EvmAddress;
+  quoteToken: EvmAddress;
+  agentTokens: readonly string[];
+  minSpreadBps: number;
+  arbBudget: bigint;
+  cooldownMs: number;
+  jobDeadlineSecs: number;
+}
+
+type State = "idle" | "scanning" | "executing" | "cooldown";
+
+function loadConfig(): Config {
+  const requireEnv = (key: string): string => {
+    const v = process.env[key];
+    if (v === undefined || v.length === 0) {
+      throw new Error(`missing required env var: ${key}`);
+    }
+    return v;
+  };
+  const optional = (key: string, fallback: string): string => process.env[key] ?? fallback;
+  const requireAddress = (key: string): EvmAddress => {
+    const v = requireEnv(key);
+    if (!/^0x[0-9a-fA-F]{40}$/.test(v)) {
+      throw new Error(`${key} must be a 0x-prefixed 20-byte hex address`);
+    }
+    return v.toLowerCase() as EvmAddress;
+  };
+  const privateKey = requireEnv("PRIVATE_KEY");
+  if (!/^0x[0-9a-fA-F]{64}$/.test(privateKey)) {
+    throw new Error("PRIVATE_KEY must be a 0x-prefixed 32-byte hex string");
+  }
+  const tokensRaw = requireEnv("AGENT_TOKENS");
+  const agentTokens = tokensRaw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+  if (agentTokens.length < 2) {
+    throw new Error("AGENT_TOKENS must list at least 2 comma-separated 0x-hex addresses");
+  }
+  for (const t of agentTokens) {
+    if (!/^0x[0-9a-fA-F]{40}$/.test(t)) {
+      throw new Error(`AGENT_TOKENS contains an invalid address: ${t}`);
+    }
+  }
+  return {
+    alchemyApiKey: requireEnv("ALCHEMY_API_KEY"),
+    gatewayUrl: requireEnv("GATEWAY_URL").replace(/\/+$/, ""),
+    privateKey: privateKey as Hex,
+    agentRegistry: requireAddress("AGENT_REGISTRY_ADDRESS"),
+    jobFactory: requireAddress("JOB_FACTORY_ADDRESS"),
+    quoteToken: requireAddress("QUOTE_TOKEN_ADDRESS"),
+    agentTokens,
+    minSpreadBps: Number.parseInt(optional("MIN_SPREAD_BPS", "50"), 10),
+    arbBudget: BigInt(optional("ARB_BUDGET", "1000000")),
+    cooldownMs: Number.parseInt(optional("COOLDOWN_MS", "30000"), 10),
+    jobDeadlineSecs: Number.parseInt(optional("JOB_DEADLINE_SECS", "3600"), 10),
+  };
+}
+
+interface SseTradeEnvelope {
+  subject?: string;
+  payload?: {
+    curve?: string;
+    side?: "buy" | "sell";
+    quote_in?: string;
+    agent_out?: string;
+    agent_in?: string;
+    quote_out?: string;
+    block_number?: number;
+    agent_token?: string;
+  };
+}
+
+/** Minimal SSE line parser. Splits on double-newline events; ignores comments. */
+async function* readSseEvents(response: Response): AsyncGenerator<SseTradeEnvelope> {
+  if (response.body === null) {
+    throw new Error("SSE response has no body");
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) return;
+    buffer += decoder.decode(value, { stream: true });
+    let sep = buffer.indexOf("\n\n");
+    while (sep !== -1) {
+      const block = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      sep = buffer.indexOf("\n\n");
+      const dataLine = block
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.startsWith("data:"))
+        .map((l) => l.slice("data:".length).trim())
+        .join("");
+      if (dataLine.length === 0) continue;
+      try {
+        yield JSON.parse(dataLine) as SseTradeEnvelope;
+      } catch {
+        // ignore malformed events; the gateway only emits JSON but a
+        // misbehaving proxy might inject keepalive comments etc.
+      }
+    }
+  }
+}
+
+/** Translate a gateway SSE envelope into a {@link TradeEvent}, or `null` if it doesn't apply. */
+function envelopeToTrade(env: SseTradeEnvelope): TradeEvent | null {
+  if (env.subject === undefined || !env.subject.startsWith("trades.")) return null;
+  const p = env.payload;
+  if (p === undefined) return null;
+  const agentToken = (p.agent_token ?? p.curve ?? "").toLowerCase();
+  if (!/^0x[0-9a-fA-F]{40}$/.test(agentToken)) return null;
+  const side = p.side;
+  if (side !== "buy" && side !== "sell") return null;
+  const trade: TradeEvent = {
+    agentToken,
+    side,
+    blockNumber: p.block_number ?? 0,
+  };
+  if (p.quote_in !== undefined) trade.quoteIn = p.quote_in;
+  if (p.quote_out !== undefined) trade.quoteOut = p.quote_out;
+  if (p.agent_in !== undefined) trade.agentIn = p.agent_in;
+  if (p.agent_out !== undefined) trade.agentOut = p.agent_out;
+  return trade;
+}
+
+async function executeArb(
+  acp: AcpAgent,
+  config: Config,
+  opp: ArbOpportunity
+): Promise<CreateJobResult> {
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + config.jobDeadlineSecs);
+  console.log(
+    `[arb-bot] executing arb cheap=${opp.cheapToken} rich=${opp.richToken} ` +
+      `spread=${opp.spreadBps}bps budget=${config.arbBudget.toString()} deadline=${deadline.toString()}`
+  );
+  const result = await acp.createJob({
+    token: config.quoteToken,
+    budget: config.arbBudget,
+    deadline,
+  });
+  console.log(
+    `[arb-bot] job created jobId=${result.jobId.toString()} clone=${result.cloneAddress} ` +
+      `tx=${result.txHash}`
+  );
+  return result;
+}
+
+async function streamTrades(
+  config: Config,
+  onEvent: (env: SseTradeEnvelope) => void,
+  abort: AbortSignal
+): Promise<void> {
+  const url = `${config.gatewayUrl}/events?subjects=trades.*`;
+  const res = await fetch(url, {
+    headers: { Accept: "text/event-stream" },
+    signal: abort,
+  });
+  if (!res.ok) {
+    throw new Error(`SSE connect failed: ${res.status} ${res.statusText}`);
+  }
+  for await (const env of readSseEvents(res)) {
+    if (abort.aborted) return;
+    onEvent(env);
+  }
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  console.log(
+    `[arb-bot] starting on base-sepolia; watching ${config.agentTokens.length} tokens; ` +
+      `min spread=${config.minSpreadBps}bps`
+  );
+
+  const provider = new AlchemyEvmProviderAdapter({
+    apiKey: config.alchemyApiKey,
+    chain: "base-sepolia",
+    privateKey: config.privateKey,
+  });
+  const acp = new AcpAgent({
+    provider,
+    gatewayUrl: config.gatewayUrl,
+    contracts: {
+      agentRegistry: config.agentRegistry,
+      jobFactory: config.jobFactory,
+    },
+  });
+
+  const book = new PriceBook();
+  const strategyConfig: StrategyConfig = {
+    minSpreadBps: config.minSpreadBps,
+    watchedTokens: config.agentTokens,
+  };
+  let state: State = "idle";
+  let cooldownUntil = 0;
+
+  const ac = new AbortController();
+  const onShutdown = (): void => {
+    console.log("[arb-bot] shutdown signal received");
+    ac.abort();
+  };
+  process.once("SIGINT", onShutdown);
+  process.once("SIGTERM", onShutdown);
+
+  // Reconnect loop. SSE drops are normal (proxy rotations, gateway
+  // redeploys); we backoff exponentially up to 30 s.
+  let backoffMs = 1000;
+  while (!ac.signal.aborted) {
+    try {
+      state = "scanning";
+      console.log(`[arb-bot] connecting to ${config.gatewayUrl}/events`);
+      await streamTrades(
+        config,
+        (env) => {
+          const trade = envelopeToTrade(env);
+          if (trade === null) return;
+          if (!config.agentTokens.includes(trade.agentToken)) return;
+          const quote = quoteFromTrade(trade);
+          if (quote === null) return;
+          book.observe(quote);
+          if (state !== "scanning") return;
+          if (Date.now() < cooldownUntil) return;
+          const opp = detectArb(book, strategyConfig);
+          if (opp === null) return;
+          state = "executing";
+          executeArb(acp, config, opp)
+            .catch((err: unknown) => {
+              console.error(`[arb-bot] arb execution failed: ${(err as Error).message}`);
+            })
+            .finally(() => {
+              cooldownUntil = Date.now() + config.cooldownMs;
+              state = "cooldown";
+              console.log(`[arb-bot] cooling down for ${config.cooldownMs}ms`);
+              setTimeout(() => {
+                if (!ac.signal.aborted) state = "scanning";
+              }, config.cooldownMs);
+            });
+        },
+        ac.signal
+      );
+      // streamTrades returned cleanly (gateway closed the connection); reset
+      // backoff and reconnect.
+      backoffMs = 1000;
+    } catch (err) {
+      if (ac.signal.aborted) break;
+      console.error(
+        `[arb-bot] sse error, reconnecting in ${backoffMs}ms: ${(err as Error).message}`
+      );
+      await sleep(backoffMs);
+      backoffMs = Math.min(backoffMs * 2, 30_000);
+    }
+  }
+  console.log("[arb-bot] exited cleanly");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+main().catch((err) => {
+  console.error("[arb-bot] fatal:", err);
+  process.exit(1);
+});

--- a/examples/arb-bot/src/strategy.ts
+++ b/examples/arb-bot/src/strategy.ts
@@ -1,0 +1,199 @@
+// strategy.ts — pure functions implementing the arb-bot's decision logic.
+//
+// Kept dependency-free (no SDK, no fetch, no chain calls) so it round-trips
+// through vitest without any IO. The main loop in `index.ts` is responsible
+// for feeding live trade events in and acting on the returned opportunities.
+//
+// Pricing model:
+//   - We treat each `Trade` as a quote-per-agent observation. For a buy,
+//     `quoteIn / agentOut` is the effective price the trader paid. For a
+//     sell, `quoteOut / agentIn` is the effective price the trader received.
+//   - We hold the most recent observation per agent token and compute the
+//     spread in basis points between any two tokens. The "rich" leg is the
+//     one with the higher price; the "cheap" leg is the lower.
+//   - Spread is symmetric (`|a-b| / min(a,b)`) so the order in which two
+//     observations arrive doesn't change the signal.
+//
+// This is intentionally naive — a production bot would model fee tiers,
+// slippage, gas, and inventory risk. The goal here is "smallest realistic
+// state machine an agent author can read in one sitting".
+
+/** Side of a trade as the gateway emits it (`store.Trade.side`). */
+export type TradeSide = "buy" | "sell";
+
+/**
+ * Subset of `store.Trade` the strategy actually consumes. Inputs are decimal-
+ * encoded uint256 strings; the strategy never coerces them to JS numbers
+ * (precision loss above 2^53).
+ */
+export interface TradeEvent {
+  /** Agent-token address, lowercase 0x-hex. */
+  agentToken: string;
+  side: TradeSide;
+  /** Decimal-encoded uint256 amount of the quote asset entering the curve. */
+  quoteIn?: string;
+  /** Decimal-encoded uint256 amount of the agent token leaving the curve. */
+  agentOut?: string;
+  /** Decimal-encoded uint256 amount of the agent token entering the curve. */
+  agentIn?: string;
+  /** Decimal-encoded uint256 amount of the quote asset leaving the curve. */
+  quoteOut?: string;
+  /** Block number the trade landed in (used as a tiebreaker for "most recent"). */
+  blockNumber: number;
+}
+
+/** A single price observation derived from a {@link TradeEvent}. */
+export interface PriceQuote {
+  agentToken: string;
+  /** quote-per-agent, as a `bigint` rational (numerator / denominator). */
+  numerator: bigint;
+  denominator: bigint;
+  blockNumber: number;
+}
+
+/** A detected arb opportunity between two agent tokens. */
+export interface ArbOpportunity {
+  cheapToken: string;
+  richToken: string;
+  /** Spread between the two prices, in basis points (1 bps = 0.01%). */
+  spreadBps: number;
+  /** The two quotes that produced the signal. */
+  cheap: PriceQuote;
+  rich: PriceQuote;
+}
+
+/** Configuration for the strategy. */
+export interface StrategyConfig {
+  /** Minimum spread (basis points) to surface as an opportunity. */
+  minSpreadBps: number;
+  /** Lowercased addresses of the agent tokens the bot is allowed to act on. */
+  watchedTokens: readonly string[];
+}
+
+/**
+ * Convert a {@link TradeEvent} to a {@link PriceQuote}. Returns `null` when
+ * the trade carries insufficient data (e.g. zero amounts) — those events
+ * MUST NOT update the price book.
+ */
+export function quoteFromTrade(t: TradeEvent): PriceQuote | null {
+  if (t.side === "buy") {
+    if (t.quoteIn === undefined || t.agentOut === undefined) return null;
+    const num = parseDecimal(t.quoteIn);
+    const den = parseDecimal(t.agentOut);
+    if (num === null || den === null || den === 0n || num === 0n) return null;
+    return {
+      agentToken: t.agentToken.toLowerCase(),
+      numerator: num,
+      denominator: den,
+      blockNumber: t.blockNumber,
+    };
+  }
+  // sell
+  if (t.quoteOut === undefined || t.agentIn === undefined) return null;
+  const num = parseDecimal(t.quoteOut);
+  const den = parseDecimal(t.agentIn);
+  if (num === null || den === null || den === 0n || num === 0n) return null;
+  return {
+    agentToken: t.agentToken.toLowerCase(),
+    numerator: num,
+    denominator: den,
+    blockNumber: t.blockNumber,
+  };
+}
+
+/**
+ * Stateful price book — keeps the most recent quote per agent token (most
+ * recent meaning highest `blockNumber` seen). Pure data structure; the main
+ * loop owns the lifetime.
+ */
+export class PriceBook {
+  readonly #quotes = new Map<string, PriceQuote>();
+
+  /** Replace the cached quote for `q.agentToken` if `q` is newer. */
+  observe(q: PriceQuote): void {
+    const key = q.agentToken.toLowerCase();
+    const prev = this.#quotes.get(key);
+    if (prev === undefined || q.blockNumber >= prev.blockNumber) {
+      this.#quotes.set(key, q);
+    }
+  }
+
+  /** Snapshot of all known quotes. Order is insertion order. */
+  snapshot(): PriceQuote[] {
+    return Array.from(this.#quotes.values());
+  }
+
+  /** Latest quote for `token`, or `undefined`. */
+  get(token: string): PriceQuote | undefined {
+    return this.#quotes.get(token.toLowerCase());
+  }
+}
+
+/**
+ * Scan the price book for an arb opportunity exceeding `minSpreadBps`.
+ *
+ * Returns the highest-spread pair drawn from `watchedTokens`. When no pair
+ * meets the threshold, returns `null`. The function is pure — given the same
+ * book + config, it always returns the same opportunity.
+ */
+export function detectArb(book: PriceBook, config: StrategyConfig): ArbOpportunity | null {
+  const watched = config.watchedTokens.map((t) => t.toLowerCase());
+  const quotes = watched.map((t) => book.get(t)).filter((q): q is PriceQuote => q !== undefined);
+  if (quotes.length < 2) return null;
+
+  let best: ArbOpportunity | null = null;
+  for (let i = 0; i < quotes.length; i += 1) {
+    for (let j = i + 1; j < quotes.length; j += 1) {
+      const a = quotes[i]!;
+      const b = quotes[j]!;
+      const bps = spreadBps(a, b);
+      if (bps < config.minSpreadBps) continue;
+      const [cheap, rich] = compareQuotes(a, b) < 0 ? [a, b] : [b, a];
+      const candidate: ArbOpportunity = {
+        cheapToken: cheap.agentToken,
+        richToken: rich.agentToken,
+        spreadBps: bps,
+        cheap,
+        rich,
+      };
+      if (best === null || candidate.spreadBps > best.spreadBps) {
+        best = candidate;
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Compute the spread between two price quotes in basis points. Symmetric:
+ * `spreadBps(a, b) === spreadBps(b, a)`.
+ */
+export function spreadBps(a: PriceQuote, b: PriceQuote): number {
+  // a = aN/aD, b = bN/bD. |a-b| / min(a,b) in basis points
+  // |aN*bD - bN*aD| / min(aN*bD, bN*aD) * 10000
+  const aCross = a.numerator * b.denominator;
+  const bCross = b.numerator * a.denominator;
+  const diff = aCross > bCross ? aCross - bCross : bCross - aCross;
+  const minCross = aCross < bCross ? aCross : bCross;
+  if (minCross === 0n) return 0;
+  // Multiply by 10000 BEFORE the divide to keep precision; then floor.
+  const bps = (diff * 10000n) / minCross;
+  // bps is bounded by reasonable spreads; safe to coerce to number for the
+  // configurable threshold which is itself a JS number.
+  if (bps > BigInt(Number.MAX_SAFE_INTEGER)) return Number.MAX_SAFE_INTEGER;
+  return Number(bps);
+}
+
+/** -1 if a < b, 1 if a > b, 0 if equal. Compares rationals without floating point. */
+export function compareQuotes(a: PriceQuote, b: PriceQuote): -1 | 0 | 1 {
+  const left = a.numerator * b.denominator;
+  const right = b.numerator * a.denominator;
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function parseDecimal(s: string): bigint | null {
+  if (!/^(0|[1-9][0-9]*)$/.test(s)) return null;
+  return BigInt(s);
+}

--- a/examples/arb-bot/tsconfig.json
+++ b/examples/arb-bot/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
+    "noEmit": false,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/__tests__/**/*"]
+}

--- a/examples/arb-bot/vitest.config.ts
+++ b/examples/arb-bot/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: false,
+    include: ["src/__tests__/**/*.test.ts"],
+  },
+});

--- a/examples/hello-agent/.env.example
+++ b/examples/hello-agent/.env.example
@@ -1,0 +1,27 @@
+# Required: Alchemy API key for Base Sepolia RPC.
+ALCHEMY_API_KEY=
+
+# Required: Titular gateway base URL. Use the public alpha endpoint or your local
+# gateway-go instance (default `http://localhost:8080`).
+GATEWAY_URL=https://api.titular.dev
+
+# Required: 0x-prefixed 32-byte private key for the agent's controller wallet.
+# The wallet must hold a small amount of Base Sepolia ETH for gas.
+PRIVATE_KEY=
+
+# Required: Base Sepolia AgentRegistry address (provided by the deployment you
+# are connecting to).
+AGENT_REGISTRY_ADDRESS=
+
+# Required: Base Sepolia JobFactory address.
+JOB_FACTORY_ADDRESS=
+
+# Optional: ipfs:// or https:// URI describing this agent. A trivial JSON file
+# served from any static host is sufficient for the example.
+METADATA_URI=ipfs://bafy-replace-me
+
+# Optional: capability bitmap (decimal). Defaults to 1 (a single capability).
+CAPABILITIES=1
+
+# Optional: poll interval in milliseconds. Defaults to 10000.
+POLL_INTERVAL_MS=10000

--- a/examples/hello-agent/README.md
+++ b/examples/hello-agent/README.md
@@ -1,0 +1,93 @@
+# hello-agent
+
+Smallest possible end-to-end ACP agent built on `@titular/acp-sdk`. Registers
+itself on chain, then polls the gateway for jobs targeting its `agentId` and
+acknowledges the first match.
+
+## What it shows
+
+- Constructing an `AlchemyEvmProviderAdapter` against Base Sepolia.
+- Registering an agent via `AcpAgent.register(...)` and getting back an
+  `agentId`.
+- Listing jobs against the gateway's `/api/v1/jobs` endpoint via
+  `acp.gateway.listJobs({ status: "created" })`.
+- Rendering on-chain state into LLM-ready messages with
+  `@titular/acp-sdk/llm` (`availableTools`, `toMessages`).
+
+It deliberately stops short of `acceptJob` / `submitResult` — those surface
+on the SDK in M5. The example is intended as a 200-LOC starting point you
+copy and extend.
+
+## Requirements
+
+- Node.js >= 22
+- pnpm >= 10
+- Base Sepolia ETH on the controller wallet (a few drops; only register
+  costs gas in this example).
+- Access to a deployed AgentRegistry + JobFactory on Base Sepolia, plus
+  the URL of a Titular gateway pointed at that deployment.
+
+## Setup
+
+```bash
+cd examples/hello-agent
+cp .env.example .env
+# edit .env — fill in ALCHEMY_API_KEY, GATEWAY_URL, PRIVATE_KEY,
+# AGENT_REGISTRY_ADDRESS, JOB_FACTORY_ADDRESS.
+pnpm install
+```
+
+## Run
+
+Dev (no build step, source-mapped errors):
+
+```bash
+pnpm --filter @titular/example-hello-agent dev
+```
+
+Built (matches what you'd ship):
+
+```bash
+pnpm --filter @titular/example-hello-agent build
+pnpm --filter @titular/example-hello-agent start
+```
+
+## Expected output
+
+```
+[hello-agent] starting on base-sepolia
+[hello-agent] controller: 0xabc...
+[hello-agent] registered agentId=42 tx=0x... metadataUri=ipfs://...
+[hello-agent] LLM tools available: acp_register, acp_browse, acp_create_job
+[hello-agent] polling https://api.titular.dev every 10000ms for jobs targeting agent 42
+[hello-agent] picked up job id=17 on_chain_id=... clone=0x... budget=1000000 deadline=...
+[hello-agent] would submit result via job clone 0x...; LLM context = 3 messages
+[hello-agent] done, handled 1 job(s)
+```
+
+To loop instead of exiting after the first job, set `STOP_AFTER_JOBS` to a
+large integer.
+
+## Environment variables
+
+See `.env.example` for the full list. Required:
+
+| Var                     | Purpose                                            |
+| ----------------------- | -------------------------------------------------- |
+| `ALCHEMY_API_KEY`       | Alchemy key with Base Sepolia access.              |
+| `GATEWAY_URL`           | Titular gateway base URL.                          |
+| `PRIVATE_KEY`           | 0x-prefixed 32-byte private key (controller).      |
+| `AGENT_REGISTRY_ADDRESS`| AgentRegistry on Base Sepolia.                     |
+| `JOB_FACTORY_ADDRESS`   | JobFactory on Base Sepolia.                        |
+
+Optional: `METADATA_URI`, `CAPABILITIES`, `POLL_INTERVAL_MS`, `STOP_AFTER_JOBS`.
+
+## Next steps
+
+- Replace the "would submit result" log with a real `submitResult` call once
+  the SDK exposes it (tracked under M5).
+- Wire the LLM helpers up to a model: feed `availableTools()` and
+  `toMessages(state, ...)` to `openai.chat.completions.create({ tools, messages })`
+  and dispatch the resulting `tool_calls[]` through `executeTool(acp, call)`.
+- Persist `agentId` between runs — re-registering on every boot creates a
+  fresh agent, which is fine for demos but not for production agents.

--- a/examples/hello-agent/package.json
+++ b/examples/hello-agent/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@titular/example-hello-agent",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Minimal end-to-end ACP agent: registers, polls the gateway for jobs targeted at it, accepts the first one, and submits a hello-world result.",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node --enable-source-maps dist/index.js",
+    "dev": "tsx src/index.ts",
+    "lint": "biome check src",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@titular/acp-sdk": "workspace:*",
+    "viem": "^2.21.50"
+  },
+  "devDependencies": {
+    "@types/node": "~22.0.0",
+    "tsx": "^4.19.2",
+    "typescript": "~5.6.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/examples/hello-agent/src/index.ts
+++ b/examples/hello-agent/src/index.ts
@@ -1,0 +1,172 @@
+// hello-agent — the smallest possible end-to-end ACP agent.
+//
+// Flow:
+//   1. Build an `AlchemyEvmProviderAdapter` from PRIVATE_KEY against Base
+//      Sepolia.
+//   2. Construct an `AcpAgent` with the configured AgentRegistry + JobFactory
+//      addresses.
+//   3. Register the agent on chain (idempotent across runs only when
+//      AGENT_ID is provided in env — a fresh run with no AGENT_ID always
+//      mints a new one).
+//   4. Poll the gateway every POLL_INTERVAL_MS for jobs in phase `created`
+//      that target this agent's id.
+//   5. On the first match, log the job and write a hello-world result line
+//      to stdout. Real agents would call `submitResult(...)` against the
+//      job clone here; the SDK exposes the gateway and provider primitives
+//      and this example stops short of that step so it stays under 200 LOC
+//      and runnable without an evaluator/arbiter setup.
+//
+// Why no `acceptJob` / `submitResult` SDK call? Those land in M5 (#100, #101).
+// Until then, the example demonstrates the public M4 surface: `register`,
+// `browse`, `gateway.listJobs`, plus the LLM helpers used to render state.
+//
+// LOC target: ~200. Keep it readable; no clever abstractions.
+
+import { AcpAgent, AlchemyEvmProviderAdapter, type EvmAddress } from "@titular/acp-sdk";
+import { availableTools, toMessages } from "@titular/acp-sdk/llm";
+import type { Hex } from "viem";
+
+interface Config {
+  alchemyApiKey: string;
+  gatewayUrl: string;
+  privateKey: Hex;
+  agentRegistry: EvmAddress;
+  jobFactory: EvmAddress;
+  metadataUri: string;
+  capabilities: bigint;
+  pollIntervalMs: number;
+}
+
+function loadConfig(): Config {
+  const requireEnv = (key: string): string => {
+    const v = process.env[key];
+    if (v === undefined || v.length === 0) {
+      throw new Error(`missing required env var: ${key}`);
+    }
+    return v;
+  };
+  const optional = (key: string, fallback: string): string => process.env[key] ?? fallback;
+
+  const privateKey = requireEnv("PRIVATE_KEY");
+  if (!/^0x[0-9a-fA-F]{64}$/.test(privateKey)) {
+    throw new Error("PRIVATE_KEY must be a 0x-prefixed 32-byte hex string");
+  }
+  const agentRegistry = requireEnv("AGENT_REGISTRY_ADDRESS");
+  const jobFactory = requireEnv("JOB_FACTORY_ADDRESS");
+  if (!/^0x[0-9a-fA-F]{40}$/.test(agentRegistry) || !/^0x[0-9a-fA-F]{40}$/.test(jobFactory)) {
+    throw new Error("AGENT_REGISTRY_ADDRESS / JOB_FACTORY_ADDRESS must be 20-byte hex addresses");
+  }
+  const pollMs = Number.parseInt(optional("POLL_INTERVAL_MS", "10000"), 10);
+  if (!Number.isFinite(pollMs) || pollMs < 1000) {
+    throw new Error("POLL_INTERVAL_MS must be an integer >= 1000");
+  }
+  return {
+    alchemyApiKey: requireEnv("ALCHEMY_API_KEY"),
+    gatewayUrl: requireEnv("GATEWAY_URL"),
+    privateKey: privateKey as Hex,
+    agentRegistry: agentRegistry.toLowerCase() as EvmAddress,
+    jobFactory: jobFactory.toLowerCase() as EvmAddress,
+    metadataUri: optional("METADATA_URI", "ipfs://bafy-replace-me"),
+    capabilities: BigInt(optional("CAPABILITIES", "1")),
+    pollIntervalMs: pollMs,
+  };
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  console.log("[hello-agent] starting on base-sepolia");
+
+  const provider = new AlchemyEvmProviderAdapter({
+    apiKey: config.alchemyApiKey,
+    chain: "base-sepolia",
+    privateKey: config.privateKey,
+  });
+  const acp = new AcpAgent({
+    provider,
+    gatewayUrl: config.gatewayUrl,
+    contracts: {
+      agentRegistry: config.agentRegistry,
+      jobFactory: config.jobFactory,
+    },
+  });
+
+  // Step 1: register on chain.
+  const controller = await provider.getAddress();
+  console.log(`[hello-agent] controller: ${controller}`);
+
+  const registered = await acp.register({
+    metadataUri: config.metadataUri,
+    capabilities: config.capabilities,
+  });
+  const myAgentId = registered.agentId;
+  console.log(
+    `[hello-agent] registered agentId=${myAgentId.toString()} tx=${registered.txHash} ` +
+      `metadataUri=${registered.metadataUri}`
+  );
+
+  // Tools surface — show that the LLM helpers are available out of the box,
+  // even when this minimal example doesn't actually call a model. Real agents
+  // would feed `tools` and `messages` to OpenAI / Anthropic / Gemini.
+  const tools = availableTools();
+  console.log(`[hello-agent] LLM tools available: ${tools.map((t) => t.function.name).join(", ")}`);
+
+  // Step 2: poll for jobs. We use the public gateway listJobs endpoint
+  // (read-only) and filter client-side to jobs targeting our agentId. The
+  // gateway does not currently expose a `target_agent_id` filter, so client-
+  // side filtering is correct — it costs at most one extra page fetch per
+  // poll on quiet networks.
+  console.log(
+    `[hello-agent] polling ${config.gatewayUrl} every ${config.pollIntervalMs}ms for jobs ` +
+      `targeting agent ${myAgentId.toString()}`
+  );
+
+  const stopAfter = Number.parseInt(process.env.STOP_AFTER_JOBS ?? "1", 10);
+  let handled = 0;
+  while (handled < stopAfter) {
+    try {
+      const page = await acp.gateway.listJobs({ status: "created", limit: 50 });
+      const myJobs = page.data.filter((j) => j.agent_id === myAgentId.toString());
+
+      if (myJobs.length === 0) {
+        await sleep(config.pollIntervalMs);
+        continue;
+      }
+
+      const job = myJobs[0]!;
+      handled += 1;
+      console.log(
+        `[hello-agent] picked up job id=${job.id} on_chain_id=${job.on_chain_id ?? "?"} ` +
+          `clone=${job.clone_address ?? "?"} budget=${job.budget} deadline=${job.deadline}`
+      );
+
+      // Step 3: submit a hello-world result. A real agent would call
+      // `submitResult(resultURI)` on the job clone here; for the example
+      // we just log what we WOULD submit. The SDK lands `submitResult` in
+      // M5 alongside the rest of the agent-side action surface.
+      const messages = toMessages(
+        {
+          jobs: [job],
+          userPrompt: "Acknowledge the job and produce a hello-world result URI.",
+        },
+        { redactAddresses: true }
+      );
+      console.log(
+        `[hello-agent] would submit result via job clone ${job.clone_address ?? "<unknown>"}; ` +
+          `LLM context = ${messages.length} messages`
+      );
+    } catch (err) {
+      console.error(`[hello-agent] poll error: ${(err as Error).message}`);
+      await sleep(config.pollIntervalMs);
+    }
+  }
+  console.log(`[hello-agent] done, handled ${handled} job(s)`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+main().catch((err) => {
+  console.error("[hello-agent] fatal:", err);
+  process.exit(1);
+});

--- a/examples/hello-agent/tsconfig.json
+++ b/examples/hello-agent/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "useUnknownInCatchVariables": true,
+    "noEmit": false,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
+        version: 6.0.1(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@1.8.0)
@@ -105,7 +105,48 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
+        version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))
+
+  examples/arb-bot:
+    dependencies:
+      '@titular/acp-sdk':
+        specifier: workspace:*
+        version: link:../../packages/acp-sdk-ts
+      viem:
+        specifier: ^2.21.50
+        version: 2.48.4(typescript@5.6.3)(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ~22.0.0
+        version: 22.0.3
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ~5.6.0
+        version: 5.6.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))
+
+  examples/hello-agent:
+    dependencies:
+      '@titular/acp-sdk':
+        specifier: workspace:*
+        version: link:../../packages/acp-sdk-ts
+      viem:
+        specifier: ^2.21.50
+        version: 2.48.4(typescript@5.6.3)(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ~22.0.0
+        version: 22.0.3
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      typescript:
+        specifier: ~5.6.0
+        version: 5.6.3
 
   packages/acp-cli:
     dependencies:
@@ -130,7 +171,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
+        version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))
 
   packages/acp-sdk-ts:
     dependencies:
@@ -149,7 +190,11 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
+        version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))
+    optionalDependencies:
+      '@napi-rs/keyring':
+        specifier: ^1.1.0
+        version: 1.2.0
 
 packages:
 
@@ -374,6 +419,162 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -534,6 +735,82 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    resolution: {integrity: sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.2.0':
+    resolution: {integrity: sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1066,6 +1343,11 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1131,6 +1413,9 @@ packages:
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
@@ -1602,6 +1887,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -1761,6 +2049,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   turbo-darwin-64@2.3.3:
     resolution: {integrity: sha512-bxX82xe6du/3rPmm4aCC5RdEilIN99VUld4HkFQuw+mvFg6darNBuQxyWSHZTtc25XgYjQrjsV05888w1grpaA==}
@@ -2219,6 +2512,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
   '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
     optionalDependencies:
       '@noble/hashes': 1.8.0
@@ -2333,6 +2704,58 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring@1.2.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.2.0
+      '@napi-rs/keyring-darwin-x64': 1.2.0
+      '@napi-rs/keyring-freebsd-x64': 1.2.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.2.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.2.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-musl': 1.2.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.2.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.2.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.2.0
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2524,10 +2947,10 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1)
+      vite: 8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1)
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -2541,7 +2964,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
+      vitest: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -2552,13 +2975,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1)
+      vite: 8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -2776,6 +3199,35 @@ snapshots:
 
   es-module-lexer@2.0.0: {}
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
 
   estree-walker@3.0.3:
@@ -2829,6 +3281,10 @@ snapshots:
   get-east-asian-width@1.5.0: {}
 
   get-stream@8.0.1: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   git-raw-commits@4.0.0:
     dependencies:
@@ -3249,6 +3705,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -3423,6 +3881,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo-darwin-64@2.3.3:
     optional: true
 
@@ -3475,7 +3940,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1):
+  vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3484,14 +3949,16 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.0.3
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.21.0
       yaml: 2.6.1
 
-  vitest@4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1)):
+  vitest@4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -3508,7 +3975,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@22.0.3)(jiti@2.6.1)(yaml@2.6.1)
+      vite: 8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,10 +191,6 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@22.0.3)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@22.0.3)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.6.1))
-    optionalDependencies:
-      '@napi-rs/keyring':
-        specifier: ^1.1.0
-        version: 1.2.0
 
 packages:
 
@@ -735,82 +731,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@napi-rs/keyring-darwin-arm64@1.2.0':
-    resolution: {integrity: sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/keyring-darwin-x64@1.2.0':
-    resolution: {integrity: sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@napi-rs/keyring-freebsd-x64@1.2.0':
-    resolution: {integrity: sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
-    resolution: {integrity: sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
-    resolution: {integrity: sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
-    resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
-    resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
-    resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/keyring-linux-x64-musl@1.2.0':
-    resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
-    resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
-    resolution: {integrity: sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
-    resolution: {integrity: sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@napi-rs/keyring@1.2.0':
-    resolution: {integrity: sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==}
-    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -2704,58 +2624,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@napi-rs/keyring-darwin-arm64@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-darwin-x64@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-freebsd-x64@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-linux-x64-musl@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
-    optional: true
-
-  '@napi-rs/keyring@1.2.0':
-    optionalDependencies:
-      '@napi-rs/keyring-darwin-arm64': 1.2.0
-      '@napi-rs/keyring-darwin-x64': 1.2.0
-      '@napi-rs/keyring-freebsd-x64': 1.2.0
-      '@napi-rs/keyring-linux-arm-gnueabihf': 1.2.0
-      '@napi-rs/keyring-linux-arm64-gnu': 1.2.0
-      '@napi-rs/keyring-linux-arm64-musl': 1.2.0
-      '@napi-rs/keyring-linux-riscv64-gnu': 1.2.0
-      '@napi-rs/keyring-linux-x64-gnu': 1.2.0
-      '@napi-rs/keyring-linux-x64-musl': 1.2.0
-      '@napi-rs/keyring-win32-arm64-msvc': 1.2.0
-      '@napi-rs/keyring-win32-ia32-msvc': 1.2.0
-      '@napi-rs/keyring-win32-x64-msvc': 1.2.0
-    optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "examples/*"


### PR DESCRIPTION
## Summary
Two runnable example projects showing how to build agents on the ACP protocol using `@titular/acp-sdk`:

- `examples/hello-agent` — minimal: register, listen, accept first job, submit hello-world result. ~200 LOC.
- `examples/arb-bot` — realistic: monitors `trades.*` via SSE, detects arb between two agent-tokens, creates job to perform it. Pure-function strategy unit-tested in isolation.

Both: `"@titular/acp-sdk": "workspace:*"`, strict TS, ESM-only, Base Sepolia pinned. `.env.example` lists required vars.

`pnpm-workspace.yaml`: add `examples/*` glob.

Closes #99.

## Test plan
- [x] `pnpm -F arb-bot test` (strategy unit tests)
- [x] typecheck clean
- [x] examples opt-out of root coverage gates (private packages)